### PR TITLE
Updated DBLP crawler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+.DS_Store
 __pycache__/
 *.py[cod]
 *$py.class

--- a/data/proceedings-20180829.json
+++ b/data/proceedings-20180829.json
@@ -1,0 +1,26459 @@
+{
+  "conf/ismir/Bainbridge00": {
+    "@key": "conf/ismir/Bainbridge00",
+    "@mdate": "2017-12-03",
+    "author": "David Bainbridge 0001",
+    "title": "The role of Music IR in the New Zealand Digital Music Library project.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/invites/bainbridge_invite.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Bainbridge00"
+  },
+  "conf/ismir/BatlleC00": {
+    "@key": "conf/ismir/BatlleC00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Eloi Batlle",
+      "Pedro Cano"
+    ],
+    "title": "Automatic Segmentation for Music Classification using Competitive Hidden Markov Models.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/batlle.pdf",
+    "url": "db/conf/ismir/ismir2000.html#BatlleC00"
+  },
+  "conf/ismir/BelloMS00": {
+    "@key": "conf/ismir/BelloMS00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Juan Pablo Bello",
+      "Giuliano Monti",
+      "Mark B. Sandler"
+    ],
+    "title": "Techniques for Automatic Music Transcription.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/bello_paper.pdf",
+    "url": "db/conf/ismir/ismir2000.html#BelloMS00"
+  },
+  "conf/ismir/BendorS00": {
+    "@key": "conf/ismir/BendorS00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Daniel Bendor",
+      "Mark B. Sandler"
+    ],
+    "title": "Time Domain Extraction of Vibrato from Monophonic Instruments.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/bendor.pdf",
+    "url": "db/conf/ismir/ismir2000.html#BendorS00"
+  },
+  "conf/ismir/Bonardi00": {
+    "@key": "conf/ismir/Bonardi00",
+    "@mdate": "2006-03-01",
+    "author": "Alain Bonardi",
+    "title": "IR for Contemporary Music: What the Musicologist Needs.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/invites/bonardi_invite.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Bonardi00"
+  },
+  "conf/ismir/ChaiV00": {
+    "@key": "conf/ismir/ChaiV00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Wei Chai",
+      "Barry Vercoe"
+    ],
+    "title": "Using User Models in Music Information Retrieval Systems.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/chai.pdf",
+    "url": "db/conf/ismir/ismir2000.html#ChaiV00"
+  },
+  "conf/ismir/Chen00": {
+    "@key": "conf/ismir/Chen00",
+    "@mdate": "2006-03-01",
+    "author": "Arbee L. P. Chen",
+    "title": "Music Representation, Indexing and Retrieval at NTHU.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/invites/chen_invite.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Chen00"
+  },
+  "conf/ismir/ChoudhuryDDFH00": {
+    "@key": "conf/ismir/ChoudhuryDDFH00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "G. Sayeed Choudhury",
+      "M. Droetboom",
+      "Tim DiLauro",
+      "Ichiro Fujinaga",
+      "Brian Harrington"
+    ],
+    "title": "Optical Music Recognition System within a Large-Scale Digitization Project.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/choudhury_paper.pdf",
+    "url": "db/conf/ismir/ismir2000.html#ChoudhuryDDFH00"
+  },
+  "conf/ismir/ClausenEMS00": {
+    "@key": "conf/ismir/ClausenEMS00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Michael Clausen",
+      "R. Engelbrecht",
+      "D. Meyer",
+      "J. Schmitz"
+    ],
+    "title": "PROMS: A Web-based Tool for Searching in Polyphonic Music.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/clausen_abs.pdf",
+    "url": "db/conf/ismir/ismir2000.html#ClausenEMS00"
+  },
+  "conf/ismir/CliffF00": {
+    "@key": "conf/ismir/CliffF00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Dave Cliff",
+      "Heppie Freeburn"
+    ],
+    "title": "Exploration of Point-Distribution Models for Similarity-based Classification and Indexing of Polyphonic Music.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/cliff.pdf",
+    "url": "db/conf/ismir/ismir2000.html#CliffF00"
+  },
+  "conf/ismir/CrochemoreIP00": {
+    "@key": "conf/ismir/CrochemoreIP00",
+    "@mdate": "2015-09-03",
+    "author": [
+      "Maxime Crochemore",
+      "Costas S. Iliopoulos",
+      "Yoan J. Pinz\u00f3n"
+    ],
+    "title": "Finding Motifs with Gaps.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/pinzon.pdf",
+    "url": "db/conf/ismir/ismir2000.html#CrochemoreIP00"
+  },
+  "conf/ismir/Dunn00": {
+    "@key": "conf/ismir/Dunn00",
+    "@mdate": "2006-03-01",
+    "author": "Jon W. Dunn",
+    "title": "Beyond VARIATIONS: Creating a Digital Music Library.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/invites/dunn_invite.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Dunn00"
+  },
+  "conf/ismir/Foote00": {
+    "@key": "conf/ismir/Foote00",
+    "@mdate": "2006-03-01",
+    "author": "Jonathan Foote",
+    "title": "ARTHUR: Retrieving Orchestral Music by Long-Term Structure.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/foote_paper.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Foote00"
+  },
+  "conf/ismir/GeorgakiRB00": {
+    "@key": "conf/ismir/GeorgakiRB00",
+    "@mdate": "2017-12-14",
+    "author": [
+      "Anastasia Georgaki",
+      "Spyros Raptis",
+      "Stelios Bakamidis"
+    ],
+    "title": "A Music Interface for Visually Impaired People in the WEDELMUSIC Environment. Design and Architecture.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/georgaki.pdf",
+    "url": "db/conf/ismir/ismir2000.html#GeorgakiRB00"
+  },
+  "conf/ismir/Good00": {
+    "@key": "conf/ismir/Good00",
+    "@mdate": "2006-03-01",
+    "author": "Michael Good",
+    "title": "Representing Music Using XML.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/good.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Good00"
+  },
+  "conf/ismir/Herrera-BoyerABS00": {
+    "@key": "conf/ismir/Herrera-BoyerABS00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Perfecto Herrera-Boyer",
+      "Xavier Amatriain",
+      "Eloi Batlle",
+      "Xavier Serra"
+    ],
+    "title": "Towards Instrument Segmentation for Music Content Description: a Critical Review of Instrument Classification Techniques.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/herrera_paper.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Herrera-BoyerABS00"
+  },
+  "conf/ismir/Huron00": {
+    "@key": "conf/ismir/Huron00",
+    "@mdate": "2006-03-01",
+    "author": "David Huron",
+    "title": "Perceptual and Cognitive Applications in Music Information Retrieval.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/invites/HuronAbstract.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Huron00"
+  },
+  "conf/ismir/Itoh00": {
+    "@key": "conf/ismir/Itoh00",
+    "@mdate": "2006-03-01",
+    "author": "Mari Itoh",
+    "title": "Subject Search for Music: Quantitative Analysis of Access Point Selection.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/itoh.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Itoh00"
+  },
+  "conf/ismir/Izmirli00": {
+    "@key": "conf/ismir/Izmirli00",
+    "@mdate": "2007-01-05",
+    "author": "\u00d6zg\u00fcr Izmirli",
+    "title": "Using a Spectral Flatness Based Feature for Audio Segmentation and Retrieval.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/izmirli.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Izmirli00"
+  },
+  "conf/ismir/LemstromP00": {
+    "@key": "conf/ismir/LemstromP00",
+    "@mdate": "2016-02-19",
+    "author": [
+      "Kjell Lemstr\u00f6m",
+      "Sami Perttu"
+    ],
+    "title": "SEMEX - An efficient Music Retrieval Prototype.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/lemstrom_paper.pdf",
+    "url": "db/conf/ismir/ismir2000.html#LemstromP00"
+  },
+  "conf/ismir/Kiernan00": {
+    "@key": "conf/ismir/Kiernan00",
+    "@mdate": "2006-03-01",
+    "author": "Francis J. Kiernan",
+    "title": "Score-based Style Recognition Using Artificial Neural Networks.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/kiernan.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Kiernan00"
+  },
+  "conf/ismir/KimCGV00": {
+    "@key": "conf/ismir/KimCGV00",
+    "@mdate": "2009-03-06",
+    "author": [
+      "Youngmoo E. Kim",
+      "Wei Chai",
+      "Ricardo Garc\u00eda",
+      "Barry Vercoe"
+    ],
+    "title": "Analysis of a Contour-based Representation for Melody.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/kim.pdf",
+    "url": "db/conf/ismir/ismir2000.html#KimCGV00"
+  },
+  "conf/ismir/Larson00": {
+    "@key": "conf/ismir/Larson00",
+    "@mdate": "2006-03-01",
+    "author": "Steve Larson",
+    "title": "Searching for Meaning: Melodic Patterns, Combinations, and Embellishments.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/invites/larson_invite.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Larson00"
+  },
+  "conf/ismir/Levering00": {
+    "@key": "conf/ismir/Levering00",
+    "@mdate": "2006-03-01",
+    "author": "Mary Levering",
+    "title": "Intellectual Property Rights in Musical Works: Overview, Digital Library Issues and Related Initiatives.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/invites/levering_invite.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Levering00"
+  },
+  "conf/ismir/LinB00": {
+    "@key": "conf/ismir/LinB00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Karen Lin",
+      "Tim Bell"
+    ],
+    "title": "Integrating Paper and Digital Music Information Systems.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/linbell_fullpaper.pdf",
+    "url": "db/conf/ismir/ismir2000.html#LinB00"
+  },
+  "conf/ismir/Logan00": {
+    "@key": "conf/ismir/Logan00",
+    "@mdate": "2006-03-01",
+    "author": "Beth Logan",
+    "title": "Mel Frequency Cepstral Coefficients for Music Modeling.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/logan_paper.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Logan00"
+  },
+  "conf/ismir/MacLellanB00": {
+    "@key": "conf/ismir/MacLellanB00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Donald MacLellan",
+      "Carola Boehm"
+    ],
+    "title": "MuTaTeD'll: A System for Music Information Retrieval of Encoded Music.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/boehm.pdf",
+    "url": "db/conf/ismir/ismir2000.html#MacLellanB00"
+  },
+  "conf/ismir/Pickens00": {
+    "@key": "conf/ismir/Pickens00",
+    "@mdate": "2006-03-01",
+    "author": "Jeremy Pickens",
+    "title": "A Comparison of Language Modeling and Probabilistic Text Information Retrieval Approaches to Monophonic Music Retrieval.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/pickens_paper.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Pickens00"
+  },
+  "conf/ismir/Roland00": {
+    "@key": "conf/ismir/Roland00",
+    "@mdate": "2006-03-01",
+    "author": "Perry Roland",
+    "title": "XML4MIR: Extensible Markup Language for Music Information Retrieval.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/roland_paper.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Roland00"
+  },
+  "conf/ismir/SchimmelpfennigK00": {
+    "@key": "conf/ismir/SchimmelpfennigK00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jochen Schimmelpfennig",
+      "Frank Kurth"
+    ],
+    "title": "MCML - Music Contents Markup Language.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/schimmelpfennig.pdf",
+    "url": "db/conf/ismir/ismir2000.html#SchimmelpfennigK00"
+  },
+  "conf/ismir/Selfridge-Field00": {
+    "@key": "conf/ismir/Selfridge-Field00",
+    "@mdate": "2006-03-01",
+    "author": "Eleanor Selfridge-Field",
+    "title": "What Motivates a Musical Query?.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/invites/selfridge_invite.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Selfridge-Field00"
+  },
+  "conf/ismir/CookT00": {
+    "@key": "conf/ismir/CookT00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Perry R. Cook",
+      "George Tzanetakis"
+    ],
+    "title": "Audio Information Retrieval (AIR) Tools.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/tzanetakis_paper.pdf",
+    "url": "db/conf/ismir/ismir2000.html#CookT00"
+  },
+  "conf/ismir/Uitdenbogerd00": {
+    "@key": "conf/ismir/Uitdenbogerd00",
+    "@mdate": "2006-03-01",
+    "author": "Alexandra L. Uitdenbogerd",
+    "title": "Music IR: Past, Present, and Future.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/papers/invites/uitdenbogerd_invite.pdf",
+    "url": "db/conf/ismir/ismir2000.html#Uitdenbogerd00"
+  },
+  "conf/ismir/UitdenbogerdZ00": {
+    "@key": "conf/ismir/UitdenbogerdZ00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Alexandra L. Uitdenbogerd",
+      "Justin Zobel"
+    ],
+    "title": "Music Ranking Techniques Evaluated.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/uitdenbogerd.pdf",
+    "url": "db/conf/ismir/ismir2000.html#UitdenbogerdZ00"
+  },
+  "conf/ismir/SchroeterDR00": {
+    "@key": "conf/ismir/SchroeterDR00",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Thomas von Schroeter",
+      "Shyamala Doraisamy",
+      "Stefan M. R\u00fcger"
+    ],
+    "title": "From Raw Polyphonic Audio to Locating Recurring Themes.",
+    "year": "2000",
+    "crossref": "conf/ismir/2000",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2000.ismir.net/posters/shroeter_ruger.pdf",
+    "url": "db/conf/ismir/ismir2000.html#SchroeterDR00"
+  },
+  "conf/ismir/Allamanche01": {
+    "@key": "conf/ismir/Allamanche01",
+    "@mdate": "2006-03-01",
+    "author": "Eric Allamanche",
+    "title": "Content-based Identification of Audio Material Using MPEG-7 Low Level Description.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/allamanche.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Allamanche01"
+  },
+  "conf/ismir/Barthelemy01": {
+    "@key": "conf/ismir/Barthelemy01",
+    "@mdate": "2008-06-19",
+    "author": "J\u00e9r\u00f4me Barth\u00e9lemy",
+    "title": "Figured Bass and Tonality Recognition.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2001.html#Barthelemy01"
+  },
+  "conf/ismir/Birmingham01": {
+    "@key": "conf/ismir/Birmingham01",
+    "@mdate": "2006-03-01",
+    "author": "William P. Birmingham",
+    "title": "MUSART: Music Retrieval Via Aural Queries.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/birmingham.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Birmingham01"
+  },
+  "conf/ismir/Chen01": {
+    "@key": "conf/ismir/Chen01",
+    "@mdate": "2006-03-01",
+    "author": "Arbee L. P. Chen",
+    "title": "Building a Platform for Performance Study of Various Music Information Retrieval Approaches.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2001.html#Chen01"
+  },
+  "conf/ismir/Cope01": {
+    "@key": "conf/ismir/Cope01",
+    "@mdate": "2006-03-01",
+    "author": "David Cope",
+    "title": "Computer Analysis of Musical Allusions.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2001.html#Cope01"
+  },
+  "conf/ismir/Dannenberg01": {
+    "@key": "conf/ismir/Dannenberg01",
+    "@mdate": "2006-03-01",
+    "author": "Roger B. Dannenberg",
+    "title": "Music Information Retrieval as Music Understanding.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2001.html#Dannenberg01"
+  },
+  "conf/ismir/Doraisamy01": {
+    "@key": "conf/ismir/Doraisamy01",
+    "@mdate": "2006-03-01",
+    "author": "Shyamala Doraisamy",
+    "title": "An Approach Towards A Polyphonic Music Retrieval System.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/doraisamy.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Doraisamy01"
+  },
+  "conf/ismir/Dovey01": {
+    "@key": "conf/ismir/Dovey01",
+    "@mdate": "2008-06-14",
+    "author": "Matthew J. Dovey",
+    "title": "A Technique for Regular Expression Style Searching in Polyphonic Music.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/dovey.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Dovey01"
+  },
+  "conf/ismir/Downie01": {
+    "@key": "conf/ismir/Downie01",
+    "@mdate": "2006-03-01",
+    "author": "J. Stephen Downie",
+    "title": "Whither MIR Research: Thoughts about the Future.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2001.html#Downie01"
+  },
+  "conf/ismir/Droettboom01": {
+    "@key": "conf/ismir/Droettboom01",
+    "@mdate": "2006-03-01",
+    "author": "Michael Droettboom",
+    "title": "Expressive and Efficient Retrieval of Symbolic Musical Data.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/droettboom.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Droettboom01"
+  },
+  "conf/ismir/Durey01": {
+    "@key": "conf/ismir/Durey01",
+    "@mdate": "2006-03-01",
+    "author": "Adriane Durey",
+    "title": "Melody Spotting Using Hidden Markov Models.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/durey.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Durey01"
+  },
+  "conf/ismir/Hofmann-Engl01": {
+    "@key": "conf/ismir/Hofmann-Engl01",
+    "@mdate": "2006-03-01",
+    "author": "Ludger Hofmann-Engl",
+    "title": "Towards a Cognitive Model of Melodic Similarity.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/hofmann-engl.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Hofmann-Engl01"
+  },
+  "conf/ismir/Holger01": {
+    "@key": "conf/ismir/Holger01",
+    "@mdate": "2006-08-05",
+    "author": [
+      "Holger H. Hoos",
+      "Kai Renz",
+      "Marko G\u00f6rg"
+    ],
+    "title": "GUIDO/MIR - an Experimental Musical Information Retrieval System based on GUIDO Music Notation.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "pages": "41-50",
+    "ee": "http://ismir2001.ismir.net/pdf/hoos.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Holger01"
+  },
+  "conf/ismir/Kornstadt01": {
+    "@key": "conf/ismir/Kornstadt01",
+    "@mdate": "2006-03-01",
+    "author": "Andreas Kornst\u00e4dt",
+    "title": "The JRing System for Computer-Assisted Musicological Analysis.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/kornstadt.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Kornstadt01"
+  },
+  "conf/ismir/LindsayK01": {
+    "@key": "conf/ismir/LindsayK01",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Adam Lindsay",
+      "Youngmoo Kim"
+    ],
+    "title": "Adventures in Standardization, or How We Learned to Stop Worrying and Love MPEG-7.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2001.html#LindsayK01"
+  },
+  "conf/ismir/Meek01": {
+    "@key": "conf/ismir/Meek01",
+    "@mdate": "2006-03-01",
+    "author": "Colin Meek",
+    "title": "Thematic Extractor.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/meek.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Meek01"
+  },
+  "conf/ismir/Nishimura01": {
+    "@key": "conf/ismir/Nishimura01",
+    "@mdate": "2006-03-01",
+    "author": "Takuichi Nishimura",
+    "title": "Music Signal Spotting Retrieval by a Humming Query Using Start Frame Feature Dependent Continuous Dynamic Programming.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/nishimura.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Nishimura01"
+  },
+  "conf/ismir/Maidin01": {
+    "@key": "conf/ismir/Maidin01",
+    "@mdate": "2014-10-27",
+    "author": "Donncha \u00d3 Maid\u00edn",
+    "title": "Score Processing For MIR.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/omaidin.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Maidin01"
+  },
+  "conf/ismir/Pachet01": {
+    "@key": "conf/ismir/Pachet01",
+    "@mdate": "2006-03-01",
+    "author": "Fran\u00e7ois Pachet",
+    "title": "A Naturalist Approach to Music File Name Analysis.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/pachet.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Pachet01"
+  },
+  "conf/ismir/Pollastri01": {
+    "@key": "conf/ismir/Pollastri01",
+    "@mdate": "2006-03-01",
+    "author": "Emanuele Pollastri",
+    "title": "An Audio Front End for Query-by-Humming Systems.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2001.html#Pollastri01"
+  },
+  "conf/ismir/Raphael01": {
+    "@key": "conf/ismir/Raphael01",
+    "@mdate": "2006-03-01",
+    "author": "Christopher Raphael",
+    "title": "Automated Rhythm Transcription.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/raphael.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Raphael01"
+  },
+  "conf/ismir/Raskin01": {
+    "@key": "conf/ismir/Raskin01",
+    "@mdate": "2006-03-01",
+    "author": "Jef Raskin",
+    "title": "Making Machines Palatable.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2001.html#Raskin01"
+  },
+  "conf/ismir/Reiss01": {
+    "@key": "conf/ismir/Reiss01",
+    "@mdate": "2006-03-01",
+    "author": "Josh Reiss",
+    "title": "Efficient Multidimensional Searching Routines.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/reiss.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Reiss01"
+  },
+  "conf/ismir/Smiraglia01": {
+    "@key": "conf/ismir/Smiraglia01",
+    "@mdate": "2006-03-01",
+    "author": "Richard P. Smiraglia",
+    "title": "Musical Works as Information Retrieval Entities: Epistemological Perspectives.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/smiraglia.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Smiraglia01"
+  },
+  "conf/ismir/Tzanetakis01": {
+    "@key": "conf/ismir/Tzanetakis01",
+    "@mdate": "2006-03-01",
+    "author": "George Tzanetakis",
+    "title": "Automatic Musical Genre Classification of Audio Signals.",
+    "year": "2001",
+    "crossref": "conf/ismir/2001",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2001.ismir.net/pdf/tzanetakis.pdf",
+    "url": "db/conf/ismir/ismir2001.html#Tzanetakis01"
+  },
+  "conf/ismir/Chaudhary02": {
+    "@key": "conf/ismir/Chaudhary02",
+    "@mdate": "2006-03-01",
+    "author": "Amar Chaudhary",
+    "title": "An Extensible Representation for Playlists.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP05-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Chaudhary02"
+  },
+  "conf/ismir/AucouturierP02": {
+    "@key": "conf/ismir/AucouturierP02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jean-Julien Aucouturier",
+      "Fran\u00e7ois Pachet"
+    ],
+    "title": "Music Similarity Measures: What's the use?",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP05-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#AucouturierP02"
+  },
+  "conf/ismir/BainbridgeM02": {
+    "@key": "conf/ismir/BainbridgeM02",
+    "@mdate": "2017-12-04",
+    "author": [
+      "David Bainbridge 0001",
+      "John R. McPherson"
+    ],
+    "title": "Forming a Corpus of Voice Queries for Music Information Retrieval.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP04-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#BainbridgeM02"
+  },
+  "conf/ismir/Barlas02": {
+    "@key": "conf/ismir/Barlas02",
+    "@mdate": "2006-03-01",
+    "author": "Chris Barlas",
+    "title": "Beating Babel - Identification, Metadata and Rights.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2002.html#Barlas02"
+  },
+  "conf/ismir/BaumannK02": {
+    "@key": "conf/ismir/BaumannK02",
+    "@mdate": "2018-07-06",
+    "author": [
+      "Stephan Baumann 0001",
+      "Andreas Kl\u00fcter"
+    ],
+    "title": "Super-convenience for Non-musicans: Querying MP3 and the Semantic Web.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP05-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#BaumannK02"
+  },
+  "conf/ismir/BlandfordS02": {
+    "@key": "conf/ismir/BlandfordS02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Ann Blandford",
+      "Hanna Stelmaszewska"
+    ],
+    "title": "Usability of Musical Digital Libraries: a Multimodal Analysis.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP07-5.pdf",
+    "url": "db/conf/ismir/ismir2002.html#BlandfordS02"
+  },
+  "conf/ismir/CanoKGB02": {
+    "@key": "conf/ismir/CanoKGB02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Pedro Cano",
+      "Martin Kaltenbrunner",
+      "Fabien Gouyon",
+      "Eloi Batlle"
+    ],
+    "title": "On the use of FastMap for Audio Retrieval and Browsing.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP02-6.pdf",
+    "url": "db/conf/ismir/ismir2002.html#CanoKGB02"
+  },
+  "conf/ismir/Chiariglione02": {
+    "@key": "conf/ismir/Chiariglione02",
+    "@mdate": "2006-03-01",
+    "author": "Leonardo Chiariglione",
+    "title": "Technology and Art - Putting Things in Context.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/Proceedings/02-FP08-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Chiariglione02"
+  },
+  "conf/ismir/ClarisseMLBML02": {
+    "@key": "conf/ismir/ClarisseMLBML02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "L. P. Clarisse",
+      "Jean-Pierre Martens",
+      "Micheline Lesaffre",
+      "Bernard De Baets",
+      "Hans De Meyer",
+      "Marc Leman"
+    ],
+    "title": "An Auditory Model Based Transcriber of Singing Sequences.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP04-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#ClarisseMLBML02"
+  },
+  "conf/ismir/CooperF02": {
+    "@key": "conf/ismir/CooperF02",
+    "@mdate": "2008-04-16",
+    "author": [
+      "Matthew L. Cooper",
+      "Jonathan Foote"
+    ],
+    "title": "Automatic Music Summarization via Similarity Analysis.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP03-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#CooperF02"
+  },
+  "conf/ismir/DannenbergH02": {
+    "@key": "conf/ismir/DannenbergH02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Roger B. Dannenberg",
+      "Ning Hu"
+    ],
+    "title": "Pattern Discovery Techniques for Music Audio.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP02-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#DannenbergH02"
+  },
+  "conf/ismir/Datta02": {
+    "@key": "conf/ismir/Datta02",
+    "@mdate": "2006-03-01",
+    "author": "Dave Datta",
+    "title": "Managing Metadata.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/Proceedings/02-FP08-4.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Datta02"
+  },
+  "conf/ismir/DoraisamyR02": {
+    "@key": "conf/ismir/DoraisamyR02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Shyamala Doraisamy",
+      "Stefan M. R\u00fcger"
+    ],
+    "title": "A Comparative and Fault-tolerance Study of the Use of N-grams with Polyphonic Music.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP04-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#DoraisamyR02"
+  },
+  "conf/ismir/DownieC02": {
+    "@key": "conf/ismir/DownieC02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "J. Stephen Downie",
+      "Sally Jo Cunningham"
+    ],
+    "title": "Toward a Theory of Music Information Retrieval Queries: System Design Implications.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP05-4.pdf",
+    "url": "db/conf/ismir/ismir2002.html#DownieC02"
+  },
+  "conf/ismir/EllisWBL02": {
+    "@key": "conf/ismir/EllisWBL02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Daniel P. W. Ellis",
+      "Brian Whitman",
+      "Adam Berenzweig",
+      "Steve Lawrence"
+    ],
+    "title": "The Quest for Ground Truth in Musical Artist Similarity.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP05-4.pdf",
+    "url": "db/conf/ismir/ismir2002.html#EllisWBL02"
+  },
+  "conf/ismir/FengZP02": {
+    "@key": "conf/ismir/FengZP02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Yazhong Feng",
+      "Yueting Zhuang",
+      "Yunhe Pan"
+    ],
+    "title": "Popular Music Retrieval by Independent Component Analysis.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP03-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#FengZP02"
+  },
+  "conf/ismir/FooteCN02": {
+    "@key": "conf/ismir/FooteCN02",
+    "@mdate": "2008-04-16",
+    "author": [
+      "Jonathan Foote",
+      "Matthew L. Cooper",
+      "Unjung Nam"
+    ],
+    "title": "Audio Retrieval by Rhythmic Similarity.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP02-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#FooteCN02"
+  },
+  "conf/ismir/FujinagaR02": {
+    "@key": "conf/ismir/FujinagaR02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Ichiro Fujinaga",
+      "Jenn Riley"
+    ],
+    "title": "Digital Image Capture of Musical Scores.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP01-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#FujinagaR02"
+  },
+  "conf/ismir/FutrelleD02": {
+    "@key": "conf/ismir/FutrelleD02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Joe Futrelle",
+      "J. Stephen Downie"
+    ],
+    "title": "Interdisciplinary Communities and Research Issues in Music Information Retrieval.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP07-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#FutrelleD02"
+  },
+  "conf/ismir/Geekie02": {
+    "@key": "conf/ismir/Geekie02",
+    "@mdate": "2006-03-01",
+    "author": "Gordon Geekie",
+    "title": "Carnatic Ragas as Music Information Retrieval Entities.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP01-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Geekie02"
+  },
+  "conf/ismir/GotoHNO02": {
+    "@key": "conf/ismir/GotoHNO02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Masataka Goto",
+      "Hiroki Hashiguchi",
+      "Takuichi Nishimura",
+      "Ryuichi Oka"
+    ],
+    "title": "RWC Music Database: Popular, Classical and Jazz Music Databases.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP04-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#GotoHNO02"
+  },
+  "conf/ismir/HaitsmaK02": {
+    "@key": "conf/ismir/HaitsmaK02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jaap Haitsma",
+      "Ton Kalker"
+    ],
+    "title": "A Highly Robust Audio Fingerprinting System.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP04-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#HaitsmaK02"
+  },
+  "conf/ismir/HeittolaK02": {
+    "@key": "conf/ismir/HeittolaK02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Toni Heittola",
+      "Anssi Klapuri"
+    ],
+    "title": "Locating Segments with Drums in Music Signals.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP02-4.pdf",
+    "url": "db/conf/ismir/ismir2002.html#HeittolaK02"
+  },
+  "conf/ismir/Hemmasi02": {
+    "@key": "conf/ismir/Hemmasi02",
+    "@mdate": "2006-03-01",
+    "author": "Harriette Hemmasi",
+    "title": "Why not MARC?",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/Proceedings/02-FP08-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Hemmasi02"
+  },
+  "conf/ismir/HirataM02": {
+    "@key": "conf/ismir/HirataM02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Keiji Hirata",
+      "Shu Matsuda"
+    ],
+    "title": "Interactive Music Summarization based on GTTM.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP03-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#HirataM02"
+  },
+  "conf/ismir/Hofstadter02": {
+    "@key": "conf/ismir/Hofstadter02",
+    "@mdate": "2006-03-01",
+    "author": "Douglas Hofstadter",
+    "title": "Variations on the Theme of Musical Similarity.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2002.html#Hofstadter02"
+  },
+  "conf/ismir/JinJ02": {
+    "@key": "conf/ismir/JinJ02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Hui Jin",
+      "H. V. Jagadish"
+    ],
+    "title": "Indexing Hidden Markov Models for Music Retrieval.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP01-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#JinJ02"
+  },
+  "conf/ismir/KilianH02": {
+    "@key": "conf/ismir/KilianH02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "J\u00fcrgen Kilian",
+      "Holger H. Hoos"
+    ],
+    "title": "Voice Separation - A Local Optimization Approach.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP01-6.pdf",
+    "url": "db/conf/ismir/ismir2002.html#KilianH02"
+  },
+  "conf/ismir/KimB02": {
+    "@key": "conf/ismir/KimB02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Ja-Young Kim",
+      "Nicholas J. Belkin"
+    ],
+    "title": "Categories of Music Description and Search Terms and Phrases Used by Non-Music Experts.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP07-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#KimB02"
+  },
+  "conf/ismir/KimW02": {
+    "@key": "conf/ismir/KimW02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Youngmoo E. Kim",
+      "Brian Whitman"
+    ],
+    "title": "Singer Identification in Popular Music using Warped Linear Prediction.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP05-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#KimW02"
+  },
+  "conf/ismir/Lartillot02": {
+    "@key": "conf/ismir/Lartillot02",
+    "@mdate": "2006-03-01",
+    "author": "Olivier Lartillot",
+    "title": "Integrating Pattern Matching into an Analogy-Oriented Pattern Discovery Framework.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP02-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Lartillot02"
+  },
+  "conf/ismir/LeeDR02": {
+    "@key": "conf/ismir/LeeDR02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jin Ha Lee",
+      "J. Stephen Downie",
+      "Allen Renear"
+    ],
+    "title": "Representing Traditional Korean Music Notation in XML.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP01-4.pdf",
+    "url": "db/conf/ismir/ismir2002.html#LeeDR02"
+  },
+  "conf/ismir/Logan02": {
+    "@key": "conf/ismir/Logan02",
+    "@mdate": "2006-03-01",
+    "author": "Beth Logan",
+    "title": "Content-Based Playlist Generation: Exploratory Experiments.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP05-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Logan02"
+  },
+  "conf/ismir/MandlW02": {
+    "@key": "conf/ismir/MandlW02",
+    "@mdate": "2017-11-15",
+    "author": [
+      "Thomas Mandl 0001",
+      "Christa Womser-Hacker"
+    ],
+    "title": "Learning to cope with Diversity in Music Retrieval.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP03-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#MandlW02"
+  },
+  "conf/ismir/MaroltD02": {
+    "@key": "conf/ismir/MaroltD02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Matija Marolt",
+      "Sasa Divjak"
+    ],
+    "title": "On detecting repeated notes in piano music.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP02-5.pdf",
+    "url": "db/conf/ismir/ismir2002.html#MaroltD02"
+  },
+  "conf/ismir/McPherson02": {
+    "@key": "conf/ismir/McPherson02",
+    "@mdate": "2006-03-01",
+    "author": "John R. McPherson",
+    "title": "Introducing Feedback into an Optical Music Recogniition System.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP01-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#McPherson02"
+  },
+  "conf/ismir/MeekB02": {
+    "@key": "conf/ismir/MeekB02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Colin Meek",
+      "William P. Birmingham"
+    ],
+    "title": "Johnny Can't Sing: A Comprehensive Error Model for Sung Music Queries.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP04-4.pdf",
+    "url": "db/conf/ismir/ismir2002.html#MeekB02"
+  },
+  "conf/ismir/MelucciO02": {
+    "@key": "conf/ismir/MelucciO02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Massimo Melucci",
+      "Nicola Orio"
+    ],
+    "title": "A Comparison of Manual and Automatic Melody Segmentation.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP01-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#MelucciO02"
+  },
+  "conf/ismir/NollGHSW02": {
+    "@key": "conf/ismir/NollGHSW02",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Thomas Noll",
+      "J\u00f6rg Garbers",
+      "Karin H\u00f6thker",
+      "Christian Spevak",
+      "Tillman Weyde"
+    ],
+    "title": "Opuscope - Towards a Corpus-Based Music Repository.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP04-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#NollGHSW02"
+  },
+  "conf/ismir/PardoB02": {
+    "@key": "conf/ismir/PardoB02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Bryan Pardo",
+      "William P. Birmingham"
+    ],
+    "title": "Encoding Timing Information for Musical Query Matching.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP02-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#PardoB02"
+  },
+  "conf/ismir/PaulusK02": {
+    "@key": "conf/ismir/PaulusK02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jouni Paulus",
+      "Anssi Klapuri"
+    ],
+    "title": "Measuring the similarity of Rhythmic Patterns.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP05-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#PaulusK02"
+  },
+  "conf/ismir/Pauws02": {
+    "@key": "conf/ismir/Pauws02",
+    "@mdate": "2006-03-01",
+    "author": "Steffen Pauws",
+    "title": "CubyHum: a fully operational \"query by humming\" system.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP06-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Pauws02"
+  },
+  "conf/ismir/PauwsE02": {
+    "@key": "conf/ismir/PauwsE02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Steffen Pauws",
+      "Berry Eggen"
+    ],
+    "title": "PATS: Realization and user evaluation of an automatic playlist generator.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP07-4.pdf",
+    "url": "db/conf/ismir/ismir2002.html#PauwsE02"
+  },
+  "conf/ismir/PeetersBR02": {
+    "@key": "conf/ismir/PeetersBR02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Geoffroy Peeters",
+      "Amaury La Burthe",
+      "Xavier Rodet"
+    ],
+    "title": "Toward Automatic Music Audio Summary Generation from Signal Analysis.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP03-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#PeetersBR02"
+  },
+  "conf/ismir/PickensBCDMS02": {
+    "@key": "conf/ismir/PickensBCDMS02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jeremy Pickens",
+      "Juan Pablo Bello",
+      "Tim Crawford",
+      "Matthew J. Dovey",
+      "Giuliano Monti",
+      "Mark B. Sandler"
+    ],
+    "title": "Polyphonic Score Retrieval Using Polyphonic Audio Queries: A Harmonic Modeling Approach.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP04-6.pdf",
+    "url": "db/conf/ismir/ismir2002.html#PickensBCDMS02"
+  },
+  "conf/ismir/Pienimaki02": {
+    "@key": "conf/ismir/Pienimaki02",
+    "@mdate": "2006-03-01",
+    "author": "Anna Pienim\u00e4ki",
+    "title": "Indexing Music Databases Using Automatic Extraction of Frequent Phrases.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP01-4.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Pienimaki02"
+  },
+  "conf/ismir/Pollastri02": {
+    "@key": "conf/ismir/Pollastri02",
+    "@mdate": "2006-03-01",
+    "author": "Emanuele Pollastri",
+    "title": "Some Considerations About Processing Singing Voice for Music Retrieval.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP03-5.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Pollastri02"
+  },
+  "conf/ismir/Raphael02": {
+    "@key": "conf/ismir/Raphael02",
+    "@mdate": "2006-03-01",
+    "author": "Christopher Raphael",
+    "title": "Automatic Transcription of Piano Music.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP01-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Raphael02"
+  },
+  "conf/ismir/RauberPM02": {
+    "@key": "conf/ismir/RauberPM02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Andreas Rauber",
+      "Elias Pampalk",
+      "Dieter Merkl"
+    ],
+    "title": "Using Psycho-Acoustic Models and Self-Organizing Maps to Create a Hierarchical Structuring of Music by Musical Styles.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP02-4.pdf",
+    "url": "db/conf/ismir/ismir2002.html#RauberPM02"
+  },
+  "conf/ismir/Schreier02": {
+    "@key": "conf/ismir/Schreier02",
+    "@mdate": "2006-03-01",
+    "author": "Eric Schreier",
+    "title": "About this Business of Metadata.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/Proceedings/02-FP08-5.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Schreier02"
+  },
+  "conf/ismir/SongBY02": {
+    "@key": "conf/ismir/SongBY02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jungmin Song",
+      "So-Young Bae",
+      "Kyoungro Yoon"
+    ],
+    "title": "Mid-Level Music Melody Representation of Polyphonic Audio for Query-by-Humming System.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP04-5.pdf",
+    "url": "db/conf/ismir/ismir2002.html#SongBY02"
+  },
+  "conf/ismir/SorsaH02": {
+    "@key": "conf/ismir/SorsaH02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Timo Sorsa",
+      "Katriina Halonen"
+    ],
+    "title": "Mobile Melody Recognition System with Voice-Only User Interface.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP03-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#SorsaH02"
+  },
+  "conf/ismir/TzanetakisEC02": {
+    "@key": "conf/ismir/TzanetakisEC02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "George Tzanetakis",
+      "Andrey Ermolinskiy",
+      "Perry R. Cook"
+    ],
+    "title": "Pitch Histograms in Audio and Symbolic Music Information Retrieval.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP01-5.pdf",
+    "url": "db/conf/ismir/ismir2002.html#TzanetakisEC02"
+  },
+  "conf/ismir/UitdenbogerdS02": {
+    "@key": "conf/ismir/UitdenbogerdS02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Alexandra L. Uitdenbogerd",
+      "Ron G. van Schyndel"
+    ],
+    "title": "A Review of Factors Affecting Music Recommender Success.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP07-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#UitdenbogerdS02"
+  },
+  "conf/ismir/VinetHP02": {
+    "@key": "conf/ismir/VinetHP02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Hugues Vinet",
+      "Perfecto Herrera",
+      "Fran\u00e7ois Pachet"
+    ],
+    "title": "The CUIDADO Project.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP06-3.pdf",
+    "url": "db/conf/ismir/ismir2002.html#VinetHP02"
+  },
+  "conf/ismir/WangLS02": {
+    "@key": "conf/ismir/WangLS02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Chaokun Wang",
+      "Jianzhong Li",
+      "Shengfei Shi"
+    ],
+    "title": "A Kind of Content-Based Music Information Retrieval Method in Peer-to-peer Environment.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP06-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#WangLS02"
+  },
+  "conf/ismir/WhitmanS02": {
+    "@key": "conf/ismir/WhitmanS02",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Brian Whitman",
+      "Paris Smaragdis"
+    ],
+    "title": "Combining Musical and Cultural Features for Intelligent Style Detection.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP02-1.pdf",
+    "url": "db/conf/ismir/ismir2002.html#WhitmanS02"
+  },
+  "conf/ismir/WigginsLM02": {
+    "@key": "conf/ismir/WigginsLM02",
+    "@mdate": "2016-09-26",
+    "author": [
+      "Geraint A. Wiggins",
+      "Kjell Lemstr\u00f6m",
+      "David Meredith 0001"
+    ],
+    "title": "SIA(M)ESE: An Algorithm for Transposition Invariant, Polyphonic Content-Based Music Retrieval.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/03-SP03-4.pdf",
+    "url": "db/conf/ismir/ismir2002.html#WigginsLM02"
+  },
+  "conf/ismir/Yang02": {
+    "@key": "conf/ismir/Yang02",
+    "@mdate": "2006-03-01",
+    "author": "Cheng Yang",
+    "title": "MACSIS: A Scalable Acoustic Index for Content-Based Music Retrieval.",
+    "year": "2002",
+    "crossref": "conf/ismir/2002",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2002.ismir.net/proceedings/02-FP02-2.pdf",
+    "url": "db/conf/ismir/ismir2002.html#Yang02"
+  },
+  "conf/ismir/AllamancheHHKE03": {
+    "@key": "conf/ismir/AllamancheHHKE03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "E. Allamanche",
+      "J\u00fcrgen Herre",
+      "Oliver Hellmuth",
+      "T. Kastner",
+      "C. Ertel"
+    ],
+    "title": "A multiple feature model for musical similarity retrieval.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Allamanche.pdf",
+    "url": "db/conf/ismir/ismir2003.html#AllamancheHHKE03"
+  },
+  "conf/ismir/ArifiCKM03": {
+    "@key": "conf/ismir/ArifiCKM03",
+    "@mdate": "2006-03-02",
+    "author": [
+      "Vlora Arifi",
+      "Michael Clausen",
+      "Frank Kurth",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Automatic synchronization of music data in score-, MIDI- and PCM-format.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Arifi.pdf",
+    "url": "db/conf/ismir/ismir2003.html#ArifiCKM03"
+  },
+  "conf/ismir/BainbridgeCD03": {
+    "@key": "conf/ismir/BainbridgeCD03",
+    "@mdate": "2017-12-03",
+    "author": [
+      "David Bainbridge 0001",
+      "Sally Jo Cunningham",
+      "J. Stephen Downie"
+    ],
+    "title": "Analysis of queries to a Wizard-of-Oz MIR system: Challenging assumptions about what people really want.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Bainbridge.pdf",
+    "url": "db/conf/ismir/ismir2003.html#BainbridgeCD03"
+  },
+  "conf/ismir/BerenzweigLEW03": {
+    "@key": "conf/ismir/BerenzweigLEW03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Adam Berenzweig",
+      "Beth Logan",
+      "Daniel P. W. Ellis",
+      "Brian Whitman"
+    ],
+    "title": "A large-scale evalutation of acoustic and subjective music similarity measures.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Berenzweig.PDF",
+    "url": "db/conf/ismir/ismir2003.html#BerenzweigLEW03"
+  },
+  "conf/ismir/ChewC03": {
+    "@key": "conf/ismir/ChewC03",
+    "@mdate": "2013-06-06",
+    "author": [
+      "Elaine Chew",
+      "Yun-Ching Chen"
+    ],
+    "title": "Determining context-defining windows: Pitch spelling using the spiral array.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Chew.PDF",
+    "url": "db/conf/ismir/ismir2003.html#ChewC03"
+  },
+  "conf/ismir/DannenbergBTMHP03": {
+    "@key": "conf/ismir/DannenbergBTMHP03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Roger B. Dannenberg",
+      "William P. Birmingham",
+      "George Tzanetakis",
+      "Colin Meek",
+      "Ning Hu",
+      "Bryan Pardo"
+    ],
+    "title": "The MUSART testbed for query-by-humming evaluation.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Dannenberg.PDF",
+    "url": "db/conf/ismir/ismir2003.html#DannenbergBTMHP03"
+  },
+  "conf/ismir/Davison03": {
+    "@key": "conf/ismir/Davison03",
+    "@mdate": "2006-03-01",
+    "author": "Stephen Davison",
+    "title": "The Sheet Music Consortium: A Specialized Open Archives Initiative harvester project.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Davison.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Davison03"
+  },
+  "conf/ismir/MulderMLLB03": {
+    "@key": "conf/ismir/MulderMLLB03",
+    "@mdate": "2014-04-25",
+    "author": [
+      "Tom De Mulder",
+      "Jean-Pierre Martens",
+      "Micheline Lesaffre",
+      "Marc Leman",
+      "Bernard De Baets"
+    ],
+    "title": "An auditory model based transriber of vocal queries.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Mulder.PDF",
+    "url": "db/conf/ismir/ismir2003.html#MulderMLLB03"
+  },
+  "conf/ismir/DixonPW03": {
+    "@key": "conf/ismir/DixonPW03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Simon Dixon",
+      "Elias Pampalk",
+      "Gerhard Widmer"
+    ],
+    "title": "Classification of dance music by periodicity patterns.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Dixon.PDF",
+    "url": "db/conf/ismir/ismir2003.html#DixonPW03"
+  },
+  "conf/ismir/DoraisamyR03": {
+    "@key": "conf/ismir/DoraisamyR03",
+    "@mdate": "2006-03-02",
+    "author": [
+      "Shyamala Doraisamy",
+      "Stefan M. R\u00fcger"
+    ],
+    "title": "Position Indexing of Adjacent and Concurrent N-Grams for Polyphonic Music Retrieval.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Doraisamy.PDF",
+    "url": "db/conf/ismir/ismir2003.html#DoraisamyR03"
+  },
+  "conf/ismir/Downie03": {
+    "@key": "conf/ismir/Downie03",
+    "@mdate": "2006-03-01",
+    "author": "J. Stephen Downie",
+    "title": "Toward the scientific evaluation of music information retrieval systems.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Downie.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Downie03"
+  },
+  "conf/ismir/EgginkB03": {
+    "@key": "conf/ismir/EgginkB03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jana Eggink",
+      "Guy J. Brown"
+    ],
+    "title": "Application of missing feature theory to the recognition of musical instruments in polyphonic audio.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Eggink.PDF",
+    "url": "db/conf/ismir/ismir2003.html#EgginkB03"
+  },
+  "conf/ismir/GilletR03": {
+    "@key": "conf/ismir/GilletR03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Olivier Gillet",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "Automatic labeling of tabla signals.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Gillet.PDF",
+    "url": "db/conf/ismir/ismir2003.html#GilletR03"
+  },
+  "conf/ismir/Goto03": {
+    "@key": "conf/ismir/Goto03",
+    "@mdate": "2006-03-01",
+    "author": "Masataka Goto",
+    "title": "Music scene description project: Toward audio-based real-time music understanding.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Goto.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Goto03"
+  },
+  "conf/ismir/GotoHNO03": {
+    "@key": "conf/ismir/GotoHNO03",
+    "@mdate": "2006-03-02",
+    "author": [
+      "Masataka Goto",
+      "Hiroki Hashiguchi",
+      "Takuichi Nishimura",
+      "Ryuichi Oka"
+    ],
+    "title": "RWC Music Database: Music genre database and musical instrument sound database.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Goto1.PDF",
+    "url": "db/conf/ismir/ismir2003.html#GotoHNO03"
+  },
+  "conf/ismir/Harford03": {
+    "@key": "conf/ismir/Harford03",
+    "@mdate": "2006-03-01",
+    "author": "S. Harford",
+    "title": "Automatic segmentation, learning and retrieval of melodies using a self-organizing neural network.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Harford.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Harford03"
+  },
+  "conf/ismir/HeoSIM03": {
+    "@key": "conf/ismir/HeoSIM03",
+    "@mdate": "2006-03-02",
+    "author": [
+      "Sung-Phil Heo",
+      "Motoyuki Suzuki",
+      "Akinori Ito",
+      "Shozo Makino"
+    ],
+    "title": "Three-dimensional continuous DP algorithm for multiple pitch candidates in a music information retrieval system.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Heo.PDF",
+    "url": "db/conf/ismir/ismir2003.html#HeoSIM03"
+  },
+  "conf/ismir/Lartillot03": {
+    "@key": "conf/ismir/Lartillot03",
+    "@mdate": "2006-03-01",
+    "author": "Olivier Lartillot",
+    "title": "Discovering musical pattern through perceptual heuristics.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Lartillot.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Lartillot03"
+  },
+  "conf/ismir/LemstromMPTU03": {
+    "@key": "conf/ismir/LemstromMPTU03",
+    "@mdate": "2006-03-07",
+    "author": [
+      "Kjell Lemstr\u00f6m",
+      "Veli M\u00e4kinen",
+      "Anna Pienim\u00e4ki",
+      "M. Turkia",
+      "Esko Ukkonen"
+    ],
+    "title": "The C-BRAHMS project.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Lemstrom.PDF",
+    "url": "db/conf/ismir/ismir2003.html#LemstromMPTU03"
+  },
+  "conf/ismir/LesaffreTMMLBMM03": {
+    "@key": "conf/ismir/LesaffreTMMLBMM03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Micheline Lesaffre",
+      "Koen Tanghe",
+      "Ga\u00ebtan Martens",
+      "Dirk Moelants",
+      "Marc Leman",
+      "Bernard De Baets",
+      "Hans De Meyer",
+      "Jean-Pierre Martens"
+    ],
+    "title": "The MAMI query-by-voice experiment: collecting and annotating vocal queries for music information retrieval.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Lesaffre.PDF",
+    "url": "db/conf/ismir/ismir2003.html#LesaffreTMMLBMM03"
+  },
+  "conf/ismir/LiM03": {
+    "@key": "conf/ismir/LiM03",
+    "@mdate": "2017-09-18",
+    "author": [
+      "Tao Li 0001",
+      "Mitsunori Ogihara"
+    ],
+    "title": "Detecting emotion in music.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Li.PDF",
+    "url": "db/conf/ismir/ismir2003.html#LiM03"
+  },
+  "conf/ismir/LiuLZ03": {
+    "@key": "conf/ismir/LiuLZ03",
+    "@mdate": "2018-06-06",
+    "author": [
+      "Dan Liu 0001",
+      "Lie Lu",
+      "HongJiang Zhang"
+    ],
+    "title": "Automatic mood detection from acoustic music data.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Liu.PDF",
+    "url": "db/conf/ismir/ismir2003.html#LiuLZ03"
+  },
+  "conf/ismir/LivshinR03": {
+    "@key": "conf/ismir/LivshinR03",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Arie Livshin",
+      "Xavier Rodet"
+    ],
+    "title": "The importance of cross database evaluation in musical instrument sound classification: A critical approach.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Livshin.PDF",
+    "url": "db/conf/ismir/ismir2003.html#LivshinR03"
+  },
+  "conf/ismir/MaddageXW03": {
+    "@key": "conf/ismir/MaddageXW03",
+    "@mdate": "2006-08-30",
+    "author": [
+      "Namunu Chinthaka Maddage",
+      "Changsheng Xu",
+      "Ye Wang"
+    ],
+    "title": "An SVM-based classification approach to musical audio.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Maddage.PDF",
+    "url": "db/conf/ismir/ismir2003.html#MaddageXW03"
+  },
+  "conf/ismir/McKinneyB03": {
+    "@key": "conf/ismir/McKinneyB03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Martin F. McKinney",
+      "Jeroen Breebaart"
+    ],
+    "title": "Features for audio and music classification.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/McKinney.PDF",
+    "url": "db/conf/ismir/ismir2003.html#McKinneyB03"
+  },
+  "conf/ismir/MeekB03": {
+    "@key": "conf/ismir/MeekB03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Colin Meek",
+      "William P. Birmingham"
+    ],
+    "title": "The dangers of parsimony in query-by-humming applications.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Meek.PDF",
+    "url": "db/conf/ismir/ismir2003.html#MeekB03"
+  },
+  "conf/ismir/OlsonD03": {
+    "@key": "conf/ismir/OlsonD03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "T. Olson",
+      "S. J. Downie"
+    ],
+    "title": "Chopin early editions: The construction and usage of a collection of digital scores.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Olson.PDF",
+    "url": "db/conf/ismir/ismir2003.html#OlsonD03"
+  },
+  "conf/ismir/Olson03": {
+    "@key": "conf/ismir/Olson03",
+    "@mdate": "2006-03-01",
+    "author": "Tod A. Olson",
+    "title": "Building Chopin Early Editions [Presentation].",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2003.html#Olson03"
+  },
+  "conf/ismir/OrioS03": {
+    "@key": "conf/ismir/OrioS03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Nicola Orio",
+      "M. Sisti Sette"
+    ],
+    "title": "An HMM-based pitch tracker for audio queries.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Orio.PDF",
+    "url": "db/conf/ismir/ismir2003.html#OrioS03"
+  },
+  "conf/ismir/PampalkDW03": {
+    "@key": "conf/ismir/PampalkDW03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Elias Pampalk",
+      "Simon Dixon",
+      "Gerhard Widmer"
+    ],
+    "title": "Exploring music collections by browsing different views.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Pampalk.PDF",
+    "url": "db/conf/ismir/ismir2003.html#PampalkDW03"
+  },
+  "conf/ismir/ParryE03": {
+    "@key": "conf/ismir/ParryE03",
+    "@mdate": "2009-04-12",
+    "author": [
+      "R. Mitchell Parry",
+      "Irfan A. Essa"
+    ],
+    "title": "Rhythmic similarity through elaboration.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Parry.PDF",
+    "url": "db/conf/ismir/ismir2003.html#ParryE03"
+  },
+  "conf/ismir/Pauws03": {
+    "@key": "conf/ismir/Pauws03",
+    "@mdate": "2006-03-01",
+    "author": "Steffen Pauws",
+    "title": "Effects of song familiarity, singing training and recent song exposure on the singing of melodies.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Pauws.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Pauws03"
+  },
+  "conf/ismir/Pedersen03": {
+    "@key": "conf/ismir/Pedersen03",
+    "@mdate": "2006-03-01",
+    "author": "Charlotte Pedersen",
+    "title": "Digital Sheet Music - The Danish Collaborative Project.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2003.html#Pedersen03"
+  },
+  "conf/ismir/Pickens03": {
+    "@key": "conf/ismir/Pickens03",
+    "@mdate": "2006-03-01",
+    "author": "Jeremy Pickens",
+    "title": "Key-specific shrinkage techniques for harmonic models.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Pickens.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Pickens03"
+  },
+  "conf/ismir/RaphaelS03": {
+    "@key": "conf/ismir/RaphaelS03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Christopher Raphael",
+      "Josh Stoddard"
+    ],
+    "title": "Harmonic analysis with probabilistic graphical models.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Raphael.PDF",
+    "url": "db/conf/ismir/ismir2003.html#RaphaelS03"
+  },
+  "conf/ismir/RicardH03": {
+    "@key": "conf/ismir/RicardH03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Julien Ricard",
+      "Perfecto Herrera"
+    ],
+    "title": "Using morphological description for generic sound retrieval.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Ricard.PDF",
+    "url": "db/conf/ismir/ismir2003.html#RicardH03"
+  },
+  "conf/ismir/Roland03": {
+    "@key": "conf/ismir/Roland03",
+    "@mdate": "2006-03-01",
+    "author": "P. Roland",
+    "title": "Design patterns in XML music representation.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Roland.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Roland03"
+  },
+  "conf/ismir/Schwartz03": {
+    "@key": "conf/ismir/Schwartz03",
+    "@mdate": "2006-03-01",
+    "author": "B. Schwartz",
+    "title": "Music Notation as a MEI Feasability Test.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Schwartz.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Schwartz03"
+  },
+  "conf/ismir/Seeger03": {
+    "@key": "conf/ismir/Seeger03",
+    "@mdate": "2006-03-01",
+    "author": "Anthony Seeger",
+    "title": "I Found It, How Can I Use It?\" - Dealing With the Ethical and Legal Constraints of Information Access.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Seeger.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Seeger03"
+  },
+  "conf/ismir/SeifertB03": {
+    "@key": "conf/ismir/SeifertB03",
+    "@mdate": "2015-01-05",
+    "author": [
+      "Frank Seifert 0001",
+      "Wolfgang Benn"
+    ],
+    "title": "Music identification by leadsheets: Converging perceptive and productive musical principles for estimation of semantic similarity of musical documents.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Seifert.PDF",
+    "url": "db/conf/ismir/ismir2003.html#SeifertB03"
+  },
+  "conf/ismir/ShehE03": {
+    "@key": "conf/ismir/ShehE03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Alexander Sheh",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "Chord segmentation and recognition using EM-trained hidden markov models.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Sheh.PDF",
+    "url": "db/conf/ismir/ismir2003.html#ShehE03"
+  },
+  "conf/ismir/ShifrinB03": {
+    "@key": "conf/ismir/ShifrinB03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jonah Shifrin",
+      "William P. Birmingham"
+    ],
+    "title": "Effectiveness of HMM-based retrieval on large databases.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Shifrin.PDF",
+    "url": "db/conf/ismir/ismir2003.html#ShifrinB03"
+  },
+  "conf/ismir/SoulezRS03": {
+    "@key": "conf/ismir/SoulezRS03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Ferr\u00e9ol Soulez",
+      "Xavier Rodet",
+      "Diemo Schwarz"
+    ],
+    "title": "Improving polyphonic and poly-instrumental music to score alignment.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Soulez.PDF",
+    "url": "db/conf/ismir/ismir2003.html#SoulezRS03"
+  },
+  "conf/ismir/TakedaNS03": {
+    "@key": "conf/ismir/TakedaNS03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Haruto Takeda",
+      "Takuya Nishimoto",
+      "Shigeki Sagayama"
+    ],
+    "title": "Automatic rhythm transcription from multiphonic MIDI signals.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Takeda.PDF",
+    "url": "db/conf/ismir/ismir2003.html#TakedaNS03"
+  },
+  "conf/ismir/TsaiWRCY03": {
+    "@key": "conf/ismir/TsaiWRCY03",
+    "@mdate": "2008-03-11",
+    "author": [
+      "Wei-Ho Tsai",
+      "Hsin-Min Wang",
+      "Dwight Rodgers",
+      "Shih-Sian Cheng",
+      "Hung-Ming Yu"
+    ],
+    "title": "Blind clustering of popular music recordings based on singer voice characteristics.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Tsai.PDF",
+    "url": "db/conf/ismir/ismir2003.html#TsaiWRCY03"
+  },
+  "conf/ismir/TuretskyE03": {
+    "@key": "conf/ismir/TuretskyE03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Robert J. Turetsky",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "Ground-truth transcriptions of real music from force-aligned MIDI syntheses.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Turetsky.PDF",
+    "url": "db/conf/ismir/ismir2003.html#TuretskyE03"
+  },
+  "conf/ismir/TypkeGVWO03": {
+    "@key": "conf/ismir/TypkeGVWO03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Rainer Typke",
+      "Panos Giannopoulos",
+      "Remco C. Veltkamp",
+      "Frans Wiering",
+      "Ren\u00e9 van Oostrum"
+    ],
+    "title": "Using transportation distances for measuring melodic similarity.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Typke.PDF",
+    "url": "db/conf/ismir/ismir2003.html#TypkeGVWO03"
+  },
+  "conf/ismir/TzanetakisGS03": {
+    "@key": "conf/ismir/TzanetakisGS03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "George Tzanetakis",
+      "Jun Gao",
+      "Peter Steenkiste"
+    ],
+    "title": "A scalable peer-to-peer system for music content and information retrieval.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Tzanetakis.PDF",
+    "url": "db/conf/ismir/ismir2003.html#TzanetakisGS03"
+  },
+  "conf/ismir/UitdenbogerdY03": {
+    "@key": "conf/ismir/UitdenbogerdY03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Alexandra L. Uitdenbogerd",
+      "Yaw Wah Yap"
+    ],
+    "title": "Was Parsons right? An experiment in usability of music representations for melody-based music retrieval.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Uitdenbogerd.PDF",
+    "url": "db/conf/ismir/ismir2003.html#UitdenbogerdY03"
+  },
+  "conf/ismir/UkkonenLM03": {
+    "@key": "conf/ismir/UkkonenLM03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Esko Ukkonen",
+      "Kjell Lemstr\u00f6m",
+      "Veli M\u00e4kinen"
+    ],
+    "title": "Geometric algorithms for transposition invariant content based music retrieval.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Ukkonen.PDF",
+    "url": "db/conf/ismir/ismir2003.html#UkkonenLM03"
+  },
+  "conf/ismir/Wang03": {
+    "@key": "conf/ismir/Wang03",
+    "@mdate": "2006-03-01",
+    "author": "Avery Wang",
+    "title": "An Industrial Strength Audio Search Algorithm.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/presentations/Wang.PDF",
+    "url": "db/conf/ismir/ismir2003.html#Wang03"
+  },
+  "conf/ismir/WoodO03": {
+    "@key": "conf/ismir/WoodO03",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Gavin Wood",
+      "Simon O'Keefe"
+    ],
+    "title": "Quantitative comparisons into content-based music recognition with the self organising map.",
+    "year": "2003",
+    "crossref": "conf/ismir/2003",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2003.ismir.net/papers/Wood.pdf",
+    "url": "db/conf/ismir/ismir2003.html#WoodO03"
+  },
+  "conf/ismir/AbdallahP04": {
+    "@key": "conf/ismir/AbdallahP04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Samer M. Abdallah",
+      "Mark D. Plumbley"
+    ],
+    "title": "Polyphonic transcription by non-negative sparse coding of power spectra.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p058-page-318-paper216.pdf",
+    "url": "db/conf/ismir/ismir2004.html#AbdallahP04"
+  },
+  "conf/ismir/AdamsBSW04": {
+    "@key": "conf/ismir/AdamsBSW04",
+    "@mdate": "2007-03-05",
+    "author": [
+      "Norman H. Adams",
+      "Mark A. Bartsch",
+      "Jonah Shifrin",
+      "Gregory H. Wakefield"
+    ],
+    "title": "Time Series Alignment for Music Information Retrieval.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p056-page-303-paper144.pdf",
+    "url": "db/conf/ismir/ismir2004.html#AdamsBSW04"
+  },
+  "conf/ismir/Aigrain04": {
+    "@key": "conf/ismir/Aigrain04",
+    "@mdate": "2006-03-01",
+    "author": "Philippe Aigrain",
+    "title": "Whose future is it?",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/pha-ISMIR2004.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Aigrain04"
+  },
+  "conf/ismir/AlonsoRD04": {
+    "@key": "conf/ismir/AlonsoRD04",
+    "@mdate": "2011-02-24",
+    "author": [
+      "Miguel A. Alonso",
+      "Ga\u00ebl Richard",
+      "Bertrand David"
+    ],
+    "title": "Tempo And Beat Estimation Of Musical Signals.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p032-page-158-paper191.pdf",
+    "url": "db/conf/ismir/ismir2004.html#AlonsoRD04"
+  },
+  "conf/ismir/AucouturierP04": {
+    "@key": "conf/ismir/AucouturierP04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jean-Julien Aucouturier",
+      "Fran\u00e7ois Pachet"
+    ],
+    "title": "Tools and Architecture for the Evaluation of Similarity Measures : Case Study of Timbre Similarity.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p038-page-198-paper231.pdf",
+    "url": "db/conf/ismir/ismir2004.html#AucouturierP04"
+  },
+  "conf/ismir/AucouturierPH04": {
+    "@key": "conf/ismir/AucouturierPH04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jean-Julien Aucouturier",
+      "Fran\u00e7ois Pachet",
+      "Peter Hanappe"
+    ],
+    "title": "From Sound Sampling To Song Sampling.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p001-page-1-paper233.pdf",
+    "url": "db/conf/ismir/ismir2004.html#AucouturierPH04"
+  },
+  "conf/ismir/BainbridgeCD04": {
+    "@key": "conf/ismir/BainbridgeCD04",
+    "@mdate": "2017-12-03",
+    "author": [
+      "David Bainbridge 0001",
+      "Sally Jo Cunningham",
+      "J. Stephen Downie"
+    ],
+    "title": "GREENSTONE as a Music Digital Library Toolkit.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p008-page-42-paper224.pdf",
+    "url": "db/conf/ismir/ismir2004.html#BainbridgeCD04"
+  },
+  "conf/ismir/BainbridgeCD04a": {
+    "@key": "conf/ismir/BainbridgeCD04a",
+    "@mdate": "2017-12-03",
+    "author": [
+      "David Bainbridge 0001",
+      "Sally Jo Cunningham",
+      "J. Stephen Downie"
+    ],
+    "title": "Visual Collaging Of Music In A Digital Library.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p072-page-397-paper223.pdf",
+    "url": "db/conf/ismir/ismir2004.html#BainbridgeCD04a"
+  },
+  "conf/ismir/BasiliSS04": {
+    "@key": "conf/ismir/BasiliSS04",
+    "@mdate": "2017-07-18",
+    "author": [
+      "Roberto Basili 0001",
+      "Alfredo Serafini",
+      "Armando Stellato"
+    ],
+    "title": "Classification of musical genre: a machine learning approach.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p092-page-505-paper239.pdf",
+    "url": "db/conf/ismir/ismir2004.html#BasiliSS04"
+  },
+  "conf/ismir/BaumannPV04": {
+    "@key": "conf/ismir/BaumannPV04",
+    "@mdate": "2018-07-06",
+    "author": [
+      "Stephan Baumann 0001",
+      "Tim Pohle",
+      "Shankar Vembu"
+    ],
+    "title": "Towards a Socio-cultural Compatibility of MIR Systems.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p084-page-460-paper146.pdf",
+    "url": "db/conf/ismir/ismir2004.html#BaumannPV04"
+  },
+  "conf/ismir/BrossierBP04": {
+    "@key": "conf/ismir/BrossierBP04",
+    "@mdate": "2007-06-11",
+    "author": [
+      "Paul Brossier",
+      "Juan Pablo Bello",
+      "Mark D. Plumbley"
+    ],
+    "title": "Fast labelling of notes in music signals.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p060-page-331-paper242.pdf",
+    "url": "db/conf/ismir/ismir2004.html#BrossierBP04"
+  },
+  "conf/ismir/CanoK04": {
+    "@key": "conf/ismir/CanoK04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Pedro Cano",
+      "Markus Koppenberger"
+    ],
+    "title": "The emergence of complex network patterns in music networks.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p085-page-466-paper253.pdf",
+    "url": "db/conf/ismir/ismir2004.html#CanoK04"
+  },
+  "conf/ismir/CaseyC04": {
+    "@key": "conf/ismir/CaseyC04",
+    "@mdate": "2014-04-16",
+    "author": [
+      "Michael A. Casey",
+      "Tim Crawford"
+    ],
+    "title": "Automatic Location And Measurement Of Score-based Gestures In Audio Recordings.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p057-page-311-paper252.pdf",
+    "url": "db/conf/ismir/ismir2004.html#CaseyC04"
+  },
+  "conf/ismir/Celma04": {
+    "@key": "conf/ismir/Celma04",
+    "@mdate": "2008-07-02",
+    "author": "\u00d2scar Celma",
+    "title": "Architecture for an MPEG-7 Web Browser.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p079-page-433-paper186.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Celma04"
+  },
+  "conf/ismir/CruzFBCACSDS04": {
+    "@key": "conf/ismir/CruzFBCACSDS04",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Fernando William Cruz",
+      "Edilson Ferneda",
+      "M\u00e1rcio da Costa P. Brand\u00e3o",
+      "Evandro de Barros Costa",
+      "Hyggo Oliveira de Almeida",
+      "Murilo Bastos da Cunha",
+      "Rafael de Sousa",
+      "Jo\u00e3o Denicol",
+      "Carlos da Silva"
+    ],
+    "title": "A Brazilian Popular Music Oriented Digital Library For Musical Harmony E-Learning.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p078-page-429-paper198.pdf",
+    "url": "db/conf/ismir/ismir2004.html#CruzFBCACSDS04"
+  },
+  "conf/ismir/DannenbergH04": {
+    "@key": "conf/ismir/DannenbergH04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Roger B. Dannenberg",
+      "Ning Hu"
+    ],
+    "title": "Understanding Search Performance in Query-by-Humming Systems.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p043-page-232-paper236.pdf",
+    "url": "db/conf/ismir/ismir2004.html#DannenbergH04"
+  },
+  "conf/ismir/DaudetRL04": {
+    "@key": "conf/ismir/DaudetRL04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Laurent Daudet",
+      "Ga\u00ebl Richard",
+      "Pierre Leveau"
+    ],
+    "title": "Methodology and Tools for the evaluation of automatic onset detection algorithms in music.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p014-page-72-paper188.pdf",
+    "url": "db/conf/ismir/ismir2004.html#DaudetRL04"
+  },
+  "conf/ismir/DaviesP04": {
+    "@key": "conf/ismir/DaviesP04",
+    "@mdate": "2009-05-14",
+    "author": [
+      "Matthew E. P. Davies",
+      "Mark D. Plumbley"
+    ],
+    "title": "Causal Tempo Tracking of Audio.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p033-page-164-paper226.pdf",
+    "url": "db/conf/ismir/ismir2004.html#DaviesP04"
+  },
+  "conf/ismir/DixonGW04": {
+    "@key": "conf/ismir/DixonGW04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Simon Dixon",
+      "Fabien Gouyon",
+      "Gerhard Widmer"
+    ],
+    "title": "Towards Characterisation of Music via Rhythmic Patterns.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p093-page-509-paper165.pdf",
+    "url": "db/conf/ismir/ismir2004.html#DixonGW04"
+  },
+  "conf/ismir/DoraisamyR04": {
+    "@key": "conf/ismir/DoraisamyR04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Shyamala Doraisamy",
+      "Stefan M. R\u00fcger"
+    ],
+    "title": "A Polyphonic Music Retrieval System Using N-Grams.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p039-page-204-paper230.pdf",
+    "url": "db/conf/ismir/ismir2004.html#DoraisamyR04"
+  },
+  "conf/ismir/DroettboomF04": {
+    "@key": "conf/ismir/DroettboomF04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Michael Droettboom",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Micro-level groundtruthing environment for OMR.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p090-page-497-paper117.pdf",
+    "url": "db/conf/ismir/ismir2004.html#DroettboomF04"
+  },
+  "conf/ismir/EerolaT04": {
+    "@key": "conf/ismir/EerolaT04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Tuomas Eerola",
+      "Petri Toiviainen"
+    ],
+    "title": "MIR In Matlab: The MIDI Toolbox.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p004-page-22-paper193.pdf",
+    "url": "db/conf/ismir/ismir2004.html#EerolaT04"
+  },
+  "conf/ismir/EgginkB04": {
+    "@key": "conf/ismir/EgginkB04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jana Eggink",
+      "Guy J. Brown"
+    ],
+    "title": "Extracting Melody Lines From Complex Audio.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p017-page-84-paper124.pdf",
+    "url": "db/conf/ismir/ismir2004.html#EgginkB04"
+  },
+  "conf/ismir/EllisA04": {
+    "@key": "conf/ismir/EllisA04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Dan Ellis",
+      "John Arroyo"
+    ],
+    "title": "Eigenrhythms: Drum pattern basis sets for classification and generation.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p101-page-554-paper247.pdf",
+    "url": "db/conf/ismir/ismir2004.html#EllisA04"
+  },
+  "conf/ismir/EssidRD04": {
+    "@key": "conf/ismir/EssidRD04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Slim Essid",
+      "Ga\u00ebl Richard",
+      "Bertrand David"
+    ],
+    "title": "Musical instrument recognition based on class pairwise feature selection.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p102-page-560-paper194.pdf",
+    "url": "db/conf/ismir/ismir2004.html#EssidRD04"
+  },
+  "conf/ismir/Frieler04": {
+    "@key": "conf/ismir/Frieler04",
+    "@mdate": "2006-03-01",
+    "author": "Klaus Frieler",
+    "title": "Beat and meter extraction using gaussified onsets.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p035-page-178-paper215.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Frieler04"
+  },
+  "conf/ismir/GomezH04": {
+    "@key": "conf/ismir/GomezH04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Emilia G\u00f3mez",
+      "Perfecto Herrera"
+    ],
+    "title": "Estimating The Tonality Of Polyphonic Audio Files: Cognitive Versus Machine Learning Modelling Strategies.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p018-page-92-paper164.pdf",
+    "url": "db/conf/ismir/ismir2004.html#GomezH04"
+  },
+  "conf/ismir/GotoIKK04": {
+    "@key": "conf/ismir/GotoIKK04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Masataka Goto",
+      "Katunobu Itou",
+      "Koji Kitayama",
+      "Tetsunori Kobayashi"
+    ],
+    "title": "Speech-Recognition Interfaces for Music Information Retrieval: 'Speech Completion' and 'Speech Spotter'.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p073-page-403-paper173.pdf",
+    "url": "db/conf/ismir/ismir2004.html#GotoIKK04"
+  },
+  "conf/ismir/GouyonD04": {
+    "@key": "conf/ismir/GouyonD04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Fabien Gouyon",
+      "Simon Dixon"
+    ],
+    "title": "Dance music classification: A tempo-based approach.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p091-page-501-paper151.pdf",
+    "url": "db/conf/ismir/ismir2004.html#GouyonD04"
+  },
+  "conf/ismir/GrachtenAM04": {
+    "@key": "conf/ismir/GrachtenAM04",
+    "@mdate": "2018-05-11",
+    "author": [
+      "Maarten Grachten",
+      "Josep Llu\u00eds Arcos",
+      "Ram\u00f3n L\u00f3pez de M\u00e1ntaras"
+    ],
+    "title": "Melodic Similarity: Looking for a Good Abstraction Level.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p040-page-210-paper166.pdf",
+    "url": "db/conf/ismir/ismir2004.html#GrachtenAM04"
+  },
+  "conf/ismir/GruhneUDC04": {
+    "@key": "conf/ismir/GruhneUDC04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Matthias Gruhne",
+      "Christian Uhle",
+      "Christian Dittmar",
+      "Markus Cremer"
+    ],
+    "title": "Extraction of Drum Patterns and their Description within the MPEG-7 High-Level-Framework.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p030-page-150-paper167.pdf",
+    "url": "db/conf/ismir/ismir2004.html#GruhneUDC04"
+  },
+  "conf/ismir/GuoS04": {
+    "@key": "conf/ismir/GuoS04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "AnYuan Guo",
+      "Hava T. Siegelmann"
+    ],
+    "title": "Time-Warped Longest Common Subsequence Algorithm for Music Retrieval.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p049-page-258-paper113.pdf",
+    "url": "db/conf/ismir/ismir2004.html#GuoS04"
+  },
+  "conf/ismir/HaD04": {
+    "@key": "conf/ismir/HaD04",
+    "@mdate": "2006-03-02",
+    "author": [
+      "Jin Ha Lee",
+      "J. Stephen Downie"
+    ],
+    "title": "Survey Of Music Information Needs, Uses, And Seeking Behaviours: Preliminary Findings.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p081-page-441-paper232.pdf",
+    "url": "db/conf/ismir/ismir2004.html#HaD04"
+  },
+  "conf/ismir/HannaLDB04": {
+    "@key": "conf/ismir/HannaLDB04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Pierre Hanna",
+      "Nicolas Louis",
+      "Myriam Desainte-Catherine",
+      "Jenny Benois-Pineau"
+    ],
+    "title": "Audio Features for Noisy Sound Segmentation.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p024-page-120-paper184.pdf",
+    "url": "db/conf/ismir/ismir2004.html#HannaLDB04"
+  },
+  "conf/ismir/Hirst04": {
+    "@key": "conf/ismir/Hirst04",
+    "@mdate": "2006-03-01",
+    "author": "David Hirst",
+    "title": "An Analytical Methodology for Acousmatic Music.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p015-page-76-paper112.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Hirst04"
+  },
+  "conf/ismir/HolmesA04": {
+    "@key": "conf/ismir/HolmesA04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Robyn Holmes",
+      "Marie-Louise Ayres"
+    ],
+    "title": "MusicAustralia: towards a national music information infrastructure.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p003-page-15-paper125.pdf",
+    "url": "db/conf/ismir/ismir2004.html#HolmesA04"
+  },
+  "conf/ismir/HsuCC04": {
+    "@key": "conf/ismir/HsuCC04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jia-Lien Hsu",
+      "Arbee L. P. Chen",
+      "Hung-Chen Chen"
+    ],
+    "title": "Finding Approximate Repeating Patterns from Sequence Data.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p046-page-246-paper148.pdf",
+    "url": "db/conf/ismir/ismir2004.html#HsuCC04"
+  },
+  "conf/ismir/ItoHSM04": {
+    "@key": "conf/ismir/ItoHSM04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Akinori Ito",
+      "Sung-Phil Heo",
+      "Motoyuki Suzuki",
+      "Shozo Makino"
+    ],
+    "title": "Comparison Of Features For DP-Matching Based Query-by-Humming System.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p055-page-297-paper201.pdf",
+    "url": "db/conf/ismir/ismir2004.html#ItoHSM04"
+  },
+  "conf/ismir/DoetsL04": {
+    "@key": "conf/ismir/DoetsL04",
+    "@mdate": "2006-03-02",
+    "author": [
+      "Peter Jan O. Doets",
+      "Reginald L. Lagendijk"
+    ],
+    "title": "Stochastic Model of a Robust Audio Fingerprinting System.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p064-page-349-paper114.pdf",
+    "url": "db/conf/ismir/ismir2004.html#DoetsL04"
+  },
+  "conf/ismir/Jehan04": {
+    "@key": "conf/ismir/Jehan04",
+    "@mdate": "2006-03-01",
+    "author": "Tristan Jehan",
+    "title": "Perceptual Segment Clustering For Music Description And Time-axis Redundancy Cancellation.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p025-page-124-paper182.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Jehan04"
+  },
+  "conf/ismir/JonesCJ04": {
+    "@key": "conf/ismir/JonesCJ04",
+    "@mdate": "2018-02-14",
+    "author": [
+      "Steve Jones",
+      "Sally Jo Cunningham",
+      "Matt Jones 0001"
+    ],
+    "title": "Organizing digital music for use: an examination of personal music collections.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p082-page-447-paper221.pdf",
+    "url": "db/conf/ismir/ismir2004.html#JonesCJ04"
+  },
+  "conf/ismir/KilianH04": {
+    "@key": "conf/ismir/KilianH04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "J\u00fcrgen Kilian",
+      "Holger H. Hoos"
+    ],
+    "title": "MusicBLAST - Gapped Sequence Alignment for MIR.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p007-page-38-paper229.pdf",
+    "url": "db/conf/ismir/ismir2004.html#KilianH04"
+  },
+  "conf/ismir/KneesPW04": {
+    "@key": "conf/ismir/KneesPW04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Peter Knees",
+      "Elias Pampalk",
+      "Gerhard Widmer"
+    ],
+    "title": "Artist Classification with Web-Based Data.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p094-page-517-paper211.pdf",
+    "url": "db/conf/ismir/ismir2004.html#KneesPW04"
+  },
+  "conf/ismir/Knopke04": {
+    "@key": "conf/ismir/Knopke04",
+    "@mdate": "2006-03-01",
+    "author": "Ian Knopke",
+    "title": "Sound, Music and Textual Associations on the World Wide Web.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p088-page-484-paper244.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Knopke04"
+  },
+  "conf/ismir/Krishnaswamy04": {
+    "@key": "conf/ismir/Krishnaswamy04",
+    "@mdate": "2006-03-01",
+    "author": "Arvindh Krishnaswamy",
+    "title": "Melodic Atoms for Transcribing Carnatic Music.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p063-page-345-paper219.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Krishnaswamy04"
+  },
+  "conf/ismir/Kroger04": {
+    "@key": "conf/ismir/Kroger04",
+    "@mdate": "2006-03-01",
+    "author": "Pedro Kr\u00f6ger",
+    "title": "CsoundXML: a meta-language in XML for sound synthesis.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p080-page-437-paper189.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Kroger04"
+  },
+  "conf/ismir/KurthMRRDF04": {
+    "@key": "conf/ismir/KurthMRRDF04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Frank Kurth",
+      "Meinard M\u00fcller",
+      "Andreas Ribbrock",
+      "Tido R\u00f6der",
+      "David Damm",
+      "Christian Fremerey"
+    ],
+    "title": "A Prototypical Service for Real-Time Access to Local Context-Based Music Information.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p006-page-34-paper132.pdf",
+    "url": "db/conf/ismir/ismir2004.html#KurthMRRDF04"
+  },
+  "conf/ismir/KuuskankareL04": {
+    "@key": "conf/ismir/KuuskankareL04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Mika Kuuskankare",
+      "Mikael Laurson"
+    ],
+    "title": "Expressive Notation Package - an Overview.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p012-page-58-paper210.pdf",
+    "url": "db/conf/ismir/ismir2004.html#KuuskankareL04"
+  },
+  "conf/ismir/Lartillot04": {
+    "@key": "conf/ismir/Lartillot04",
+    "@mdate": "2006-03-01",
+    "author": "Olivier Lartillot",
+    "title": "A multi-parametric and redundancy-filtering approach to pattern identification.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p027-page-132-paper213.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Lartillot04"
+  },
+  "conf/ismir/NweW04": {
+    "@key": "conf/ismir/NweW04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Tin Lay Nwe",
+      "Ye Wang"
+    ],
+    "title": "Automatic Detection Of Vocal Segments In Popular Songs.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p028-page-138-paper183.pdf",
+    "url": "db/conf/ismir/ismir2004.html#NweW04"
+  },
+  "conf/ismir/LesaffreLBM04": {
+    "@key": "conf/ismir/LesaffreLBM04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Micheline Lesaffre",
+      "Marc Leman",
+      "Bernard De Baets",
+      "Jean-Pierre Martens"
+    ],
+    "title": "Methodological Considerations Concerning Manual Annotation Of Musical Audio In Function Of Algorithm Development.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p013-page-64-paper126.pdf",
+    "url": "db/conf/ismir/ismir2004.html#LesaffreLBM04"
+  },
+  "conf/ismir/LiS04": {
+    "@key": "conf/ismir/LiS04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Ming Li",
+      "Ronan Sleep"
+    ],
+    "title": "Improving Melody Classification by Discriminant Feature Extraction and Fusion.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p044-page-238-paper123.pdf",
+    "url": "db/conf/ismir/ismir2004.html#LiS04"
+  },
+  "conf/ismir/Logan04": {
+    "@key": "conf/ismir/Logan04",
+    "@mdate": "2006-03-01",
+    "author": "Beth Logan",
+    "title": "Music Recommendation from Song Sets.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p077-page-425-paper141.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Logan04"
+  },
+  "conf/ismir/LoureiroPY04": {
+    "@key": "conf/ismir/LoureiroPY04",
+    "@mdate": "2016-01-29",
+    "author": [
+      "Maur\u00edcio A. Loureiro",
+      "Hugo Bastos de Paula",
+      "Hani C. Yehia"
+    ],
+    "title": "Timbre Classification Of A Single Musical Instrument.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p099-page-546-paper199.pdf",
+    "url": "db/conf/ismir/ismir2004.html#LoureiroPY04"
+  },
+  "conf/ismir/LubiwT04": {
+    "@key": "conf/ismir/LubiwT04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Anna Lubiw",
+      "Luke Tanur"
+    ],
+    "title": "Pattern Matching in Polyphonic Music as a Weighted Geometric Translation Problem.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p054-page-289-paper154.pdf",
+    "url": "db/conf/ismir/ismir2004.html#LubiwT04"
+  },
+  "conf/ismir/Marolt04": {
+    "@key": "conf/ismir/Marolt04",
+    "@mdate": "2006-03-01",
+    "author": "Matija Marolt",
+    "title": "Gaussian Mixture Models For Extraction Of Melodic Lines From Audio Recordings.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p016-page-80-paper159.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Marolt04"
+  },
+  "conf/ismir/McKayF04": {
+    "@key": "conf/ismir/McKayF04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Cory McKay",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Automatic Genre Classification Using Large High-Level Musical Feature Sets.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p095-page-525-paper240.pdf",
+    "url": "db/conf/ismir/ismir2004.html#McKayF04"
+  },
+  "conf/ismir/McKinneyM04": {
+    "@key": "conf/ismir/McKinneyM04",
+    "@mdate": "2011-08-16",
+    "author": [
+      "Martin F. McKinney",
+      "Dirk Moelants"
+    ],
+    "title": "Extracting the perceptual tempo from music.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p029-page-146-paper197.pdf",
+    "url": "db/conf/ismir/ismir2004.html#McKinneyM04"
+  },
+  "conf/ismir/MitchellE04": {
+    "@key": "conf/ismir/MitchellE04",
+    "@mdate": "2006-09-07",
+    "author": [
+      "R. Mitchell",
+      "Irfan A. Essa"
+    ],
+    "title": "Feature Weighting for Segmentation.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p023-page-116-paper192.pdf",
+    "url": "db/conf/ismir/ismir2004.html#MitchellE04"
+  },
+  "conf/ismir/MullensiefenF04": {
+    "@key": "conf/ismir/MullensiefenF04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Daniel M\u00fcllensiefen",
+      "Klaus Frieler"
+    ],
+    "title": "Optimizing Measures Of Melodic Similarity For The Exploration Of A Large Folk Song Database.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p052-page-274-paper178.pdf",
+    "url": "db/conf/ismir/ismir2004.html#MullensiefenF04"
+  },
+  "conf/ismir/MullerKR04": {
+    "@key": "conf/ismir/MullerKR04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Meinard M\u00fcller",
+      "Frank Kurth",
+      "Tido R\u00f6der"
+    ],
+    "title": "Towards an Efficient Algorithm for Automatic Score-to-Audio Synchronization.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p067-page-365-paper136.pdf",
+    "url": "db/conf/ismir/ismir2004.html#MullerKR04"
+  },
+  "conf/ismir/NakanoOGH04": {
+    "@key": "conf/ismir/NakanoOGH04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Tomoyasu Nakano",
+      "Jun Ogata",
+      "Masataka Goto",
+      "Yuzuru Hiraga"
+    ],
+    "title": "A Drum Pattern Retrieval Method by Voice Percussion.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p100-page-550-paper157.pdf",
+    "url": "db/conf/ismir/ismir2004.html#NakanoOGH04"
+  },
+  "conf/ismir/NesbitHS04": {
+    "@key": "conf/ismir/NesbitHS04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Andrew Nesbit",
+      "Lloyd Hollenberg",
+      "Anthony Senyard"
+    ],
+    "title": "Towards Automatic Transcription of Australian Aboriginal Music.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p059-page-326-paper245.pdf",
+    "url": "db/conf/ismir/ismir2004.html#NesbitHS04"
+  },
+  "conf/ismir/NeveO04": {
+    "@key": "conf/ismir/NeveO04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Giovanna Neve",
+      "Nicola Orio"
+    ],
+    "title": "Indexing and Retrieval of Music Documents through Pattern Analysis and Data Fusion Techniques.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p041-page-216-paper181.pdf",
+    "url": "db/conf/ismir/ismir2004.html#NeveO04"
+  },
+  "conf/ismir/PachetZ04": {
+    "@key": "conf/ismir/PachetZ04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Fran\u00e7ois Pachet",
+      "Aymeric Zils"
+    ],
+    "title": "Automatic extraction of music descriptors from acoustic signals.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p065-page-353-paper177.pdf",
+    "url": "db/conf/ismir/ismir2004.html#PachetZ04"
+  },
+  "conf/ismir/Pampalk04": {
+    "@key": "conf/ismir/Pampalk04",
+    "@mdate": "2006-03-01",
+    "author": "Elias Pampalk",
+    "title": "A Matlab Toolbox to Compute Music Similarity from Audio.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p048-page-254-paper180.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Pampalk04"
+  },
+  "conf/ismir/Pardo04": {
+    "@key": "conf/ismir/Pardo04",
+    "@mdate": "2006-03-01",
+    "author": "Bryan Pardo",
+    "title": "Tempo Tracking with a Single Oscillator.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p031-page-154-paper206.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Pardo04"
+  },
+  "conf/ismir/Pauws04": {
+    "@key": "conf/ismir/Pauws04",
+    "@mdate": "2006-03-01",
+    "author": "Steffen Pauws",
+    "title": "Musical key extraction from audio.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p019-page-96-paper142.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Pauws04"
+  },
+  "conf/ismir/PedroTBGM04": {
+    "@key": "conf/ismir/PedroTBGM04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Jose Pedro",
+      "Vadim Tarasov",
+      "Eloi Batlle",
+      "Enric Guaus",
+      "Jaume Masip"
+    ],
+    "title": "Industrial audio fingerprinting distributed system with CORBA and Web Services.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p061-page-337-paper174.pdf",
+    "url": "db/conf/ismir/ismir2004.html#PedroTBGM04"
+  },
+  "conf/ismir/PienimakiL04": {
+    "@key": "conf/ismir/PienimakiL04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Anna Pienim\u00e4ki",
+      "Kjell Lemstr\u00f6m"
+    ],
+    "title": "Clustering Symbolic Music Using Paradigmatic and Surface Level Analyses.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p050-page-262-paper175.pdf",
+    "url": "db/conf/ismir/ismir2004.html#PienimakiL04"
+  },
+  "conf/ismir/PikrakisAT04": {
+    "@key": "conf/ismir/PikrakisAT04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Aggelos Pikrakis",
+      "Iasonas Antonopoulos",
+      "Sergios Theodoridis"
+    ],
+    "title": "Music meter and tempo tracking from raw polyphonic audio.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p037-page-192-paper160.pdf",
+    "url": "db/conf/ismir/ismir2004.html#PikrakisAT04"
+  },
+  "conf/ismir/Raphael04": {
+    "@key": "conf/ismir/Raphael04",
+    "@mdate": "2006-03-01",
+    "author": "Christopher Raphael",
+    "title": "A Hybrid Graphical Model for Aligning Polyphonic Audio with Musical Scores.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p070-page-387-paper171.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Raphael04"
+  },
+  "conf/ismir/Raphael04a": {
+    "@key": "conf/ismir/Raphael04a",
+    "@mdate": "2006-03-01",
+    "author": "Christopher Raphael",
+    "title": "Demonstration of 'Music Plus One'--- a System for Orchestral Musical Accompanimen.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p071-page-395-paper176.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Raphael04a"
+  },
+  "conf/ismir/ReissS04": {
+    "@key": "conf/ismir/ReissS04",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Josh Reiss",
+      "Mark B. Sandler"
+    ],
+    "title": "Audio Issues In MIR Evaluation.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p005-page-28-paper133.pdf",
+    "url": "db/conf/ismir/ismir2004.html#ReissS04"
+  },
+  "conf/ismir/SandvoldGH04": {
+    "@key": "conf/ismir/SandvoldGH04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Vegard Sandvold",
+      "Fabien Gouyon",
+      "Perfecto Herrera"
+    ],
+    "title": "Drum sound classification in polyphonic audio recordings using localized sound models.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p097-page-537-paper150.pdf",
+    "url": "db/conf/ismir/ismir2004.html#SandvoldGH04"
+  },
+  "conf/ismir/ScherleB04": {
+    "@key": "conf/ismir/ScherleB04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Ryan Scherle",
+      "Donald Byrd"
+    ],
+    "title": "The Anatomy of a Bibliographic Search System for Music.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p089-page-489-paper241.pdf",
+    "url": "db/conf/ismir/ismir2004.html#ScherleB04"
+  },
+  "conf/ismir/Shalev-ShwartzKS04": {
+    "@key": "conf/ismir/Shalev-ShwartzKS04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Shai Shalev-Shwartz",
+      "Joseph Keshet",
+      "Yoram Singer"
+    ],
+    "title": "Learning to Align Polyphonic Music.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p069-page-381-paper140.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Shalev-ShwartzKS04"
+  },
+  "conf/ismir/ShresthaK04": {
+    "@key": "conf/ismir/ShresthaK04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Prarthana Shrestha",
+      "Ton Kalker"
+    ],
+    "title": "Audio Fingerprinting In Peer-to-peer Networks.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p062-page-341-paper91.pdf",
+    "url": "db/conf/ismir/ismir2004.html#ShresthaK04"
+  },
+  "conf/ismir/Singer04": {
+    "@key": "conf/ismir/Singer04",
+    "@mdate": "2006-03-01",
+    "author": "Jane Singer",
+    "title": "Creating a nested melodic representation: competition and cooperation among bottom-up and top-down Gestalt principles.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p022-page-112-paper155.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Singer04"
+  },
+  "conf/ismir/StephenFT04": {
+    "@key": "conf/ismir/StephenFT04",
+    "@mdate": "2006-05-04",
+    "author": [
+      "J. Stephen Downie",
+      "Joe Futrelle",
+      "David K. Tcheng"
+    ],
+    "title": "The International Music Information Retrieval Systems Evaluation Laboratory: Governance, Access and Security.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p002-page-9-paper220.pdf",
+    "url": "db/conf/ismir/ismir2004.html#StephenFT04"
+  },
+  "conf/ismir/StoddardRU04": {
+    "@key": "conf/ismir/StoddardRU04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Josh Stoddard",
+      "Christopher Raphael",
+      "Paul E. Utgoff"
+    ],
+    "title": "Well-Tempered Spelling: A Key Invariant Pitch Spelling Algorithm.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p021-page-106-paper208.pdf",
+    "url": "db/conf/ismir/ismir2004.html#StoddardRU04"
+  },
+  "conf/ismir/StuartLS04": {
+    "@key": "conf/ismir/StuartLS04",
+    "@mdate": "2010-03-24",
+    "author": [
+      "Craig Stuart Sapp",
+      "Yi-Wen Liu",
+      "Eleanor Selfridge-Field"
+    ],
+    "title": "Search Effectiveness Measures for Symbolic Music Queries in Very Large Databases.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p051-page-266-paper135.pdf",
+    "url": "db/conf/ismir/ismir2004.html#StuartLS04"
+  },
+  "conf/ismir/SuyotoU04": {
+    "@key": "conf/ismir/SuyotoU04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Iman S. H. Suyoto",
+      "Alexandra L. Uitdenbogerd"
+    ],
+    "title": "Exploring Microtonal Matching.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p042-page-224-paper225.pdf",
+    "url": "db/conf/ismir/ismir2004.html#SuyotoU04"
+  },
+  "conf/ismir/Taheri-PanahM04": {
+    "@key": "conf/ismir/Taheri-PanahM04",
+    "@mdate": "2015-11-04",
+    "author": [
+      "Sara Taheri-Panah",
+      "Andrew MacFarlane 0001"
+    ],
+    "title": "Music Information Retrieval systems: why do individuals use them and what are their needs?.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p083-page-455-paper110.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Taheri-PanahM04"
+  },
+  "conf/ismir/TakedaNS04": {
+    "@key": "conf/ismir/TakedaNS04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Haruto Takeda",
+      "Takuya Nishimoto",
+      "Shigeki Sagayama"
+    ],
+    "title": "Rhythm and Tempo Recognition of Music Performance from a Probabilistic Approach.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p066-page-357-paper250.pdf",
+    "url": "db/conf/ismir/ismir2004.html#TakedaNS04"
+  },
+  "conf/ismir/Terrat04": {
+    "@key": "conf/ismir/Terrat04",
+    "@mdate": "2006-03-01",
+    "author": "Richard Terrat",
+    "title": "Pregroup Grammars for Chords.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p047-page-250-paper139.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Terrat04"
+  },
+  "conf/ismir/TindaleKTF04": {
+    "@key": "conf/ismir/TindaleKTF04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Adam R. Tindale",
+      "Ajay Kapur",
+      "George Tzanetakis",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Retrieval of percussion gestures using timbre classification techniques.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p098-page-541-paper235.pdf",
+    "url": "db/conf/ismir/ismir2004.html#TindaleKTF04"
+  },
+  "conf/ismir/TorrensHA04": {
+    "@key": "conf/ismir/TorrensHA04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Marc Torrens",
+      "Patrick Hertzog",
+      "Josep Llu\u00eds Arcos"
+    ],
+    "title": "Visualizing and Exploring Personal Music Libraries.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p076-page-421-paper214.pdf",
+    "url": "db/conf/ismir/ismir2004.html#TorrensHA04"
+  },
+  "conf/ismir/Toussaint04": {
+    "@key": "conf/ismir/Toussaint04",
+    "@mdate": "2006-03-01",
+    "author": "Godfried T. Toussaint",
+    "title": "A Comparison of Rhythmic Similarity Measures.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p045-page-242-paper134.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Toussaint04"
+  },
+  "conf/ismir/ToyodaNK04": {
+    "@key": "conf/ismir/ToyodaNK04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Ken'ichi Toyoda",
+      "Kenzi Noike",
+      "Haruhiro Katayose"
+    ],
+    "title": "Utility System For Constructing Database Of Performance Deviations.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p068-page-373-paper162.pdf",
+    "url": "db/conf/ismir/ismir2004.html#ToyodaNK04"
+  },
+  "conf/ismir/TsaiW04": {
+    "@key": "conf/ismir/TsaiW04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Wei-Ho Tsai",
+      "Hsin-Min Wang"
+    ],
+    "title": "Towards Automatic Identification Of Singing Language In Popular Music Recordings.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p103-page-568-paper145.pdf",
+    "url": "db/conf/ismir/ismir2004.html#TsaiW04"
+  },
+  "conf/ismir/TypkeWV04": {
+    "@key": "conf/ismir/TypkeWV04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Rainer Typke",
+      "Frans Wiering",
+      "Remco C. Veltkamp"
+    ],
+    "title": "A search method for notated polyphonic music with pitch and tempo fluctuations.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p053-page-281-paper120.pdf",
+    "url": "db/conf/ismir/ismir2004.html#TypkeWV04"
+  },
+  "conf/ismir/TzanetakisKB04": {
+    "@key": "conf/ismir/TzanetakisKB04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "George Tzanetakis",
+      "Ajay Kapur",
+      "Manj Benning"
+    ],
+    "title": "Query-by-Beat-Boxing: Music Retrieval For The DJ.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p034-page-170-paper217.pdf",
+    "url": "db/conf/ismir/ismir2004.html#TzanetakisKB04"
+  },
+  "conf/ismir/Vignoli04": {
+    "@key": "conf/ismir/Vignoli04",
+    "@mdate": "2006-03-01",
+    "author": "Fabio Vignoli",
+    "title": "Digital Music Interaction Concepts: A User Study.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p075-page-415-paper152.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Vignoli04"
+  },
+  "conf/ismir/VignoliGW04": {
+    "@key": "conf/ismir/VignoliGW04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Fabio Vignoli",
+      "Rob van Gulik",
+      "Huub van de Wetering"
+    ],
+    "title": "Mapping Music In The Palm Of Your Hand, Explore And Discover Your Collection.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p074-page-409-paper153.pdf",
+    "url": "db/conf/ismir/ismir2004.html#VignoliGW04"
+  },
+  "conf/ismir/VincentR04": {
+    "@key": "conf/ismir/VincentR04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Emmanuel Vincent",
+      "Xavier Rodet"
+    ],
+    "title": "Instrument identification in solo and ensemble music using Independent Subspace Analysis.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p104-page-576-paper119.pdf",
+    "url": "db/conf/ismir/ismir2004.html#VincentR04"
+  },
+  "conf/ismir/WestC04": {
+    "@key": "conf/ismir/WestC04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Kristopher West",
+      "Stephen Cox"
+    ],
+    "title": "Features and classifiers for the automatic classification of musical audio signals.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p096-page-531-paper115.pdf",
+    "url": "db/conf/ismir/ismir2004.html#WestC04"
+  },
+  "conf/ismir/Weyde04": {
+    "@key": "conf/ismir/Weyde04",
+    "@mdate": "2006-03-01",
+    "author": "Tillman Weyde",
+    "title": "The Influence of Pitch on Melodic Segmentation.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p026-page-128-paper237.pdf",
+    "url": "db/conf/ismir/ismir2004.html#Weyde04"
+  },
+  "conf/ismir/WhitmanE04": {
+    "@key": "conf/ismir/WhitmanE04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Brian Whitman",
+      "Dan Ellis"
+    ],
+    "title": "Automatic Record Reviews.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p086-page-470-paper203.pdf",
+    "url": "db/conf/ismir/ismir2004.html#WhitmanE04"
+  },
+  "conf/ismir/WoodO04": {
+    "@key": "conf/ismir/WoodO04",
+    "@mdate": "2007-06-26",
+    "author": [
+      "Gavin Wood",
+      "Simon O'Keefe"
+    ],
+    "title": "A Case Study of Distributed Music Audio Analysis Using the Geddei Processing Framework.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p009-page-44-paper158.pdf",
+    "url": "db/conf/ismir/ismir2004.html#WoodO04"
+  },
+  "conf/ismir/WustC04": {
+    "@key": "conf/ismir/WustC04",
+    "@mdate": "2008-07-02",
+    "author": [
+      "Otto W\u00fcst",
+      "\u00d2scar Celma"
+    ],
+    "title": "An MPEG-7 Database System and Application for Content-Based Management and Retrieval of Music.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p010-page-48-paper227.pdf",
+    "url": "db/conf/ismir/ismir2004.html#WustC04"
+  },
+  "conf/ismir/YangL04": {
+    "@key": "conf/ismir/YangL04",
+    "@mdate": "2018-06-12",
+    "author": [
+      "Dan Yang 0002",
+      "Won-Sook Lee"
+    ],
+    "title": "Disambiguating Music Emotion Using Software Agents.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p011-page-52-paper218.pdf",
+    "url": "db/conf/ismir/ismir2004.html#YangL04"
+  },
+  "conf/ismir/YoshiiGO04": {
+    "@key": "conf/ismir/YoshiiGO04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Kazuyoshi Yoshii",
+      "Masataka Goto",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Automatic Drum Sound Description for Real-World Music Using Template Adaptation and Matching Methods.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p036-page-184-paper172.pdf",
+    "url": "db/conf/ismir/ismir2004.html#YoshiiGO04"
+  },
+  "conf/ismir/YoshiokaKKOO04": {
+    "@key": "conf/ismir/YoshiokaKKOO04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Takuya Yoshioka",
+      "Tetsuro Kitahara",
+      "Kazunori Komatani",
+      "Tetsuya Ogata",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Automatic Chord Transcription with Concurrent Recognition of Chord Symbols and Boundaries.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p020-page-100-paper149.pdf",
+    "url": "db/conf/ismir/ismir2004.html#YoshiokaKKOO04"
+  },
+  "conf/ismir/ZadelF04": {
+    "@key": "conf/ismir/ZadelF04",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Mark Zadel",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Web Services for Music Information Retrieval.",
+    "year": "2004",
+    "crossref": "conf/ismir/2004",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2004.ismir.net/proceedings/p087-page-478-paper243.pdf",
+    "url": "db/conf/ismir/ismir2004.html#ZadelF04"
+  },
+  "conf/ismir/LeeDC05": {
+    "@key": "conf/ismir/LeeDC05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Jin Ha Lee",
+      "J. Stephen Downie",
+      "Sally Jo Cunningham"
+    ],
+    "title": "Challenges in Cross-Cultural/Multilingual Music Information Seeking.",
+    "pages": "1-7",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1100.pdf",
+    "url": "db/conf/ismir/ismir2005.html#LeeDC05"
+  },
+  "conf/ismir/Grund05": {
+    "@key": "conf/ismir/Grund05",
+    "@mdate": "2006-02-24",
+    "author": "Cynthia M. Grund",
+    "title": "Music Information Retrieval, Memory and Culture: Some Philosohpical Remarks.",
+    "pages": "8-12",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1112.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Grund05"
+  },
+  "conf/ismir/NorowiDR05": {
+    "@key": "conf/ismir/NorowiDR05",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Noris Mohd. Norowi",
+      "Shyamala Doraisamy",
+      "Rahmita Wirza O. K. Rahmat"
+    ],
+    "title": "Factors Affecting Automatic Genre Classification: An Investigation Incorporating Non-Western Musical Forms.",
+    "pages": "13-20",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1111.pdf",
+    "url": "db/conf/ismir/ismir2005.html#NorowiDR05"
+  },
+  "conf/ismir/SchedlKW05": {
+    "@key": "conf/ismir/SchedlKW05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Markus Schedl",
+      "Peter Knees",
+      "Gerhard Widmer"
+    ],
+    "title": "Discovering and Visualizing Prototypical Artists by Web-Based Co-Occurrence Analysis.",
+    "pages": "21-28",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1054.pdf",
+    "url": "db/conf/ismir/ismir2005.html#SchedlKW05"
+  },
+  "conf/ismir/Knopke05": {
+    "@key": "conf/ismir/Knopke05",
+    "@mdate": "2006-02-24",
+    "author": "Ian Knopke",
+    "title": "Geospatial Location of Music and Sound Files for Music Information Retrieval.",
+    "pages": "29-33",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1132.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Knopke05"
+  },
+  "conf/ismir/LidyR05": {
+    "@key": "conf/ismir/LidyR05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Thomas Lidy",
+      "Andreas Rauber"
+    ],
+    "title": "Evaluation of Feature Extractors and Psycho-Acoustic Transformations for Music Genre Classification.",
+    "pages": "34-41",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1033.pdf",
+    "url": "db/conf/ismir/ismir2005.html#LidyR05"
+  },
+  "conf/ismir/McKayFMLF05": {
+    "@key": "conf/ismir/McKayFMLF05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Cory McKay",
+      "Rebecca Fiebrink",
+      "Daniel McEnnis",
+      "Beinan Li",
+      "Ichiro Fujinaga"
+    ],
+    "title": "ACE: A Framework for Optimizing Music Classification.",
+    "pages": "42-49",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1083.pdf",
+    "url": "db/conf/ismir/ismir2005.html#McKayFMLF05"
+  },
+  "conf/ismir/TangheLDLBM05": {
+    "@key": "conf/ismir/TangheLDLBM05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Koen Tanghe",
+      "Micheline Lesaffre",
+      "Sven Degroeve",
+      "Marc Leman",
+      "Bernard De Baets",
+      "Jean-Pierre Martens"
+    ],
+    "title": "Collecting Ground Truth Annotations for Drum Detection in Polyphonic Music.",
+    "pages": "50-57",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1006.pdf",
+    "url": "db/conf/ismir/ismir2005.html#TangheLDLBM05"
+  },
+  "conf/ismir/WoodO05": {
+    "@key": "conf/ismir/WoodO05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Gavin Wood",
+      "Simon O'Keefe"
+    ],
+    "title": "On Techniques for Content-Based Visual Annotation to Aid Intra-Track Music Navigation.",
+    "pages": "58-65",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1023.pdf",
+    "url": "db/conf/ismir/ismir2005.html#WoodO05"
+  },
+  "conf/ismir/HarteSAG05": {
+    "@key": "conf/ismir/HarteSAG05",
+    "@mdate": "2008-05-05",
+    "author": [
+      "Christopher Harte",
+      "Mark B. Sandler",
+      "Samer A. Abdallah",
+      "Emilia G\u00f3mez"
+    ],
+    "title": "Symbolic Representation of Musical Chords: A Proposed Syntax for Text Annotations.",
+    "pages": "66-71",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1080.pdf",
+    "url": "db/conf/ismir/ismir2005.html#HarteSAG05"
+  },
+  "conf/ismir/KuuskankareL05": {
+    "@key": "conf/ismir/KuuskankareL05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Mika Kuuskankare",
+      "Mikael Laurson"
+    ],
+    "title": "Annotating Musical Scores in ENP.",
+    "pages": "72-76",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1086.pdf",
+    "url": "db/conf/ismir/ismir2005.html#KuuskankareL05"
+  },
+  "conf/ismir/HerreraCMCGGK05": {
+    "@key": "conf/ismir/HerreraCMCGGK05",
+    "@mdate": "2008-07-02",
+    "author": [
+      "Perfecto Herrera",
+      "\u00d2scar Celma",
+      "Jordi Massaguer",
+      "Pedro Cano",
+      "Emilia G\u00f3mez",
+      "Fabien Gouyon",
+      "Markus Koppenberger"
+    ],
+    "title": "MUCOSA: A Music Content Semantic Annotator.",
+    "pages": "77-83",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1115.pdf",
+    "url": "db/conf/ismir/ismir2005.html#HerreraCMCGGK05"
+  },
+  "conf/ismir/SaitoKNS05": {
+    "@key": "conf/ismir/SaitoKNS05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Shoichiro Saito",
+      "Hirokazu Kameoka",
+      "Takuya Nishimoto",
+      "Shigeki Sagayama"
+    ],
+    "title": "Specmurt Analysis of Multi-Pitch Music Signals with Adaptive Estimation of Common Harmonic Structure .",
+    "pages": "84-91",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1131.pdf",
+    "url": "db/conf/ismir/ismir2005.html#SaitoKNS05"
+  },
+  "conf/ismir/GilletR05": {
+    "@key": "conf/ismir/GilletR05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Olivier Gillet",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "Drum Track Transcription of Polyphonic Music Using Noise Subspace Projection.",
+    "pages": "92-99",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1061.pdf",
+    "url": "db/conf/ismir/ismir2005.html#GilletR05"
+  },
+  "conf/ismir/Collins05": {
+    "@key": "conf/ismir/Collins05",
+    "@mdate": "2006-02-24",
+    "author": "Nick Collins",
+    "title": "Using a Pitch Detector for Onset Detection.",
+    "pages": "100-106",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1008.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Collins05"
+  },
+  "conf/ismir/Chordia05": {
+    "@key": "conf/ismir/Chordia05",
+    "@mdate": "2006-02-24",
+    "author": "Parag Chordia",
+    "title": "Segmentation and Recognition of Tabla Strokes.",
+    "pages": "107-114",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1137.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Chordia05"
+  },
+  "conf/ismir/KameokaNS05": {
+    "@key": "conf/ismir/KameokaNS05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Hirokazu Kameoka",
+      "Takuya Nishimoto",
+      "Shigeki Sagayama"
+    ],
+    "title": "Harmonic-Temporal Clustering via Deterministic Annealing EM Algorithm for Audio Feature Extraction.",
+    "pages": "115-122",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1130.pdf",
+    "url": "db/conf/ismir/ismir2005.html#KameokaNS05"
+  },
+  "conf/ismir/Riley05": {
+    "@key": "conf/ismir/Riley05",
+    "@mdate": "2006-02-24",
+    "author": "Jenn Riley",
+    "title": "Exploiting Musical Connections: A Proposal for Support of Work Relationships in a Digital Music Library.",
+    "pages": "123-129",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1108.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Riley05"
+  },
+  "conf/ismir/KapurMT05": {
+    "@key": "conf/ismir/KapurMT05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Ajay Kapur",
+      "Richard I. McWalter",
+      "George Tzanetakis"
+    ],
+    "title": "New Music Interfaces for Rhythm-Based Retrieval.",
+    "pages": "130-136",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1109.pdf",
+    "url": "db/conf/ismir/ismir2005.html#KapurMT05"
+  },
+  "conf/ismir/KarydisNPKM05": {
+    "@key": "conf/ismir/KarydisNPKM05",
+    "@mdate": "2017-12-17",
+    "author": [
+      "Ioannis Karydis",
+      "Alexandros Nanopoulos",
+      "Apostolos N. Papadopoulos",
+      "Dimitrios Katsaros 0001",
+      "Yannis Manolopoulos"
+    ],
+    "title": "Content-Based Music Information Retrieval in Wireless Ad-Hoc Networks.",
+    "pages": "137-144",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1039.pdf",
+    "url": "db/conf/ismir/ismir2005.html#KarydisNPKM05"
+  },
+  "conf/ismir/LobbBB05": {
+    "@key": "conf/ismir/LobbBB05",
+    "@mdate": "2017-12-04",
+    "author": [
+      "Richard Lobb",
+      "Tim Bell",
+      "David Bainbridge 0001"
+    ],
+    "title": "Fast Capture of Sheet Music for an Agile Digital Music Library.",
+    "pages": "145-152",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1018.pdf",
+    "url": "db/conf/ismir/ismir2005.html#LobbBB05"
+  },
+  "conf/ismir/TypkeWV05": {
+    "@key": "conf/ismir/TypkeWV05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Rainer Typke",
+      "Frans Wiering",
+      "Remco C. Veltkamp"
+    ],
+    "title": "A Survey of Music Information Retrieval Systems.",
+    "pages": "153-160",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1020.pdf",
+    "url": "db/conf/ismir/ismir2005.html#TypkeWV05"
+  },
+  "conf/ismir/PolinerE05": {
+    "@key": "conf/ismir/PolinerE05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Graham E. Poliner",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "A Classification Approach to Melody Transcription.",
+    "pages": "161-166",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1107.pdf",
+    "url": "db/conf/ismir/ismir2005.html#PolinerE05"
+  },
+  "conf/ismir/CambouropoulosCIMS05": {
+    "@key": "conf/ismir/CambouropoulosCIMS05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Emilios Cambouropoulos",
+      "Maxime Crochemore",
+      "Costas S. Iliopoulos",
+      "Manal Mohamed",
+      "Marie-France Sagot"
+    ],
+    "title": "A Pattern Extraction Algorithm for Abstract Melodic Representations that Allow Partial Overlapping of Intervallic Categories.",
+    "pages": "167-174",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1022.pdf",
+    "url": "db/conf/ismir/ismir2005.html#CambouropoulosCIMS05"
+  },
+  "conf/ismir/Paiva05": {
+    "@key": "conf/ismir/Paiva05",
+    "@mdate": "2006-02-24",
+    "author": "Rui Pedro Paiva",
+    "title": "On the Detection of Melody Notes in Polyphonic Audio.",
+    "pages": "175-182",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1032.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Paiva05"
+  },
+  "conf/ismir/TsaiYW05": {
+    "@key": "conf/ismir/TsaiYW05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Wei-Ho Tsai",
+      "Hung-Ming Yu",
+      "Hsin-Min Wang"
+    ],
+    "title": "Query-By-Example Technique for Retrieving Cover Versions of Popular Songs with Similar Melodies.",
+    "pages": "183-190",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1047.pdf",
+    "url": "db/conf/ismir/ismir2005.html#TsaiYW05"
+  },
+  "conf/ismir/Lartillot05": {
+    "@key": "conf/ismir/Lartillot05",
+    "@mdate": "2006-02-24",
+    "author": "Olivier Lartillot",
+    "title": "Efficient Extraction of Closed Motivic Patterns in Multi-Dimensional Symbolic Representations of Music.",
+    "pages": "191-198",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1082.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Lartillot05"
+  },
+  "conf/ismir/AdamsMW05": {
+    "@key": "conf/ismir/AdamsMW05",
+    "@mdate": "2007-03-05",
+    "author": [
+      "Norman H. Adams",
+      "Daniela Marquez",
+      "Gregory H. Wakefield"
+    ],
+    "title": "Iterative Deepening for Melody Alignment and Retrieval.",
+    "pages": "199-206",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1005.pdf",
+    "url": "db/conf/ismir/ismir2005.html#AdamsMW05"
+  },
+  "conf/ismir/PickensI05": {
+    "@key": "conf/ismir/PickensI05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Jeremy Pickens",
+      "Costas S. Iliopoulos"
+    ],
+    "title": "Markov Random Fields and Maximum Entropy Modeling for Music Information Retrieval.",
+    "pages": "207-214",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1007.pdf",
+    "url": "db/conf/ismir/ismir2005.html#PickensI05"
+  },
+  "conf/ismir/PardoS05": {
+    "@key": "conf/ismir/PardoS05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Bryan Pardo",
+      "Manan Sanghi"
+    ],
+    "title": "Polyphonic Musical Sequence Alignment for Database Search.",
+    "pages": "215-222",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1078.pdf",
+    "url": "db/conf/ismir/ismir2005.html#PardoS05"
+  },
+  "conf/ismir/HuD05": {
+    "@key": "conf/ismir/HuD05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Ning Hu",
+      "Roger B. Dannenberg"
+    ],
+    "title": "A Bootstrap Method for Training an Accurate Audio Segmenter.",
+    "pages": "223-229",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1128.pdf",
+    "url": "db/conf/ismir/ismir2005.html#HuD05"
+  },
+  "conf/ismir/RoyAPB05": {
+    "@key": "conf/ismir/RoyAPB05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Pierre Roy",
+      "Jean-Julien Aucouturier",
+      "Fran\u00e7ois Pachet",
+      "Anthony Beuriv\u00e9"
+    ],
+    "title": "Exploiting the Tradeoff Between Precision and Cpu-Time to Speed Up Nearest Neighbor Search.",
+    "pages": "230-237",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1056.pdf",
+    "url": "db/conf/ismir/ismir2005.html#RoyAPB05"
+  },
+  "conf/ismir/BertinC05": {
+    "@key": "conf/ismir/BertinC05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Nancy Bertin",
+      "Alain de Cheveign\u00e9"
+    ],
+    "title": "Scalable Metadata and Quick Retrieval of Audio Signals.",
+    "pages": "238-244",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1114.pdf",
+    "url": "db/conf/ismir/ismir2005.html#BertinC05"
+  },
+  "conf/ismir/Parker05": {
+    "@key": "conf/ismir/Parker05",
+    "@mdate": "2006-02-24",
+    "author": "Charles L. Parker",
+    "title": "Applications of Binary Classification and Adaptive Boosting to the Query-By-Humming Problem.",
+    "pages": "245-251",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1104.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Parker05"
+  },
+  "conf/ismir/LiS05": {
+    "@key": "conf/ismir/LiS05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Ming Li",
+      "Ronan Sleep"
+    ],
+    "title": "Genre Classification via an LZ78-Based String Kernel.",
+    "pages": "252-259",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1116.pdf",
+    "url": "db/conf/ismir/ismir2005.html#LiS05"
+  },
+  "conf/ismir/FlexerPW05": {
+    "@key": "conf/ismir/FlexerPW05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Arthur Flexer",
+      "Elias Pampalk",
+      "Gerhard Widmer"
+    ],
+    "title": "Novelty Detection Based on Spectral Similarity of Songs.",
+    "pages": "260-263",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1014.pdf",
+    "url": "db/conf/ismir/ismir2005.html#FlexerPW05"
+  },
+  "conf/ismir/StenzelK05": {
+    "@key": "conf/ismir/StenzelK05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Richard Stenzel",
+      "Thomas Kamps"
+    ],
+    "title": "Improving Content-Based Similarity Measures by Training a Collaborative Model.",
+    "pages": "264-271",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1081.pdf",
+    "url": "db/conf/ismir/ismir2005.html#StenzelK05"
+  },
+  "conf/ismir/VignoliP05": {
+    "@key": "conf/ismir/VignoliP05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Fabio Vignoli",
+      "Steffen Pauws"
+    ],
+    "title": "A Music Retrieval System Based on User Driven Similarity and Its Evaluation.",
+    "pages": "272-279",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1021.pdf",
+    "url": "db/conf/ismir/ismir2005.html#VignoliP05"
+  },
+  "conf/ismir/MeredithW05": {
+    "@key": "conf/ismir/MeredithW05",
+    "@mdate": "2016-09-26",
+    "author": [
+      "David Meredith 0001",
+      "Geraint A. Wiggins"
+    ],
+    "title": "Comparing Pitch Spelling Algorithms.",
+    "pages": "280-287",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1004.pdf",
+    "url": "db/conf/ismir/ismir2005.html#MeredithW05"
+  },
+  "conf/ismir/MuellerKC05": {
+    "@key": "conf/ismir/MuellerKC05",
+    "@mdate": "2006-03-01",
+    "author": [
+      "Meinard M\u00fcller",
+      "Frank Kurth",
+      "Michael Clausen"
+    ],
+    "title": "Audio Matching via Chroma-Based Statistical Features.",
+    "pages": "288-295",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1019.pdf",
+    "url": "db/conf/ismir/ismir2005.html#MuellerKC05"
+  },
+  "conf/ismir/ChuanC05": {
+    "@key": "conf/ismir/ChuanC05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Ching-Hua Chuan",
+      "Elaine Chew"
+    ],
+    "title": "Fuzzy Analysis in Pitch-Class Determination for Polyphonic Audio Key Finding.",
+    "pages": "296-303",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1037.pdf",
+    "url": "db/conf/ismir/ismir2005.html#ChuanC05"
+  },
+  "conf/ismir/BelloP05": {
+    "@key": "conf/ismir/BelloP05",
+    "@mdate": "2006-03-02",
+    "author": [
+      "Juan Pablo Bello",
+      "Jeremy Pickens"
+    ],
+    "title": "A Robust Mid-Level Representation for Harmonic Content in Music Signals.",
+    "pages": "304-311",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1038.pdf",
+    "url": "db/conf/ismir/ismir2005.html#BelloP05"
+  },
+  "conf/ismir/PaiementEB05": {
+    "@key": "conf/ismir/PaiementEB05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Jean-Fran\u00e7ois Paiement",
+      "Douglas Eck",
+      "Samy Bengio"
+    ],
+    "title": "A Probabilistic Model for Chord Progressions.",
+    "pages": "312-319",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1091.pdf",
+    "url": "db/conf/ismir/ismir2005.html#PaiementEB05"
+  },
+  "conf/ismir/DownieWEV05": {
+    "@key": "conf/ismir/DownieWEV05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "J. Stephen Downie",
+      "Kris West",
+      "Andreas F. Ehmann",
+      "Emmanuel Vincent"
+    ],
+    "title": "The 2005 Music Information retrieval Evaluation Exchange (MIREX 2005): Preliminary Overview.",
+    "pages": "320-323",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/xxxx.pdf",
+    "url": "db/conf/ismir/ismir2005.html#DownieWEV05"
+  },
+  "conf/ismir/EssidRD05": {
+    "@key": "conf/ismir/EssidRD05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Slim Essid",
+      "Ga\u00ebl Richard",
+      "Bertrand David"
+    ],
+    "title": "Inferring Efficient Hierarchical Taxonomies for MIR Tasks: Application to Musical Instruments.",
+    "pages": "324-328",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1088.pdf",
+    "url": "db/conf/ismir/ismir2005.html#EssidRD05"
+  },
+  "conf/ismir/FujiharaKGKOO05": {
+    "@key": "conf/ismir/FujiharaKGKOO05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Hiromasa Fujihara",
+      "Tetsuro Kitahara",
+      "Masataka Goto",
+      "Kazunori Komatani",
+      "Tetsuya Ogata",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Singer Identification Based on Accompaniment Sound Reduction and Reliable Frame Selection.",
+    "pages": "329-336",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1099.pdf",
+    "url": "db/conf/ismir/ismir2005.html#FujiharaKGKOO05"
+  },
+  "conf/ismir/VembuB05": {
+    "@key": "conf/ismir/VembuB05",
+    "@mdate": "2018-07-06",
+    "author": [
+      "Shankar Vembu",
+      "Stephan Baumann 0001"
+    ],
+    "title": "Separation of Vocals from Polyphonic Audio Recordings .",
+    "pages": "337-344",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1028.pdf",
+    "url": "db/conf/ismir/ismir2005.html#VembuB05"
+  },
+  "conf/ismir/CasagrandeEK05": {
+    "@key": "conf/ismir/CasagrandeEK05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Norman Casagrande",
+      "Douglas Eck",
+      "Bal\u00e1zs K\u00e9gl"
+    ],
+    "title": "Frame-Level Audio Feature Extraction Using AdaBoost.",
+    "pages": "345-350",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1065.pdf",
+    "url": "db/conf/ismir/ismir2005.html#CasagrandeEK05"
+  },
+  "conf/ismir/ToiviainenE05": {
+    "@key": "conf/ismir/ToiviainenE05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Petri Toiviainen",
+      "Tuomas Eerola"
+    ],
+    "title": "Classification of Musical Metre with Autocorrelation and Discriminant Functions.",
+    "pages": "351-357",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1049.pdf",
+    "url": "db/conf/ismir/ismir2005.html#ToiviainenE05"
+  },
+  "conf/ismir/HamanakaHT05": {
+    "@key": "conf/ismir/HamanakaHT05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Masatoshi Hamanaka",
+      "Keiji Hirata",
+      "Satoshi Tojo"
+    ],
+    "title": "ATTA: Automatic Time-Span Tree Analyzer Based on Extended GTTM.",
+    "pages": "358-365",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1015.pdf",
+    "url": "db/conf/ismir/ismir2005.html#HamanakaHT05"
+  },
+  "conf/ismir/Dannenberg05": {
+    "@key": "conf/ismir/Dannenberg05",
+    "@mdate": "2006-02-24",
+    "author": "Roger B. Dannenberg",
+    "title": "Toward Automated Holistic Beat Tracking, Music Analysis and Understanding.",
+    "pages": "366-373",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1030.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Dannenberg05"
+  },
+  "conf/ismir/JensenXZ05": {
+    "@key": "conf/ismir/JensenXZ05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Kristoffer Jensen",
+      "Jieping Xu",
+      "Martin Zachariasen"
+    ],
+    "title": "Rhythm-Based Segmentation of Popular Chinese Music.",
+    "pages": "374-380",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1031.pdf",
+    "url": "db/conf/ismir/ismir2005.html#JensenXZ05"
+  },
+  "conf/ismir/KurthMDFRC05": {
+    "@key": "conf/ismir/KurthMDFRC05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Frank Kurth",
+      "Meinard M\u00fcller",
+      "David Damm",
+      "Christian Fremerey",
+      "Andreas Ribbrock",
+      "Michael Clausen"
+    ],
+    "title": "Syncplayer - An Advanced System for Multimodal Music Access.",
+    "pages": "381-388",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1025.pdf",
+    "url": "db/conf/ismir/ismir2005.html#KurthMDFRC05"
+  },
+  "conf/ismir/Isaacson05": {
+    "@key": "conf/ismir/Isaacson05",
+    "@mdate": "2006-02-24",
+    "author": "Eric J. Isaacson",
+    "title": "What You See Is What You Get: on Visualizing Music.",
+    "pages": "389-395",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1129.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Isaacson05"
+  },
+  "conf/ismir/MorchenUNS05": {
+    "@key": "conf/ismir/MorchenUNS05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Fabian M\u00f6rchen",
+      "Alfred Ultsch",
+      "Mario N\u00f6cker",
+      "Christian Stamm"
+    ],
+    "title": "Databionic Visualization of Music Collections According to Perceptual Distance.",
+    "pages": "396-403",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1051.pdf",
+    "url": "db/conf/ismir/ismir2005.html#MorchenUNS05"
+  },
+  "conf/ismir/GotoG05": {
+    "@key": "conf/ismir/GotoG05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Masataka Goto",
+      "Takayuki Goto"
+    ],
+    "title": "Musicream: New Music Playback Interface for Streaming, Sticking, Sorting, and Recalling Musical Pieces.",
+    "pages": "404-411",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1058.pdf",
+    "url": "db/conf/ismir/ismir2005.html#GotoG05"
+  },
+  "conf/ismir/AucouturierP05": {
+    "@key": "conf/ismir/AucouturierP05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Jean-Julien Aucouturier",
+      "Fran\u00e7ois Pachet"
+    ],
+    "title": "Ringomatic: A Real-Time Interactive Drummer Using Constraint-Satisfaction and Drum Sound Descriptors.",
+    "pages": "412-419",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1057.pdf",
+    "url": "db/conf/ismir/ismir2005.html#AucouturierP05"
+  },
+  "conf/ismir/AbdallahNSCR05": {
+    "@key": "conf/ismir/AbdallahNSCR05",
+    "@mdate": "2016-08-30",
+    "author": [
+      "Samer A. Abdallah",
+      "Katy C. Noland",
+      "Mark B. Sandler",
+      "Michael A. Casey",
+      "Christophe Rhodes"
+    ],
+    "title": "Theory and Evaluation of a Bayesian Music Structure Extractor.",
+    "pages": "420-425",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1134.pdf",
+    "url": "db/conf/ismir/ismir2005.html#AbdallahNSCR05"
+  },
+  "conf/ismir/AmatriainMGM05": {
+    "@key": "conf/ismir/AmatriainMGM05",
+    "@mdate": "2018-08-20",
+    "author": [
+      "Xavier Amatriain",
+      "Jordi Massaguer",
+      "David Garc\u00eda",
+      "Ismael Mosquera"
+    ],
+    "title": "The CLAM Annotator: A Cross-Platform Audio Descriptors Editing Tool.",
+    "pages": "426-429",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/3017.pdf",
+    "url": "db/conf/ismir/ismir2005.html#AmatriainMGM05"
+  },
+  "conf/ismir/BellBGB05": {
+    "@key": "conf/ismir/BellBGB05",
+    "@mdate": "2017-12-04",
+    "author": [
+      "Tim Bell",
+      "David Blizzard",
+      "Richard D. Green",
+      "David Bainbridge 0001"
+    ],
+    "title": "Design of a Digital Music Stand.",
+    "pages": "430-433",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/3043.pdf",
+    "url": "db/conf/ismir/ismir2005.html#BellBGB05"
+  },
+  "conf/ismir/BrayT05": {
+    "@key": "conf/ismir/BrayT05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Stuart Bray",
+      "George Tzanetakis"
+    ],
+    "title": "Distributed Audio Feature Extraction for Music.",
+    "pages": "434-437",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2125.pdf",
+    "url": "db/conf/ismir/ismir2005.html#BrayT05"
+  },
+  "conf/ismir/BurgoyneS05": {
+    "@key": "conf/ismir/BurgoyneS05",
+    "@mdate": "2011-12-07",
+    "author": [
+      "John Ashley Burgoyne",
+      "Lawrence K. Saul"
+    ],
+    "title": "Learning Harmonic Relationships in Digital Audio with Dirichlet-Based Hidden Markov Models.",
+    "pages": "438-443",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1093.pdf",
+    "url": "db/conf/ismir/ismir2005.html#BurgoyneS05"
+  },
+  "conf/ismir/CabralPB05": {
+    "@key": "conf/ismir/CabralPB05",
+    "@mdate": "2006-10-18",
+    "author": [
+      "Giordano Ribeiro de Eulalio Cabral",
+      "Fran\u00e7ois Pachet",
+      "Jean-Pierre Briot"
+    ],
+    "title": "Automatic X Traditional Descriptor Extraction: the Case of Chord Recognition.",
+    "pages": "444-449",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1087.pdf",
+    "url": "db/conf/ismir/ismir2005.html#CabralPB05"
+  },
+  "conf/ismir/CahillM05": {
+    "@key": "conf/ismir/CahillM05",
+    "@mdate": "2014-10-27",
+    "author": [
+      "Margaret Cahill",
+      "Donncha \u00d3 Maid\u00edn"
+    ],
+    "title": "Melodic Similarity Algorithms -- Using Similarity Ratings for Development and Early Evaluation.",
+    "pages": "450-453",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2075.pdf",
+    "url": "db/conf/ismir/ismir2005.html#CahillM05"
+  },
+  "conf/ismir/CantoneCF05": {
+    "@key": "conf/ismir/CantoneCF05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Domenico Cantone",
+      "Salvatore Cristofaro",
+      "Simone Faro"
+    ],
+    "title": "On Tuning the (\\delta, \\alpha)-Sequential-Sampling Algorithm for \\delta-Approximate Matching with Alpha-Bounded Gaps in Musical Sequences.",
+    "pages": "454-459",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1036.pdf",
+    "url": "db/conf/ismir/ismir2005.html#CantoneCF05"
+  },
+  "conf/ismir/CantoneCF05a": {
+    "@key": "conf/ismir/CantoneCF05a",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Domenico Cantone",
+      "Salvatore Cristofaro",
+      "Simone Faro"
+    ],
+    "title": "Solving the (\\delta, \\alpha)-Approximate Matching Problem Under Transposition Invariance in Musical Sequences.",
+    "pages": "460-463",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2070.pdf",
+    "url": "db/conf/ismir/ismir2005.html#CantoneCF05a"
+  },
+  "conf/ismir/CelmaRH05": {
+    "@key": "conf/ismir/CelmaRH05",
+    "@mdate": "2008-07-02",
+    "author": [
+      "\u00d2scar Celma",
+      "Miquel Ram\u00edrez",
+      "Perfecto Herrera"
+    ],
+    "title": "Foafing the Music: A Music Recommendation System based on RSS Feeds and User Preferences.",
+    "pages": "464-467",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/3119.pdf",
+    "url": "db/conf/ismir/ismir2005.html#CelmaRH05"
+  },
+  "conf/ismir/ChaiV05": {
+    "@key": "conf/ismir/ChaiV05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Wei Chai",
+      "Barry Vercoe"
+    ],
+    "title": "Detection of Key Change in Classical Piano Music.",
+    "pages": "468-473",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1041.pdf",
+    "url": "db/conf/ismir/ismir2005.html#ChaiV05"
+  },
+  "conf/ismir/CunninghamDB05": {
+    "@key": "conf/ismir/CunninghamDB05",
+    "@mdate": "2017-12-03",
+    "author": [
+      "Sally Jo Cunningham",
+      "J. Stephen Downie",
+      "David Bainbridge 0001"
+    ],
+    "title": "\"The Pain, the Pain\": Modelling Music Information Behavior and the Songs We Hate.",
+    "pages": "474-477",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2124.pdf",
+    "url": "db/conf/ismir/ismir2005.html#CunninghamDB05"
+  },
+  "conf/ismir/DalitzK05": {
+    "@key": "conf/ismir/DalitzK05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Christophe Dalitz",
+      "Thomas Karsten"
+    ],
+    "title": "Using the Gamera Framework for Building a Lute Tablature Recognition System.",
+    "pages": "478-481",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2012.pdf",
+    "url": "db/conf/ismir/ismir2005.html#DalitzK05"
+  },
+  "conf/ismir/DegroeveTBLM05": {
+    "@key": "conf/ismir/DegroeveTBLM05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Sven Degroeve",
+      "Koen Tanghe",
+      "Bernard De Baets",
+      "Marc Leman",
+      "Jean-Pierre Martens"
+    ],
+    "title": "A Simulated Annealing Optimization of Audio Features for Drum Classification.",
+    "pages": "482-487",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1055.pdf",
+    "url": "db/conf/ismir/ismir2005.html#DegroeveTBLM05"
+  },
+  "conf/ismir/DhanarajL05": {
+    "@key": "conf/ismir/DhanarajL05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Ruth Dhanaraj",
+      "Beth Logan"
+    ],
+    "title": "Automatic Prediction of Hit Songs.",
+    "pages": "488-491",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2024.pdf",
+    "url": "db/conf/ismir/ismir2005.html#DhanarajL05"
+  },
+  "conf/ismir/DixonW05": {
+    "@key": "conf/ismir/DixonW05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Simon Dixon",
+      "Gerhard Widmer"
+    ],
+    "title": "MATCH: A Music Alignment Tool Chest.",
+    "pages": "492-497",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1002.pdf",
+    "url": "db/conf/ismir/ismir2005.html#DixonW05"
+  },
+  "conf/ismir/DoetsL05": {
+    "@key": "conf/ismir/DoetsL05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Peter Jan O. Doets",
+      "Reginald L. Lagendijk"
+    ],
+    "title": "Extracting Quality Parameters for Compressed Audio from Fingerprints.",
+    "pages": "498-503",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1063.pdf",
+    "url": "db/conf/ismir/ismir2005.html#DoetsL05"
+  },
+  "conf/ismir/EckC05": {
+    "@key": "conf/ismir/EckC05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Douglas Eck",
+      "Norman Casagrande"
+    ],
+    "title": "Finding Meter in Music Using An Autocorrelation Phase Matrix and Shannon Entropy.",
+    "pages": "504-509",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1105.pdf",
+    "url": "db/conf/ismir/ismir2005.html#EckC05"
+  },
+  "conf/ismir/FiebrinkMF05": {
+    "@key": "conf/ismir/FiebrinkMF05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Rebecca Fiebrink",
+      "Cory McKay",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Combining D2K and JGAP for Efficient Feature Weighting for Classification Tasks in Music Information Retrieval.",
+    "pages": "510-513",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2121.pdf",
+    "url": "db/conf/ismir/ismir2005.html#FiebrinkMF05"
+  },
+  "conf/ismir/Gerhard05": {
+    "@key": "conf/ismir/Gerhard05",
+    "@mdate": "2006-02-24",
+    "author": "David Gerhard",
+    "title": "Pitch Track Target Deviation in Natural Singing.",
+    "pages": "514-519",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1113.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Gerhard05"
+  },
+  "conf/ismir/GulikV05": {
+    "@key": "conf/ismir/GulikV05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Rob van Gulik",
+      "Fabio Vignoli"
+    ],
+    "title": "Visual Playlist Generation on the Artist Map.",
+    "pages": "520-523",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2011.pdf",
+    "url": "db/conf/ismir/ismir2005.html#GulikV05"
+  },
+  "conf/ismir/HeydarianR05": {
+    "@key": "conf/ismir/HeydarianR05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Peyman Heydarian",
+      "Joshua D. Reiss"
+    ],
+    "title": "The Persian Music and the Santur Instrument.",
+    "pages": "524-527",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2120.pdf",
+    "url": "db/conf/ismir/ismir2005.html#HeydarianR05"
+  },
+  "conf/ismir/HomburgMMMW05": {
+    "@key": "conf/ismir/HomburgMMMW05",
+    "@mdate": "2006-10-23",
+    "author": [
+      "Helge Homburg",
+      "Ingo Mierswa",
+      "B\u00fclent M\u00f6ller",
+      "Katharina Morik",
+      "Michael Wurst"
+    ],
+    "title": "A Benchmark Dataset for Audio Classification and Clustering.",
+    "pages": "528-531",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2117.pdf",
+    "url": "db/conf/ismir/ismir2005.html#HomburgMMMW05"
+  },
+  "conf/ismir/HosoyaSIM05": {
+    "@key": "conf/ismir/HosoyaSIM05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Toru Hosoya",
+      "Motoyuki Suzuki",
+      "Akinori Ito",
+      "Shozo Makino"
+    ],
+    "title": "Lyrics Recognition from a Singing Voice Based on Finite State Automaton for Music Information Retrieval.",
+    "pages": "532-535",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2068.pdf",
+    "url": "db/conf/ismir/ismir2005.html#HosoyaSIM05"
+  },
+  "conf/ismir/HuDWE05": {
+    "@key": "conf/ismir/HuDWE05",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "J. Stephen Downie",
+      "Kris West",
+      "Andreas F. Ehmann"
+    ],
+    "title": "Mining Music Reviews: Promising Preliminary Results.",
+    "pages": "536-539",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2066.pdf",
+    "url": "db/conf/ismir/ismir2005.html#HuDWE05"
+  },
+  "conf/ismir/Izmirli05": {
+    "@key": "conf/ismir/Izmirli05",
+    "@mdate": "2007-01-05",
+    "author": "\u00d6zg\u00fcr Izmirli",
+    "title": "Tonal Similarity from Audio Using a Template Based Attractor Model.",
+    "pages": "540-545",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1110.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Izmirli05"
+  },
+  "conf/ismir/JangHL05": {
+    "@key": "conf/ismir/JangHL05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Jyh-Shing Roger Jang",
+      "Chao-Ling Hsu",
+      "Hong-Ru Lee"
+    ],
+    "title": "Continuous HMM and Its Enhancement for Singing/Humming Query Retrieval.",
+    "pages": "546-551",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1064.pdf",
+    "url": "db/conf/ismir/ismir2005.html#JangHL05"
+  },
+  "conf/ismir/KirlinU05": {
+    "@key": "conf/ismir/KirlinU05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Phillip B. Kirlin",
+      "Paul E. Utgoff"
+    ],
+    "title": "VOISE: Learning to Segregate Voices in Explicit and Implicit Polyphony.",
+    "pages": "552-557",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1097.pdf",
+    "url": "db/conf/ismir/ismir2005.html#KirlinU05"
+  },
+  "conf/ismir/KitaharaGKOO05": {
+    "@key": "conf/ismir/KitaharaGKOO05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Tetsuro Kitahara",
+      "Masataka Goto",
+      "Kazunori Komatani",
+      "Tetsuya Ogata",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Instrument Identification in Polyphonic Music: Feature Weighting with Mixed Sounds, Pitch-Dependent Timbre Modeling, and Use of Musical Context.",
+    "pages": "558-563",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1098.pdf",
+    "url": "db/conf/ismir/ismir2005.html#KitaharaGKOO05"
+  },
+  "conf/ismir/KneesSW05": {
+    "@key": "conf/ismir/KneesSW05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Peter Knees",
+      "Markus Schedl",
+      "Gerhard Widmer"
+    ],
+    "title": "Multiple Lyrics Alignment: Automatic Retrieval of Song Lyrics.",
+    "pages": "564-569",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1059.pdf",
+    "url": "db/conf/ismir/ismir2005.html#KneesSW05"
+  },
+  "conf/ismir/LaiLF05": {
+    "@key": "conf/ismir/LaiLF05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Catherine Lai",
+      "Beinan Li",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Preservation Digitization of David Edelberg's Handel LP Collection: A Pilot Project.",
+    "pages": "570-575",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1090.pdf",
+    "url": "db/conf/ismir/ismir2005.html#LaiLF05"
+  },
+  "conf/ismir/LampropoulosLT05": {
+    "@key": "conf/ismir/LampropoulosLT05",
+    "@mdate": "2006-03-10",
+    "author": [
+      "Aristomenis S. Lampropoulos",
+      "Paraskevi S. Lampropoulou",
+      "George A. Tsihrintzis"
+    ],
+    "title": "Musical Genre Classification Enhanced by Improved Source Separation Technique.",
+    "pages": "576-581",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1079.pdf",
+    "url": "db/conf/ismir/ismir2005.html#LampropoulosLT05"
+  },
+  "conf/ismir/LiangZX05": {
+    "@key": "conf/ismir/LiangZX05",
+    "@mdate": "2018-03-20",
+    "author": [
+      "Wei Liang",
+      "Shuwu Zhang",
+      "Bo Xu 0002"
+    ],
+    "title": "A Hierarchical Approach for Audio Stream Segmentation and Classification.",
+    "pages": "582-585",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2073.pdf",
+    "url": "db/conf/ismir/ismir2005.html#LiangZX05"
+  },
+  "conf/ismir/LiangZX05a": {
+    "@key": "conf/ismir/LiangZX05a",
+    "@mdate": "2018-03-20",
+    "author": [
+      "Wei Liang",
+      "Shuwu Zhang",
+      "Bo Xu 0002"
+    ],
+    "title": "A Histogram Algorithm for Fast Audio Retrieval.",
+    "pages": "586-589",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2069.pdf",
+    "url": "db/conf/ismir/ismir2005.html#LiangZX05a"
+  },
+  "conf/ismir/Lubbers05": {
+    "@key": "conf/ismir/Lubbers05",
+    "@mdate": "2006-02-24",
+    "author": "Dominik L\u00fcbbers",
+    "title": "SoniXplorer: Combining Visualization and Auralization for Content-Based Exploration of Music Collections.",
+    "pages": "590-593",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2071.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Lubbers05"
+  },
+  "conf/ismir/MandelE05": {
+    "@key": "conf/ismir/MandelE05",
+    "@mdate": "2009-09-17",
+    "author": [
+      "Michael I. Mandel",
+      "Dan Ellis"
+    ],
+    "title": "Song-Level Features and Support Vector Machines for Music Classification.",
+    "pages": "594-599",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1106.pdf",
+    "url": "db/conf/ismir/ismir2005.html#MandelE05"
+  },
+  "conf/ismir/McEnnisMFD05": {
+    "@key": "conf/ismir/McEnnisMFD05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Daniel McEnnis",
+      "Cory McKay",
+      "Ichiro Fujinaga",
+      "Philippe Depalle"
+    ],
+    "title": "jAudio: An Feature Extraction Library.",
+    "pages": "600-603",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2103.pdf",
+    "url": "db/conf/ismir/ismir2005.html#McEnnisMFD05"
+  },
+  "conf/ismir/MengS05": {
+    "@key": "conf/ismir/MengS05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Anders Meng",
+      "John Shawe-Taylor"
+    ],
+    "title": "An Investigation of Feature Models for Music Genre Classification Using the Support Vector Classifier.",
+    "pages": "604-609",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1048.pdf",
+    "url": "db/conf/ismir/ismir2005.html#MengS05"
+  },
+  "conf/ismir/MesarosA05": {
+    "@key": "conf/ismir/MesarosA05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Annamaria Mesaros",
+      "Jaakko Astola"
+    ],
+    "title": "The Mel-Frequency Cepstral Coefficients in the Context of Singer Identification.",
+    "pages": "610-613",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1050.pdf",
+    "url": "db/conf/ismir/ismir2005.html#MesarosA05"
+  },
+  "conf/ismir/Munoz-ExpositoGRVR05": {
+    "@key": "conf/ismir/Munoz-ExpositoGRVR05",
+    "@mdate": "2016-02-09",
+    "author": [
+      "J. Enrique Mu\u00f1oz Exp\u00f3sito",
+      "Sebastian Garc\u00eda Gal\u00e1n",
+      "Nicol\u00e1s Ruiz-Reyes",
+      "Pedro Vera-Candeas",
+      "F. Rivas-Pe\u00f1a"
+    ],
+    "title": "Speech/Music Discrimination Using a Single Warped LPC-Based Feature.",
+    "pages": "614-617",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2027.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Munoz-ExpositoGRVR05"
+  },
+  "conf/ismir/NeumayerDR05": {
+    "@key": "conf/ismir/NeumayerDR05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Robert Neumayer",
+      "Michael Dittenbach",
+      "Andreas Rauber"
+    ],
+    "title": "PlaySOM and PocketSOMPlayer, Alternative Interfaces to Large Music Collections.",
+    "pages": "618-623",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1096.pdf",
+    "url": "db/conf/ismir/ismir2005.html#NeumayerDR05"
+  },
+  "conf/ismir/NeveO05": {
+    "@key": "conf/ismir/NeveO05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Giovanna Neve",
+      "Nicola Orio"
+    ],
+    "title": "Experiments on Segmentation Techniques for Music Documents Indexing.",
+    "pages": "624-627",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2122.pdf",
+    "url": "db/conf/ismir/ismir2005.html#NeveO05"
+  },
+  "conf/ismir/PampalkFW05": {
+    "@key": "conf/ismir/PampalkFW05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Elias Pampalk",
+      "Arthur Flexer",
+      "Gerhard Widmer"
+    ],
+    "title": "Improvements of Audio-Based Music Similarity and Genre Classificaton.",
+    "pages": "628-633",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1053.pdf",
+    "url": "db/conf/ismir/ismir2005.html#PampalkFW05"
+  },
+  "conf/ismir/PampalkPW05": {
+    "@key": "conf/ismir/PampalkPW05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Elias Pampalk",
+      "Tim Pohle",
+      "Gerhard Widmer"
+    ],
+    "title": "Dynamic Playlist Generation Based on Skipping Behavior.",
+    "pages": "634-637",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2072.pdf",
+    "url": "db/conf/ismir/ismir2005.html#PampalkPW05"
+  },
+  "conf/ismir/PauwsW05": {
+    "@key": "conf/ismir/PauwsW05",
+    "@mdate": "2006-09-28",
+    "author": [
+      "Steffen Pauws",
+      "Sander van de Wijdeven"
+    ],
+    "title": "User Evaluation of a New Interactive Playlist Generation Concept.",
+    "pages": "638-643",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1029.pdf",
+    "url": "db/conf/ismir/ismir2005.html#PauwsW05"
+  },
+  "conf/ismir/Peeters05": {
+    "@key": "conf/ismir/Peeters05",
+    "@mdate": "2006-02-24",
+    "author": "Geoffroy Peeters",
+    "title": "Rhythm Classification Using Spectral Rhythm Patterns.",
+    "pages": "644-647",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2076.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Peeters05"
+  },
+  "conf/ismir/Pickens05": {
+    "@key": "conf/ismir/Pickens05",
+    "@mdate": "2006-02-24",
+    "author": "Jeremy Pickens",
+    "title": "Classifier Combination for Capturing Musical Variation.",
+    "pages": "648-651",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2010.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Pickens05"
+  },
+  "conf/ismir/PikrakisT05": {
+    "@key": "conf/ismir/PikrakisT05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Aggelos Pikrakis",
+      "Sergios Theodoridis"
+    ],
+    "title": "A Novel HMM Approach to Melody Spotting in Raw Audio Recordings.",
+    "pages": "652-657",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1044.pdf",
+    "url": "db/conf/ismir/ismir2005.html#PikrakisT05"
+  },
+  "conf/ismir/Raphael05": {
+    "@key": "conf/ismir/Raphael05",
+    "@mdate": "2009-03-19",
+    "author": "Christopher Raphael",
+    "title": "A Graphical Model for Recognizing Sung Melodies.",
+    "pages": "658-663",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1127.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Raphael05"
+  },
+  "conf/ismir/Sapp05": {
+    "@key": "conf/ismir/Sapp05",
+    "@mdate": "2006-02-24",
+    "author": "Craig Stuart Sapp",
+    "title": "Online Database of Scores in the Humdrum File Format.",
+    "pages": "664-665",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/3123.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Sapp05"
+  },
+  "conf/ismir/ScaringellaZ05": {
+    "@key": "conf/ismir/ScaringellaZ05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Nicolas Scaringella",
+      "Giorgio Zoia"
+    ],
+    "title": "On the Modeling of Time Information for Automatic Genre Recognition Systems in Audio Signals.",
+    "pages": "666-671",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1060.pdf",
+    "url": "db/conf/ismir/ismir2005.html#ScaringellaZ05"
+  },
+  "conf/ismir/SinyorMFMF05": {
+    "@key": "conf/ismir/SinyorMFMF05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Elliot Sinyor",
+      "Cory McKay",
+      "Rebecca Fiebrink",
+      "Daniel McEnnis",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Beatbox Classification Using ACE.",
+    "pages": "672-675",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2126.pdf",
+    "url": "db/conf/ismir/ismir2005.html#SinyorMFMF05"
+  },
+  "conf/ismir/Walser05": {
+    "@key": "conf/ismir/Walser05",
+    "@mdate": "2006-02-24",
+    "author": "Robert Young Walser",
+    "title": "Herding Folksongs.",
+    "pages": "676-679",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2138.pdf",
+    "url": "db/conf/ismir/ismir2005.html#Walser05"
+  },
+  "conf/ismir/WestC05": {
+    "@key": "conf/ismir/WestC05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Kris West",
+      "Stephen Cox"
+    ],
+    "title": "Finding An Optimal Segmentation for Audio Genre Classification.",
+    "pages": "680-685",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1003.pdf",
+    "url": "db/conf/ismir/ismir2005.html#WestC05"
+  },
+  "conf/ismir/WeydeD05": {
+    "@key": "conf/ismir/WeydeD05",
+    "@mdate": "2006-02-24",
+    "author": [
+      "Tillman Weyde",
+      "Christian Datzko"
+    ],
+    "title": "Efficient Melody Retrieval with Motif Contour Classes.",
+    "pages": "686-689",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/2118.pdf",
+    "url": "db/conf/ismir/ismir2005.html#WeydeD05"
+  },
+  "conf/ismir/XueS05": {
+    "@key": "conf/ismir/XueS05",
+    "@mdate": "2016-03-12",
+    "author": [
+      "Wen Xue",
+      "Mark Sandler"
+    ],
+    "title": "A Partial Searching Algorithm and Its Application for Polyphonic Music Transcription.",
+    "pages": "690-695",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1077.pdf",
+    "url": "db/conf/ismir/ismir2005.html#XueS05"
+  },
+  "conf/ismir/YuWJ05": {
+    "@key": "conf/ismir/YuWJ05",
+    "@mdate": "2018-07-06",
+    "author": [
+      "Yi Yu 0001",
+      "Chiemi Watanabe",
+      "Kazuki Joe"
+    ],
+    "title": "Towards a Fast and Efficient Match Algorithm for Content-Based Music Retrieval on Acoustic Data.",
+    "pages": "696-701",
+    "year": "2005",
+    "crossref": "conf/ismir/2005",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2005.ismir.net/proceedings/1035.pdf",
+    "url": "db/conf/ismir/ismir2005.html#YuWJ05"
+  },
+  "conf/ismir/LaiF06": {
+    "@key": "conf/ismir/LaiF06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Catherine Lai",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Data Dictionary: Metadata for Phonograph Records.",
+    "pages": "1-6",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#LaiF06"
+  },
+  "conf/ismir/McEnnisMF06": {
+    "@key": "conf/ismir/McEnnisMF06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Daniel McEnnis",
+      "Cory McKay",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Overview of OMEN.",
+    "pages": "7-12",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#McEnnisMF06"
+  },
+  "conf/ismir/RileyM06": {
+    "@key": "conf/ismir/RileyM06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Jenn Riley",
+      "Constance A. Mayer"
+    ],
+    "title": "Ask a Librarian: The Role of Librarians in the Music Information Retrieval Community.",
+    "pages": "13-18",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#RileyM06"
+  },
+  "conf/ismir/HuDE06": {
+    "@key": "conf/ismir/HuDE06",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "J. Stephen Downie",
+      "Andreas F. Ehmann"
+    ],
+    "title": "Exploiting Recommended Usage Metadata: Exploratory Analyses.",
+    "pages": "19-22",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#HuDE06"
+  },
+  "conf/ismir/SeppanenEH06": {
+    "@key": "conf/ismir/SeppanenEH06",
+    "@mdate": "2008-04-03",
+    "author": [
+      "Jarno Sepp\u00e4nen",
+      "Antti J. Eronen",
+      "Jarmo Hiipakka"
+    ],
+    "title": "Joint Beat & Tatum Tracking from Music Signals.",
+    "pages": "23-28",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#SeppanenEH06"
+  },
+  "conf/ismir/WhiteleyCG06": {
+    "@key": "conf/ismir/WhiteleyCG06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Nick Whiteley",
+      "Ali Taylan Cemgil",
+      "Simon J. Godsill"
+    ],
+    "title": "Bayesian Modelling of Temporal Structure in Musical Audio.",
+    "pages": "29-34",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#WhiteleyCG06"
+  },
+  "conf/ismir/KurthGM06": {
+    "@key": "conf/ismir/KurthGM06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Frank Kurth",
+      "Thorsten Gehrmann",
+      "Meinard M\u00fcller"
+    ],
+    "title": "The Cyclic Beat Spectrum: Tempo-Related Audio Features for Time-Scale Invariant Audio Identification.",
+    "pages": "35-40",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#KurthGM06"
+  },
+  "conf/ismir/ByrdS06": {
+    "@key": "conf/ismir/ByrdS06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Donald Byrd",
+      "Megan Schindele"
+    ],
+    "title": "Prospects for Improving OMR with Multiple Recognizers.",
+    "pages": "41-46",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#ByrdS06"
+  },
+  "conf/ismir/BainbridgeB06": {
+    "@key": "conf/ismir/BainbridgeB06",
+    "@mdate": "2017-12-04",
+    "author": [
+      "David Bainbridge 0001",
+      "Tim Bell"
+    ],
+    "title": "Identifying music documents in a collection of images.",
+    "pages": "47-52",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#BainbridgeB06"
+  },
+  "conf/ismir/Pugin06": {
+    "@key": "conf/ismir/Pugin06",
+    "@mdate": "2007-01-05",
+    "author": "Laurent Pugin",
+    "title": "Optical Music Recognitoin of Early Typographic Prints using Hidden Markov Models.",
+    "pages": "53-56",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Pugin06"
+  },
+  "conf/ismir/MadsenW06": {
+    "@key": "conf/ismir/MadsenW06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "S\u00f8ren Tjagvad Madsen",
+      "Gerhard Widmer"
+    ],
+    "title": "Separating voices in MIDI.",
+    "pages": "57-60",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#MadsenW06"
+  },
+  "conf/ismir/RizoLPPI06": {
+    "@key": "conf/ismir/RizoLPPI06",
+    "@mdate": "2008-12-02",
+    "author": [
+      "David Rizo",
+      "Pedro J. Ponce de Le\u00f3n",
+      "Carlos P\u00e9rez-Sancho",
+      "Antonio Pertusa",
+      "Jos\u00e9 Manuel I\u00f1esta Quereda"
+    ],
+    "title": "A Pattern Recognition Approach for Melody Track Selection in MIDI Files.",
+    "pages": "61-66",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#RizoLPPI06"
+  },
+  "conf/ismir/HazanGR06": {
+    "@key": "conf/ismir/HazanGR06",
+    "@mdate": "2018-08-19",
+    "author": [
+      "Amaury Hazan",
+      "Maarten Grachten",
+      "Rafael Ram\u00edrez 0001"
+    ],
+    "title": "Evolving Performance Models by Performance Similarity: Beyond Note-to-note Transformations.",
+    "pages": "67-72",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#HazanGR06"
+  },
+  "conf/ismir/Winget06": {
+    "@key": "conf/ismir/Winget06",
+    "@mdate": "2009-12-28",
+    "author": "Megan A. Winget",
+    "title": "Heroic Frogs Save the Bow: Performing Musician's Annotation and Interaction Behavior with Written Music.",
+    "pages": "73-78",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Winget06"
+  },
+  "conf/ismir/RobineL06": {
+    "@key": "conf/ismir/RobineL06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Matthias Robine",
+      "Mathieu Lagrange"
+    ],
+    "title": "Evaluation of the Technical Leval of Saxophone Performers by Considering the Evolution of Spectral Parameters of the Sound.",
+    "pages": "79-84",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#RobineL06"
+  },
+  "conf/ismir/BergstraLE06": {
+    "@key": "conf/ismir/BergstraLE06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "James Bergstra",
+      "Alexandre Lacoste",
+      "Douglas Eck"
+    ],
+    "title": "Predicting genre labels for artist using FreeDB.",
+    "pages": "85-88",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#BergstraLE06"
+  },
+  "conf/ismir/ReedL06": {
+    "@key": "conf/ismir/ReedL06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Jeremy Reed",
+      "Chin-Hui Lee"
+    ],
+    "title": "A Study on Music Genre Classification Based on Universal Acoustic Models.",
+    "pages": "89-94",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#ReedL06"
+  },
+  "conf/ismir/LivshinR06": {
+    "@key": "conf/ismir/LivshinR06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Arie Livshin",
+      "Xavier Rodet"
+    ],
+    "title": "The Significance of the Non-Harmonic \"Noise\" Versis the Harmonic Series for Musical Instrument Recognition.",
+    "pages": "95-100",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#LivshinR06"
+  },
+  "conf/ismir/McKayF06": {
+    "@key": "conf/ismir/McKayF06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Cory McKay",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Musical genre classification: Is it worth pursuing and how can it be improved?",
+    "pages": "101-106",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#McKayF06"
+  },
+  "conf/ismir/PikrakisGT06": {
+    "@key": "conf/ismir/PikrakisGT06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Aggelos Pikrakis",
+      "Theodoros Giannakopoulos",
+      "Sergios Theodoridis"
+    ],
+    "title": "A computationally efficient speech/music discriminator for radio recordings.",
+    "pages": "107-110",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#PikrakisGT06"
+  },
+  "conf/ismir/FlexerGDW06": {
+    "@key": "conf/ismir/FlexerGDW06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Arthur Flexer",
+      "Fabien Gouyon",
+      "Simon Dixon",
+      "Gerhard Widmer"
+    ],
+    "title": "Probabilistic Combination of Features for Music Classification.",
+    "pages": "111-114",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#FlexerGDW06"
+  },
+  "conf/ismir/Peeters06": {
+    "@key": "conf/ismir/Peeters06",
+    "@mdate": "2007-01-05",
+    "author": "Geoffroy Peeters",
+    "title": "Chroma-based estimation of musical key from audio-signal analysis.",
+    "pages": "115-120",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Peeters06"
+  },
+  "conf/ismir/NolandS06": {
+    "@key": "conf/ismir/NolandS06",
+    "@mdate": "2016-08-30",
+    "author": [
+      "Katy C. Noland",
+      "Mark B. Sandler"
+    ],
+    "title": "Key Estimation Using a Hidden Markov Model.",
+    "pages": "121-126",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#NolandS06"
+  },
+  "conf/ismir/Izmirli06": {
+    "@key": "conf/ismir/Izmirli06",
+    "@mdate": "2007-01-05",
+    "author": "\u00d6zg\u00fcr Izmirli",
+    "title": "Audio Key Finding Using Low-Dimensional Spaces.",
+    "pages": "127-132",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Izmirli06"
+  },
+  "conf/ismir/LeeS06": {
+    "@key": "conf/ismir/LeeS06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Kyogu Lee",
+      "Malcolm Slaney"
+    ],
+    "title": "Automatic Chord Recognition from Audio Using a HMM with Supervised Learning.",
+    "pages": "133-137",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#LeeS06"
+  },
+  "conf/ismir/PauwsVV06": {
+    "@key": "conf/ismir/PauwsVV06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Steffen Pauws",
+      "Wim Verhaegh",
+      "Mark Vossen"
+    ],
+    "title": "Fast Generation of Optimal Music Playlists using Local Search.",
+    "pages": "138-143",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#PauwsVV06"
+  },
+  "conf/ismir/CaseyS06": {
+    "@key": "conf/ismir/CaseyS06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Michael A. Casey",
+      "Malcolm Slaney"
+    ],
+    "title": "Song Intersection by Approximate Nearest Neighbor Search.",
+    "pages": "144-149",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#CaseyS06"
+  },
+  "conf/ismir/CliffordCCMW06": {
+    "@key": "conf/ismir/CliffordCCMW06",
+    "@mdate": "2016-09-26",
+    "author": [
+      "Rapha\u00ebl Clifford",
+      "Manolis Christodoulakis",
+      "Tim Crawford",
+      "David Meredith 0001",
+      "Geraint A. Wiggins"
+    ],
+    "title": "A Fast, Randomised, Maximal Subset Matching Algorithm for Document-Level Music Retrieval.",
+    "pages": "150-155",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#CliffordCCMW06"
+  },
+  "conf/ismir/GilletR06": {
+    "@key": "conf/ismir/GilletR06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Olivier Gillet",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "ENST-Drums: an extensive audio-visual database for drum signals processing.",
+    "pages": "156-159",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#GilletR06"
+  },
+  "conf/ismir/McKayMF06": {
+    "@key": "conf/ismir/McKayMF06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Cory McKay",
+      "Daniel McEnnis",
+      "Ichiro Fujinaga"
+    ],
+    "title": "A Large Publicly Accassible Prototype Audio Database for Music Research.",
+    "pages": "160-163",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#McKayMF06"
+  },
+  "conf/ismir/LoscosWB06": {
+    "@key": "conf/ismir/LoscosWB06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Alex Loscos",
+      "Ye Wang",
+      "Wei Jie Jonathan Boo"
+    ],
+    "title": "Low Level Descriptors for Automatic Violin Transcription.",
+    "pages": "164-167",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#LoscosWB06"
+  },
+  "conf/ismir/SuzukiHIM06": {
+    "@key": "conf/ismir/SuzukiHIM06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Motoyuki Suzuki",
+      "Toru Hosoya",
+      "Akinori Ito",
+      "Shozo Makino"
+    ],
+    "title": "Music Information Retrieval from a Singing Voice Based on Verification of Recognized Hypotheses.",
+    "pages": "168-171",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#SuzukiHIM06"
+  },
+  "conf/ismir/ItoyamaKKOO06": {
+    "@key": "conf/ismir/ItoyamaKKOO06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Katsutoshi Itoyama",
+      "Tetsuro Kitahara",
+      "Kazunori Komatani",
+      "Tetsuya Ogata",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Automatic Feature Weighting in Automatic Transcription of Specified Part in Polyphonic Music.",
+    "pages": "172-175",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#ItoyamaKKOO06"
+  },
+  "conf/ismir/LiW06": {
+    "@key": "conf/ismir/LiW06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Yipeng Li",
+      "DeLiang Wang"
+    ],
+    "title": "Singing Voice Separation from Monaural Recordings.",
+    "pages": "176-179",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#LiW06"
+  },
+  "conf/ismir/GomezH06": {
+    "@key": "conf/ismir/GomezH06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Emilia G\u00f3mez",
+      "Perfecto Herrera"
+    ],
+    "title": "The song remains the same: identifying versions of the same piece using tonal descriptors.",
+    "pages": "180-185",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#GomezH06"
+  },
+  "conf/ismir/LidyR06": {
+    "@key": "conf/ismir/LidyR06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Thomas Lidy",
+      "Andreas Rauber"
+    ],
+    "title": "Visually Profiling Radio Stations.",
+    "pages": "186-191",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#LidyR06"
+  },
+  "conf/ismir/MullerMK06": {
+    "@key": "conf/ismir/MullerMK06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Meinard M\u00fcller",
+      "Henning Mattes",
+      "Frank Kurth"
+    ],
+    "title": "An Efficient Multiscale Approach to Audio Synchronization.",
+    "pages": "192-197",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#MullerMK06"
+  },
+  "conf/ismir/BrudererMK06": {
+    "@key": "conf/ismir/BrudererMK06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Michael J. Bruderer",
+      "Martin F. McKinney",
+      "Armin Kohlrausch"
+    ],
+    "title": "Structural boundary perception in popular music.",
+    "pages": "198-201",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#BrudererMK06"
+  },
+  "conf/ismir/NicholsR06": {
+    "@key": "conf/ismir/NicholsR06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Eric Nichols",
+      "Christofer Raphael"
+    ],
+    "title": "Globally Optimal Audio Partitioning.",
+    "pages": "202-205",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#NicholsR06"
+  },
+  "conf/ismir/Cont06": {
+    "@key": "conf/ismir/Cont06",
+    "@mdate": "2012-05-12",
+    "author": "Arshia Cont",
+    "title": "Realtime Multiple Pitch Observation using Sparse Non-negative Constraints.",
+    "pages": "206-211",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Cont06"
+  },
+  "conf/ismir/Lerch06": {
+    "@key": "conf/ismir/Lerch06",
+    "@mdate": "2007-01-05",
+    "author": "Alexander Lerch",
+    "title": "On the Requirement of Automatic Tuning Frequency Estimation.",
+    "pages": "212-215",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Lerch06"
+  },
+  "conf/ismir/Klapuri06": {
+    "@key": "conf/ismir/Klapuri06",
+    "@mdate": "2007-01-05",
+    "author": "Anssi Klapuri",
+    "title": "Multiple Fundamental Frequency Estimation by Summing Harmonic Amplitudes.",
+    "pages": "216-221",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Klapuri06"
+  },
+  "conf/ismir/RyynanenK06": {
+    "@key": "conf/ismir/RyynanenK06",
+    "@mdate": "2009-02-21",
+    "author": [
+      "Matti Ryyn\u00e4nen",
+      "Anssi Klapuri"
+    ],
+    "title": "Transcription of the Singing Melody in Polyphonic Music.",
+    "pages": "222-227",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#RyynanenK06"
+  },
+  "conf/ismir/PohleKSW06": {
+    "@key": "conf/ismir/PohleKSW06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Tim Pohle",
+      "Peter Knees",
+      "Markus Schedl",
+      "Gerhard Widmer"
+    ],
+    "title": "Independent Component Analysis for Music Similarity Computation.",
+    "pages": "228-233",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#PohleKSW06"
+  },
+  "conf/ismir/MardirossianC06": {
+    "@key": "conf/ismir/MardirossianC06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Arpi Mardirossian",
+      "Elaine Chew"
+    ],
+    "title": "Music Summarization Via Key Distributions: Analyses of Similarity Assessment Across Variations.",
+    "pages": "234-239",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#MardirossianC06"
+  },
+  "conf/ismir/CunninghamBF06": {
+    "@key": "conf/ismir/CunninghamBF06",
+    "@mdate": "2017-12-03",
+    "author": [
+      "Sally Jo Cunningham",
+      "David Bainbridge 0001",
+      "Annette Falconer"
+    ],
+    "title": "'More of an Art than a Science': Supporting the Creation of Playlists and Mixes.",
+    "pages": "240-245",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#CunninghamBF06"
+  },
+  "conf/ismir/NovelloMK06": {
+    "@key": "conf/ismir/NovelloMK06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Alberto Novello",
+      "Martin F. McKinney",
+      "Armin Kohlrausch"
+    ],
+    "title": "Perceptual evaluation of music similarity.",
+    "pages": "246-249",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#NovelloMK06"
+  },
+  "conf/ismir/OliverK06": {
+    "@key": "conf/ismir/OliverK06",
+    "@mdate": "2009-03-20",
+    "author": [
+      "Nuria Oliver",
+      "Lucas Kreger-Stickles"
+    ],
+    "title": "PAPA: Physiology and Purpose-Aware Automatic Playlist Generation.",
+    "pages": "250-253",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#OliverK06"
+  },
+  "conf/ismir/TurnbullBL06": {
+    "@key": "conf/ismir/TurnbullBL06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Douglas Turnbull",
+      "Luke Barrington",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Modeling music and words using a multi-class na\u00efve Bayes approach.",
+    "pages": "254-259",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#TurnbullBL06"
+  },
+  "conf/ismir/SchedlPKW06": {
+    "@key": "conf/ismir/SchedlPKW06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Markus Schedl",
+      "Tim Pohle",
+      "Peter Knees",
+      "Gerhard Widmer"
+    ],
+    "title": "Assigning and Visualizing Music Genres by Web-based Co-Occurrence Analysis.",
+    "pages": "260-265",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#SchedlPKW06"
+  },
+  "conf/ismir/GeleijnseK06": {
+    "@key": "conf/ismir/GeleijnseK06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Gijs Geleijnse",
+      "Jan H. M. Korst"
+    ],
+    "title": "Web-Based Artist Categorization.",
+    "pages": "266-271",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#GeleijnseK06"
+  },
+  "conf/ismir/Selfridge-Field06": {
+    "@key": "conf/ismir/Selfridge-Field06",
+    "@mdate": "2007-01-05",
+    "author": "Eleanor Selfridge-Field",
+    "title": "Social Cognition and Melodic Persistence: Where Metadata and Content Diverge.",
+    "pages": "272-275",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Selfridge-Field06"
+  },
+  "conf/ismir/Temperley06": {
+    "@key": "conf/ismir/Temperley06",
+    "@mdate": "2007-01-05",
+    "author": "David Temperley",
+    "title": "A Probabilistic Model of Melody Perception.",
+    "pages": "276-279",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Temperley06"
+  },
+  "conf/ismir/Marolt06": {
+    "@key": "conf/ismir/Marolt06",
+    "@mdate": "2007-01-05",
+    "author": "Matija Marolt",
+    "title": "A Mid-level Melody-based Representation for Calculating Audio Similarity.",
+    "pages": "280-285",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Marolt06"
+  },
+  "conf/ismir/SigurdssonPL06": {
+    "@key": "conf/ismir/SigurdssonPL06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Sigurdur Sigurdsson",
+      "Kaare Brandt Petersen",
+      "Tue Lehn-Schi\u00f8ler"
+    ],
+    "title": "Mel Frequency Cepstral Coefficients: An Evaluation of Robustness of MP3 Encoded Music.",
+    "pages": "286-289",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#SigurdssonPL06"
+  },
+  "conf/ismir/Arenas-GarciaLHM06": {
+    "@key": "conf/ismir/Arenas-GarciaLHM06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Jer\u00f3nimo Arenas-Garc\u00eda",
+      "Jan Larsen",
+      "Lars Kai Hansen",
+      "Anders Meng"
+    ],
+    "title": "Optimal filtering of dynamics in short-time features for music organization.",
+    "pages": "290-295",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Arenas-GarciaLHM06"
+  },
+  "conf/ismir/YoshiiGKOO06": {
+    "@key": "conf/ismir/YoshiiGKOO06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Kazuyoshi Yoshii",
+      "Masataka Goto",
+      "Kazunori Komatani",
+      "Tetsuya Ogata",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Hybrid Collaborative and Content-based Music Recommendation Using Probabilistic Model with Latent User Preferences.",
+    "pages": "296-301",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#YoshiiGKOO06"
+  },
+  "conf/ismir/Hamanaka06": {
+    "@key": "conf/ismir/Hamanaka06",
+    "@mdate": "2007-01-05",
+    "author": "Masatoshi Hamanaka",
+    "title": "Music Scope Headphones: Natural User Interface for Selection of Music.",
+    "pages": "302-307",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Hamanaka06"
+  },
+  "conf/ismir/CorthautGD06": {
+    "@key": "conf/ismir/CorthautGD06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Nik Corthaut",
+      "Sten Govaerts",
+      "Erik Duval"
+    ],
+    "title": "Moody Tunes: The Rockanango Project.",
+    "pages": "308-313",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#CorthautGD06"
+  },
+  "conf/ismir/WoodruffPD06": {
+    "@key": "conf/ismir/WoodruffPD06",
+    "@mdate": "2011-02-23",
+    "author": [
+      "John F. Woodruff",
+      "Bryan Pardo",
+      "Roger B. Dannenberg"
+    ],
+    "title": "Remixing Stereo Music with Score-Informed Source Separation.",
+    "pages": "314-319",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#WoodruffPD06"
+  },
+  "conf/ismir/Lehn-SchiolerAPH06": {
+    "@key": "conf/ismir/Lehn-SchiolerAPH06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Tue Lehn-Schi\u00f8ler",
+      "Jer\u00f3nimo Arenas-Garc\u00eda",
+      "Kaare Brandt Petersen",
+      "Lars Kai Hansen"
+    ],
+    "title": "A Genre Classification Plug-in for Data Collection.",
+    "pages": "320-321",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Lehn-SchiolerAPH06"
+  },
+  "conf/ismir/SandvoldACH06": {
+    "@key": "conf/ismir/SandvoldACH06",
+    "@mdate": "2008-07-02",
+    "author": [
+      "Vegard Sandvold",
+      "Thomas Aussenac",
+      "\u00d2scar Celma",
+      "Perfecto Herrera"
+    ],
+    "title": "Good Vibrations: Music Discovery through Personal Musical Concepts.",
+    "pages": "322-323",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#SandvoldACH06"
+  },
+  "conf/ismir/CannamLSB06": {
+    "@key": "conf/ismir/CannamLSB06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Chris Cannam",
+      "Christian Landone",
+      "Mark B. Sandler",
+      "Juan Pablo Bello"
+    ],
+    "title": "The Sonic Visualiser: A Visualisation Platform for Semantic Descriptors from Musical Signals.",
+    "pages": "324-327",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#CannamLSB06"
+  },
+  "conf/ismir/ParMR06": {
+    "@key": "conf/ismir/ParMR06",
+    "@mdate": "2007-06-29",
+    "author": [
+      "Steven van de Par",
+      "Martin F. McKinney",
+      "Andr\u00e9 Redert"
+    ],
+    "title": "Musical Key Extraction from Audio Using Profile Training.",
+    "pages": "328-329",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#ParMR06"
+  },
+  "conf/ismir/BosmaVW06": {
+    "@key": "conf/ismir/BosmaVW06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Martijn Bosma",
+      "Remco C. Veltkamp",
+      "Frans Wiering"
+    ],
+    "title": "Muugle: A Modular Music Information Retrieval Framework.",
+    "pages": "330-331",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#BosmaVW06"
+  },
+  "conf/ismir/Garbers06": {
+    "@key": "conf/ismir/Garbers06",
+    "@mdate": "2007-01-05",
+    "author": "J\u00f6rg Garbers",
+    "title": "An Integrated MIR Programming and Testing Environment.",
+    "pages": "332-333",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Garbers06"
+  },
+  "conf/ismir/MoelantsCLGCTMH06": {
+    "@key": "conf/ismir/MoelantsCLGCTMH06",
+    "@mdate": "2007-01-09",
+    "author": [
+      "Dirk Moelants",
+      "Olmo Cornelis",
+      "Marc Leman",
+      "Jos Gansemans",
+      "Rita M. M. De Caluwe",
+      "Guy De Tr\u00e9",
+      "Tom Matth\u00e9",
+      "Axel Hallez"
+    ],
+    "title": "Problems and Opportunities of Applying Data- & Audio-Mining Techniques to Ethnic Music.",
+    "pages": "334-336",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#MoelantsCLGCTMH06"
+  },
+  "conf/ismir/CastroAFCCB06": {
+    "@key": "conf/ismir/CastroAFCCB06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Beatriz Magalh\u00e3es Castro",
+      "Luiza Beth Nunes Alonso",
+      "Edilson Ferneda",
+      "Murilo Bastos da Cunha",
+      "Fernando William Cruz",
+      "M\u00e1rcio da Costa P. Brand\u00e3o"
+    ],
+    "title": "BDB-MUS: a project for the preservation of Brazilian musical heritage.",
+    "pages": "337-339",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#CastroAFCCB06"
+  },
+  "conf/ismir/FiebrinkF06": {
+    "@key": "conf/ismir/FiebrinkF06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Rebecca Fiebrink",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Feature Selection Pitfalls and Music Classification.",
+    "pages": "340-341",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#FiebrinkF06"
+  },
+  "conf/ismir/DoraisamyAN06": {
+    "@key": "conf/ismir/DoraisamyAN06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Shyamala Doraisamy",
+      "Hamdan Adnan",
+      "Noris Mohd. Norowi"
+    ],
+    "title": "Towards a MIR System for Malaysian Music.",
+    "pages": "342-343",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#DoraisamyAN06"
+  },
+  "conf/ismir/SeifertRR06": {
+    "@key": "conf/ismir/SeifertRR06",
+    "@mdate": "2015-01-05",
+    "author": [
+      "Frank Seifert 0001",
+      "Katharina Rasch",
+      "Michael Rentzsch"
+    ],
+    "title": "Tempo Induction by Stream-Based Evaluation of Musical Events.",
+    "pages": "344-345",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#SeifertRR06"
+  },
+  "conf/ismir/Jacobson06": {
+    "@key": "conf/ismir/Jacobson06",
+    "@mdate": "2007-01-05",
+    "author": "Kurt Jacobson",
+    "title": "A Multifaceted Approach to Music Similarity.",
+    "pages": "346-348",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Jacobson06"
+  },
+  "conf/ismir/EichnerWH06": {
+    "@key": "conf/ismir/EichnerWH06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Matthias Eichner",
+      "Matthias Wolff",
+      "R\u00fcdiger Hoffmann"
+    ],
+    "title": "Instrument classification using Hidden Markov Models.",
+    "pages": "349-350",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#EichnerWH06"
+  },
+  "conf/ismir/MayerLR06": {
+    "@key": "conf/ismir/MayerLR06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Rudolf Mayer",
+      "Thomas Lidy",
+      "Andreas Rauber"
+    ],
+    "title": "The Map of Mozart.",
+    "pages": "351-352",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#MayerLR06"
+  },
+  "conf/ismir/DehghaniL06": {
+    "@key": "conf/ismir/DehghaniL06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Morteza Dehghani",
+      "Andrew M. Lovett"
+    ],
+    "title": "Efficient Genre Classification using Qualitative Representations.",
+    "pages": "353-354",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#DehghaniL06"
+  },
+  "conf/ismir/CahillO06": {
+    "@key": "conf/ismir/CahillO06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Margaret Cahill",
+      "Donncha O'Maid\u00edn"
+    ],
+    "title": "Assessing the Performance of Melodic Similarity Algorithms Using Human Judgments of Similarity.",
+    "pages": "355-356",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#CahillO06"
+  },
+  "conf/ismir/LeueI06": {
+    "@key": "conf/ismir/LeueI06",
+    "@mdate": "2016-02-01",
+    "author": [
+      "Ian Leue",
+      "\u00d6zg\u00fcr Izmirli"
+    ],
+    "title": "Tempo Tracking With a Periodicity Comb Kernel.",
+    "pages": "357-358",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#LeueI06"
+  },
+  "conf/ismir/Goto06": {
+    "@key": "conf/ismir/Goto06",
+    "@mdate": "2007-01-05",
+    "author": "Masataka Goto",
+    "title": "AIST Annotation for the RWC Music Database.",
+    "pages": "359-360",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Goto06"
+  },
+  "conf/ismir/HoffmanC06": {
+    "@key": "conf/ismir/HoffmanC06",
+    "@mdate": "2010-09-06",
+    "author": [
+      "Matthew D. Hoffman",
+      "Perry R. Cook"
+    ],
+    "title": "Feature-Based Synthesis: A Tool for Evaluating, Designing, and Interacting with Music IR Systems.",
+    "pages": "361-362",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#HoffmanC06"
+  },
+  "conf/ismir/KapurS06": {
+    "@key": "conf/ismir/KapurS06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Ajay Kapur",
+      "Eric Singer"
+    ],
+    "title": "A Retrieval Approach for Human/Robotic Musical Performance.",
+    "pages": "363-364",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#KapurS06"
+  },
+  "conf/ismir/CelmaCH06": {
+    "@key": "conf/ismir/CelmaCH06",
+    "@mdate": "2008-07-02",
+    "author": [
+      "\u00d2scar Celma",
+      "Pedro Cano",
+      "Perfecto Herrera"
+    ],
+    "title": "Search Sounds: An audio crawler focused on weblogs.",
+    "pages": "365-366",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#CelmaCH06"
+  },
+  "conf/ismir/PampalkG06": {
+    "@key": "conf/ismir/PampalkG06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Elias Pampalk",
+      "Masataka Goto"
+    ],
+    "title": "MusicRainbow: A New User Interface to Discover Artists Using Audio-based Similarity and Web-based Labeling.",
+    "pages": "367-370",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#PampalkG06"
+  },
+  "conf/ismir/GeleijnseK06a": {
+    "@key": "conf/ismir/GeleijnseK06a",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Gijs Geleijnse",
+      "Jan H. M. Korst"
+    ],
+    "title": "Efficient Lyrics Extraction from the Web.",
+    "pages": "371-372",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#GeleijnseK06a"
+  },
+  "conf/ismir/LeeJD06": {
+    "@key": "conf/ismir/LeeJD06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Jin Ha Lee",
+      "M. Cameron Jones",
+      "J. Stephen Downie"
+    ],
+    "title": "Factors Affecting Response Rates for Real-Life MIR Queries.",
+    "pages": "373-374",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#LeeJD06"
+  },
+  "conf/ismir/Kranenburg06": {
+    "@key": "conf/ismir/Kranenburg06",
+    "@mdate": "2007-01-05",
+    "author": "Peter van Kranenburg",
+    "title": "Composer attribution by quantifying compositional strategies.",
+    "pages": "375-376",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Kranenburg06"
+  },
+  "conf/ismir/SchwenningerBWH06": {
+    "@key": "conf/ismir/SchwenningerBWH06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Jochen Schwenninger",
+      "Raymond Brueckner",
+      "Daniel Willett",
+      "Marcus E. Hennecke"
+    ],
+    "title": "Language Identification in Vocal Music.",
+    "pages": "377-379",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#SchwenningerBWH06"
+  },
+  "conf/ismir/LiBF06": {
+    "@key": "conf/ismir/LiBF06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Beinan Li",
+      "John Ashley Burgoyne",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Extending Audacity for Audio Annotation.",
+    "pages": "379-380",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#LiBF06"
+  },
+  "conf/ismir/LaplanteD06": {
+    "@key": "conf/ismir/LaplanteD06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Audrey Laplante",
+      "J. Stephen Downie"
+    ],
+    "title": "Everyday Life Music Information-Seeking Behaviour of Young Adults.",
+    "pages": "381-382",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#LaplanteD06"
+  },
+  "conf/ismir/Grund06": {
+    "@key": "conf/ismir/Grund06",
+    "@mdate": "2007-01-05",
+    "author": "Cynthia M. Grund",
+    "title": "A Philosophical Wish List for Research in Music Information Retrieval.",
+    "pages": "383-384",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Grund06"
+  },
+  "conf/ismir/McEnnisMF06a": {
+    "@key": "conf/ismir/McEnnisMF06a",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Daniel McEnnis",
+      "Cory McKay",
+      "Ichiro Fujinaga"
+    ],
+    "title": "jAudio: Additions and Improvements.",
+    "pages": "385-386",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#McEnnisMF06a"
+  },
+  "conf/ismir/SinclairDF06": {
+    "@key": "conf/ismir/SinclairDF06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Stephen Sinclair",
+      "Michael Droettboom",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Lilypond for pyScore: Approaching a universal translator for music notation.",
+    "pages": "387-388",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#SinclairDF06"
+  },
+  "conf/ismir/PampalkG06a": {
+    "@key": "conf/ismir/PampalkG06a",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Elias Pampalk",
+      "Martin Gasser"
+    ],
+    "title": "An Implementation of a Simple Playlist Generator Based on Audio Similarity Measures and User Feedback.",
+    "pages": "389-390",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#PampalkG06a"
+  },
+  "conf/ismir/Mountain06": {
+    "@key": "conf/ismir/Mountain06",
+    "@mdate": "2007-01-05",
+    "author": "Rosemary Mountain",
+    "title": "Name that mood! Describe that tune! Invitation to the IMP.",
+    "pages": "391-392",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#Mountain06"
+  },
+  "conf/ismir/KimWP06": {
+    "@key": "conf/ismir/KimWP06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Youngmoo E. Kim",
+      "Donald S. Williamson",
+      "Sridhar Pilli"
+    ],
+    "title": "Towards Quantifying the \"Album Effect\" in Artist Identification.",
+    "pages": "393-394",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#KimWP06"
+  },
+  "conf/ismir/SkowronekMP06": {
+    "@key": "conf/ismir/SkowronekMP06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Janto Skowronek",
+      "Martin F. McKinney",
+      "Steven van de Par"
+    ],
+    "title": "Ground truth for automatic music mood classification.",
+    "pages": "395-396",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#SkowronekMP06"
+  },
+  "conf/ismir/RuppinY06": {
+    "@key": "conf/ismir/RuppinY06",
+    "@mdate": "2007-01-05",
+    "author": [
+      "Adi Ruppin",
+      "Hezy Yeshurun"
+    ],
+    "title": "MIDI Music Genre Classification by Invariant Features.",
+    "pages": "397-399",
+    "year": "2006",
+    "crossref": "conf/ismir/2006",
+    "booktitle": "ISMIR",
+    "url": "db/conf/ismir/ismir2006.html#RuppinY06"
+  },
+  "conf/ismir/DeliegeP07": {
+    "@key": "conf/ismir/DeliegeP07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Fran\u00e7ois Deli\u00e8ge",
+      "Torben Bach Pedersen"
+    ],
+    "title": "Fuzzy Song Sets for Music Warehouses.",
+    "pages": "21-26",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p021_deliege.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#DeliegeP07"
+  },
+  "conf/ismir/PengLO07": {
+    "@key": "conf/ismir/PengLO07",
+    "@mdate": "2017-09-18",
+    "author": [
+      "Wei Peng 0001",
+      "Tao Li 0001",
+      "Mitsunori Ogihara"
+    ],
+    "title": "Music Clustering with Constraints.",
+    "pages": "27-32",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p027_peng.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#PengLO07"
+  },
+  "conf/ismir/Peeters07": {
+    "@key": "conf/ismir/Peeters07",
+    "@mdate": "2011-08-15",
+    "author": "Geoffroy Peeters",
+    "title": "Sequence Representation of Music Structure Using Higher-Order Similarity Matrix and Maximum-Likelihood Approach.",
+    "pages": "35-40",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p035_peeters.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Peeters07"
+  },
+  "conf/ismir/RhodesC07": {
+    "@key": "conf/ismir/RhodesC07",
+    "@mdate": "2014-04-16",
+    "author": [
+      "Christophe Rhodes",
+      "Michael A. Casey"
+    ],
+    "title": "Algorithms for Determining and Labelling Approximate Hierarchical Self-Similarity.",
+    "pages": "41-46",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p041_rhodes.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#RhodesC07"
+  },
+  "conf/ismir/MullerC07": {
+    "@key": "conf/ismir/MullerC07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Meinard M\u00fcller",
+      "Michael Clausen"
+    ],
+    "title": "Transposition-Invariant Self-Similarity Matrices.",
+    "pages": "47-50",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p047_mullermuller.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#MullerC07"
+  },
+  "conf/ismir/TurnbullLPG07": {
+    "@key": "conf/ismir/TurnbullLPG07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Douglas Turnbull",
+      "Gert R. G. Lanckriet",
+      "Elias Pampalk",
+      "Masataka Goto"
+    ],
+    "title": "A Supervised Approach for Detecting Boundaries in Music Using Difference Features and Boosting.",
+    "pages": "51-54",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p051_turnbull.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#TurnbullLPG07"
+  },
+  "conf/ismir/Marsden07": {
+    "@key": "conf/ismir/Marsden07",
+    "@mdate": "2011-08-15",
+    "author": "Alan Marsden",
+    "title": "Automatic Derivation of Musical Structure: A Tool for Research on Schenkerian Analysis.",
+    "pages": "55-58",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p055_marsden.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Marsden07"
+  },
+  "conf/ismir/LidyRPQ07": {
+    "@key": "conf/ismir/LidyRPQ07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Thomas Lidy",
+      "Andreas Rauber",
+      "Antonio Pertusa",
+      "Jos\u00e9 Manuel I\u00f1esta Quereda"
+    ],
+    "title": "Improving Genre Classification by Combination of Audio and Symbolic Descriptors Using a Transcription Systems.",
+    "pages": "61-66",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p061_lidy.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LidyRPQ07"
+  },
+  "conf/ismir/HuD07": {
+    "@key": "conf/ismir/HuD07",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "J. Stephen Downie"
+    ],
+    "title": "Exploring Mood Metadata: Relationships with Genre, Artist and Usage Metadata.",
+    "pages": "67-72",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p067_hu.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#HuD07"
+  },
+  "conf/ismir/CraftWC07": {
+    "@key": "conf/ismir/CraftWC07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Alastair J. D. Craft",
+      "Geraint A. Wiggins",
+      "Tim Crawford"
+    ],
+    "title": "How Many Beans Make Five? The Consensus Problem in Music-Genre Classification and a New Evaluation Method for Single-Genre Categorisation Systems.",
+    "pages": "73-76",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p073_craft.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#CraftWC07"
+  },
+  "conf/ismir/DeCoroBF07": {
+    "@key": "conf/ismir/DeCoroBF07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Christopher DeCoro",
+      "Zafer Barut\u00e7uoglu",
+      "Rebecca Fiebrink"
+    ],
+    "title": "Bayesian Aggregation for Hierarchical Genre Classification.",
+    "pages": "77-80",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p077_decoro.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#DeCoroBF07"
+  },
+  "conf/ismir/CunninghamBM07": {
+    "@key": "conf/ismir/CunninghamBM07",
+    "@mdate": "2017-12-03",
+    "author": [
+      "Sally Jo Cunningham",
+      "David Bainbridge 0001",
+      "Dana McKay"
+    ],
+    "title": "Finding New Music: A Diary Study of Everyday Encounters with Novel Songs.",
+    "pages": "83-88",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p083_cunningham.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#CunninghamBM07"
+  },
+  "conf/ismir/YoshiiGKOO07": {
+    "@key": "conf/ismir/YoshiiGKOO07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Kazuyoshi Yoshii",
+      "Masataka Goto",
+      "Kazunori Komatani",
+      "Tetsuya Ogata",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Improving Efficiency and Scalability of Model-Based Music Recommender System Based on Incremental Training.",
+    "pages": "89-94",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p089_yoshii.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#YoshiiGKOO07"
+  },
+  "conf/ismir/AngladeTV07": {
+    "@key": "conf/ismir/AngladeTV07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Amelie Anglade",
+      "Marco Tiemann",
+      "Fabio Vignoli"
+    ],
+    "title": "Virtual Communities for Creating Shared Music Channels.",
+    "pages": "95-100",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p095_anglade.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#AngladeTV07"
+  },
+  "conf/ismir/PampalkG07": {
+    "@key": "conf/ismir/PampalkG07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Elias Pampalk",
+      "Masataka Goto"
+    ],
+    "title": "MusicSun: A New Approach to Artist Recommendation.",
+    "pages": "101-104",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p101_pampalk.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#PampalkG07"
+  },
+  "conf/ismir/JensenECJ07": {
+    "@key": "conf/ismir/JensenECJ07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jesper H\u00f8jvang Jensen",
+      "Daniel P. W. Ellis",
+      "Mads Gr\u00e6sb\u00f8ll Christensen",
+      "S\u00f8ren Holdt Jensen"
+    ],
+    "title": "Evaluation of Distance Measures Between Gaussian Mixture Models of MFCCs.",
+    "pages": "107-108",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p107_jensen.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#JensenECJ07"
+  },
+  "conf/ismir/GomezAR07": {
+    "@key": "conf/ismir/GomezAR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Carlos G\u00f3mez",
+      "Soraya Abad-Mota",
+      "Edna Ruckhaus"
+    ],
+    "title": "An Analysis of the Mongeau-Sankoff Algorithm for Music Information Retrieval.",
+    "pages": "109-110",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p109_gomezgomez.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#GomezAR07"
+  },
+  "conf/ismir/NovelloM07": {
+    "@key": "conf/ismir/NovelloM07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Alberto Novello",
+      "Martin F. McKinney"
+    ],
+    "title": "Assessment of Perceptual Music Similarity.",
+    "pages": "111-112",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p111_novello.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#NovelloM07"
+  },
+  "conf/ismir/McKayF07": {
+    "@key": "conf/ismir/McKayF07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Cory McKay",
+      "Ichiro Fujinaga"
+    ],
+    "title": "jWebMiner: A Web-Based Feature Extractor.",
+    "pages": "113-114",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p113_mckay.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#McKayF07"
+  },
+  "conf/ismir/PohleKSW07": {
+    "@key": "conf/ismir/PohleKSW07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Tim Pohle",
+      "Peter Knees",
+      "Markus Schedl",
+      "Gerhard Widmer"
+    ],
+    "title": "Meaningfully Browsing Music Services.",
+    "pages": "115-116",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p115_pohle.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#PohleKSW07"
+  },
+  "conf/ismir/SchedlWPS07": {
+    "@key": "conf/ismir/SchedlWPS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Markus Schedl",
+      "Gerhard Widmer",
+      "Tim Pohle",
+      "Klaus Seyerlehner"
+    ],
+    "title": "Web-Based Detection of Music Band Members and Line-Up.",
+    "pages": "117-118",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p117_schedl.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#SchedlWPS07"
+  },
+  "conf/ismir/GeleijnseK07": {
+    "@key": "conf/ismir/GeleijnseK07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Gijs Geleijnse",
+      "Jan H. M. Korst"
+    ],
+    "title": "Tool Play Live: Dealing with Ambiguity in Artist Similarity Mining from the Web.",
+    "pages": "119-120",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p119_geleijnse.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#GeleijnseK07"
+  },
+  "conf/ismir/WeiZO07": {
+    "@key": "conf/ismir/WeiZO07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Bin Wei",
+      "Chengliang Zhang",
+      "Mitsunori Ogihara"
+    ],
+    "title": "Keyword Generation for Lyrics.",
+    "pages": "121-122",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p121_wei.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#WeiZO07"
+  },
+  "conf/ismir/KnopkeB07": {
+    "@key": "conf/ismir/KnopkeB07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ian Knopke",
+      "Donald Byrd"
+    ],
+    "title": "Towards Musicdiff: A Foundation for Improved Optical Music Recognition Using Multiple Recognizers.",
+    "pages": "123-126",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p123_knopke.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#KnopkeB07"
+  },
+  "conf/ismir/LartillotT07": {
+    "@key": "conf/ismir/LartillotT07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Olivier Lartillot",
+      "Petri Toiviainen"
+    ],
+    "title": "MIR in Matlab (II): A Toolbox for Musical Feature Extraction from Audio.",
+    "pages": "127-130",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p127_lartillot.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LartillotT07"
+  },
+  "conf/ismir/FremereyKMC07": {
+    "@key": "conf/ismir/FremereyKMC07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Christian Fremerey",
+      "Frank Kurth",
+      "Meinard M\u00fcller",
+      "Michael Clausen"
+    ],
+    "title": "A Demonstration of the SyncPlayer System.",
+    "pages": "131-132",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p131_fremerey.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#FremereyKMC07"
+  },
+  "conf/ismir/HurleyBMS07": {
+    "@key": "conf/ismir/HurleyBMS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Neil J. Hurley",
+      "F\u00e9lix Balado",
+      "Elizabeth P. McCarthy",
+      "Guenole C. M. Silvestre"
+    ],
+    "title": "Performance of Philips Audio Fingerprinting under Desynchronisation.",
+    "pages": "133-134",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p133_hurley.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#HurleyBMS07"
+  },
+  "conf/ismir/MohriMW07": {
+    "@key": "conf/ismir/MohriMW07",
+    "@mdate": "2015-02-12",
+    "author": [
+      "Mehryar Mohri",
+      "Pedro J. Moreno",
+      "Eugene Weinstein"
+    ],
+    "title": "Robust Music Identification, Detection, and Analysis.",
+    "pages": "135-138",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p135_mohri.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#MohriMW07"
+  },
+  "conf/ismir/BetserCR07": {
+    "@key": "conf/ismir/BetserCR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Micha\u00ebl Betser",
+      "Patrice Collen",
+      "Jean-Bernard Rault"
+    ],
+    "title": "Audio Identification Using Sinusoidal Modeling and Application to Jingle Detection.",
+    "pages": "139-142",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p139_betser.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#BetserCR07"
+  },
+  "conf/ismir/LebosseB07": {
+    "@key": "conf/ismir/LebosseB07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "J\u00e9r\u00f4me Leboss\u00e9",
+      "Luc Brun"
+    ],
+    "title": "Audio Fingerprint Identification by Approximate String Matching.",
+    "pages": "143-144",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p143_lebosse.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LebosseB07"
+  },
+  "conf/ismir/HanR07": {
+    "@key": "conf/ismir/HanR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Yushen Han",
+      "Christopher Raphael"
+    ],
+    "title": "Desoloing Monaural Audio Using Mixture Models.",
+    "pages": "145-148",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p145_han.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#HanR07"
+  },
+  "conf/ismir/BurredS07": {
+    "@key": "conf/ismir/BurredS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Juan Jos\u00e9 Burred",
+      "Thomas Sikora"
+    ],
+    "title": "Monaural Source Separation from Musical Mixtures Based on Time-Frequency Timbre Models.",
+    "pages": "149-152",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p149_burred.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#BurredS07"
+  },
+  "conf/ismir/PintoLDWV07": {
+    "@key": "conf/ismir/PintoLDWV07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Alberto Pinto",
+      "Reinier H. van Leuken",
+      "M. Fatih Demirci",
+      "Frans Wiering",
+      "Remco C. Veltkamp"
+    ],
+    "title": "Indexing Music Collections Through Graph Spectra.",
+    "pages": "153-156",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p153_pinto.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#PintoLDWV07"
+  },
+  "conf/ismir/LaiFDFRHM07": {
+    "@key": "conf/ismir/LaiFDFRHM07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Catherine Lai",
+      "Ichiro Fujinaga",
+      "David Descheneau",
+      "Michael Frishkopf",
+      "Jenn Riley",
+      "Joseph Hafner",
+      "Brian McMillan"
+    ],
+    "title": "Metadata Infrastructure for Sound Recordings.",
+    "pages": "157-158",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p157_lai.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LaiFDFRHM07"
+  },
+  "conf/ismir/LandoneHR07": {
+    "@key": "conf/ismir/LandoneHR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Christian Landone",
+      "Joseph Harrop",
+      "Josh Reiss"
+    ],
+    "title": "Enabling Access to Sound Archives Through Integration, Enrichment and Retrieval: The EASAIER Project.",
+    "pages": "159-160",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p159_landone.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LandoneHR07"
+  },
+  "conf/ismir/Proutskova07": {
+    "@key": "conf/ismir/Proutskova07",
+    "@mdate": "2011-08-15",
+    "author": "Polina Proutskova",
+    "title": "Musical Memory of the World - Data Infrastructure in Ethnomusicological Archives.",
+    "pages": "161-162",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p161_proutskova.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Proutskova07"
+  },
+  "conf/ismir/LanzelotteBU07": {
+    "@key": "conf/ismir/LanzelotteBU07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Rosana S. G. Lanzelotte",
+      "Adriana O. Ballest\u00e9",
+      "Martha Ulhoa"
+    ],
+    "title": "A Digital Collection of Brazilian Lundus.",
+    "pages": "163-164",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p163_lanzelotte.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LanzelotteBU07"
+  },
+  "conf/ismir/LiLF07": {
+    "@key": "conf/ismir/LiLF07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Beinan Li",
+      "Simon de Leon",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Alternative Digitization Approach for Stereo Phonograph Records Using Optical Audio Reconstruction.",
+    "pages": "165-166",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p165_li.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LiLF07"
+  },
+  "conf/ismir/LeitichT07": {
+    "@key": "conf/ismir/LeitichT07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Stefan Leitich",
+      "Martin Topf"
+    ],
+    "title": "Globe of Music - Music Library Visualization Using Geosom.",
+    "pages": "167-170",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p167_leitich.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LeitichT07"
+  },
+  "conf/ismir/TindaleST07": {
+    "@key": "conf/ismir/TindaleST07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Adam R. Tindale",
+      "David Sprague",
+      "George Tzanetakis"
+    ],
+    "title": "Strike-A-Tune: Fuzzy Music Navigation Using a Drum Interface.",
+    "pages": "171-172",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p171_tindale.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#TindaleST07"
+  },
+  "conf/ismir/LamereE07": {
+    "@key": "conf/ismir/LamereE07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Paul Lamere",
+      "Douglas Eck"
+    ],
+    "title": "Using 3D Visualizations to Explore and Discover Music.",
+    "pages": "173-174",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p173_lamere.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LamereE07"
+  },
+  "conf/ismir/HitchnerMT07": {
+    "@key": "conf/ismir/HitchnerMT07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Stephen Hitchner",
+      "Jennifer Murdoch",
+      "George Tzanetakis"
+    ],
+    "title": "Music Browsing Using a Tabletop Display.",
+    "pages": "175-176",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p175_hitchner.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#HitchnerMT07"
+  },
+  "conf/ismir/Knees07": {
+    "@key": "conf/ismir/Knees07",
+    "@mdate": "2011-08-15",
+    "author": "Peter Knees",
+    "title": "Search & Select - Intuitively Retrieving Music from Large Collections.",
+    "pages": "177-178",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p177_knees.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Knees07"
+  },
+  "conf/ismir/TiemannPV07": {
+    "@key": "conf/ismir/TiemannPV07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Marco Tiemann",
+      "Steffen Pauws",
+      "Fabio Vignoli"
+    ],
+    "title": "Ensemble Learning for Hybrid Music Recommendation.",
+    "pages": "179-180",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p179_tiemann.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#TiemannPV07"
+  },
+  "conf/ismir/DonaldsonK07": {
+    "@key": "conf/ismir/DonaldsonK07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Justin Donaldson",
+      "Ian Knopke"
+    ],
+    "title": "Music Recommendation Mapping and Interface Based on Structural Network Entropy.",
+    "pages": "181-182",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p181_donaldson.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#DonaldsonK07"
+  },
+  "conf/ismir/Ahmaniemi07": {
+    "@key": "conf/ismir/Ahmaniemi07",
+    "@mdate": "2011-08-15",
+    "author": "Teemu Tuomas Ahmaniemi",
+    "title": "Influence of Tempo and Subjective Rating of Music in Step Frequency of Running.",
+    "pages": "183-184",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p183_ahmaniemi.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Ahmaniemi07"
+  },
+  "conf/ismir/McEnnisC07": {
+    "@key": "conf/ismir/McEnnisC07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Daniel McEnnis",
+      "Sally Jo Cunningham"
+    ],
+    "title": "Sociology and Music Recommendation Systems.",
+    "pages": "185-186",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p185_mcennis.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#McEnnisC07"
+  },
+  "conf/ismir/MardirossianC07": {
+    "@key": "conf/ismir/MardirossianC07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Arpi Mardirossian",
+      "Elaine Chew"
+    ],
+    "title": "Visualizing Music: Tonal Progressions and Distributions.",
+    "pages": "189-194",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p189_mardirossian.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#MardirossianC07"
+  },
+  "conf/ismir/Izmirli07": {
+    "@key": "conf/ismir/Izmirli07",
+    "@mdate": "2011-08-15",
+    "author": "\u00d6zg\u00fcr Izmirli",
+    "title": "Localized Key Finding from Audio Using Nonnegative Matrix Factorization for Segmentation.",
+    "pages": "195-200",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p195_izmirli.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Izmirli07"
+  },
+  "conf/ismir/TeodoruR07": {
+    "@key": "conf/ismir/TeodoruR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Gabi Teodoru",
+      "Christopher Raphael"
+    ],
+    "title": "Pitch Spelling with Conditionally Independent Voices.",
+    "pages": "201-206",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p201_teodoru.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#TeodoruR07"
+  },
+  "conf/ismir/GatzscheMGB07": {
+    "@key": "conf/ismir/GatzscheMGB07",
+    "@mdate": "2012-08-24",
+    "author": [
+      "Gabriel Gatzsche",
+      "Markus Mehnert",
+      "David Gatzsche",
+      "Karlheinz Brandenburg"
+    ],
+    "title": "A Symmetry Based Approach for Musical Tonality Analysis.",
+    "pages": "207-210",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p207_gatzsche.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#GatzscheMGB07"
+  },
+  "conf/ismir/MartinsBTL07": {
+    "@key": "conf/ismir/MartinsBTL07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Luis Gustavo Martins",
+      "Juan Jos\u00e9 Burred",
+      "George Tzanetakis",
+      "Mathieu Lagrange"
+    ],
+    "title": "Polyphonic Instrument Recognition Using Spectral Clustering.",
+    "pages": "213-218",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p213_martins.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#MartinsBTL07"
+  },
+  "conf/ismir/GilletR07": {
+    "@key": "conf/ismir/GilletR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Olivier Gillet",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "Supervised and Unsupervised Sequence Modelling for Drum Transcription.",
+    "pages": "219-224",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p219_gillet.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#GilletR07"
+  },
+  "conf/ismir/PaulusK07": {
+    "@key": "conf/ismir/PaulusK07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jouni Paulus",
+      "Anssi Klapuri"
+    ],
+    "title": "Combining Temporal and Spectral Features in HMM-Based Drum Transcription.",
+    "pages": "225-228",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p225_paulus.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#PaulusK07"
+  },
+  "conf/ismir/RoyPK07": {
+    "@key": "conf/ismir/RoyPK07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Pierre Roy",
+      "Fran\u00e7ois Pachet",
+      "Sergio Krakowski"
+    ],
+    "title": "Improving the Classification of Percussive Sounds with Analytical Features: A Case Study.",
+    "pages": "229-232",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p229_roy.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#RoyPK07"
+  },
+  "conf/ismir/LeveauSD07": {
+    "@key": "conf/ismir/LeveauSD07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Pierre Leveau",
+      "David Sodoyer",
+      "Laurent Daudet"
+    ],
+    "title": "Automatic Instrument Recognition in a Polyphonic Mixture Using Sparse Representations.",
+    "pages": "233-236",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p233_leveau.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LeveauSD07"
+  },
+  "conf/ismir/Bello07": {
+    "@key": "conf/ismir/Bello07",
+    "@mdate": "2011-08-15",
+    "author": "Juan Pablo Bello",
+    "title": "Audio-Based Cover Song Retrieval Using Approximate Chord Sequences: Testing Shifts, Gaps, Swaps and Beats.",
+    "pages": "239-244",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p239_bello.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Bello07"
+  },
+  "conf/ismir/LeeS07": {
+    "@key": "conf/ismir/LeeS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Kyogu Lee",
+      "Malcolm Slaney"
+    ],
+    "title": "A Unified System for Chord Transcription and Key Extraction Using Hidden Markov Models.",
+    "pages": "245-250",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p245_lee.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LeeS07"
+  },
+  "conf/ismir/BurgoynePKF07": {
+    "@key": "conf/ismir/BurgoynePKF07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "John Ashley Burgoyne",
+      "Laurent Pugin",
+      "Corey Kereliuk",
+      "Ichiro Fujinaga"
+    ],
+    "title": "A Cross-Validated Study of Modelling Strategies for Automatic Chord Recognition in Audio.",
+    "pages": "251-254",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p251_burgoyne.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#BurgoynePKF07"
+  },
+  "conf/ismir/MauchDHCF07": {
+    "@key": "conf/ismir/MauchDHCF07",
+    "@mdate": "2014-04-16",
+    "author": [
+      "Matthias Mauch",
+      "Simon Dixon",
+      "Christopher Harte",
+      "Michael A. Casey",
+      "Benjamin Fields"
+    ],
+    "title": "Discovering Chord Idioms Through Beatles and Real Book Songs.",
+    "pages": "255-258",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p255_mauch.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#MauchDHCF07"
+  },
+  "conf/ismir/KurthMFCC07": {
+    "@key": "conf/ismir/KurthMFCC07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Frank Kurth",
+      "Meinard M\u00fcller",
+      "Christian Fremerey",
+      "Yoon-ha Chang",
+      "Michael Clausen"
+    ],
+    "title": "Automated Synchronization of Scanned Sheet Music with Audio Recordings.",
+    "pages": "261-266",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p261_kurth.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#KurthMFCC07"
+  },
+  "conf/ismir/PeelingCG07": {
+    "@key": "conf/ismir/PeelingCG07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Paul H. Peeling",
+      "Ali Taylan Cemgil",
+      "Simon J. Godsill"
+    ],
+    "title": "A Probabilistic Framework for Matching Music Representations.",
+    "pages": "267-272",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p267_peeling.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#PeelingCG07"
+  },
+  "conf/ismir/MiottoO07": {
+    "@key": "conf/ismir/MiottoO07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Riccardo Miotto",
+      "Nicola Orio"
+    ],
+    "title": "A Methodology for the Segmentation and Identification of Music Works.",
+    "pages": "273-278",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p273_miotto.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#MiottoO07"
+  },
+  "conf/ismir/YouD07": {
+    "@key": "conf/ismir/YouD07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Wei You",
+      "Roger B. Dannenberg"
+    ],
+    "title": "Polyphonic Music Note Onset Detection Using Semi-Supervised Learning.",
+    "pages": "279-282",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p279_you.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#YouD07"
+  },
+  "conf/ismir/HamanakaHT07": {
+    "@key": "conf/ismir/HamanakaHT07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Masatoshi Hamanaka",
+      "Keiji Hirata",
+      "Satoshi Tojo"
+    ],
+    "title": "ATTA: Implementing GTTM on a Computer.",
+    "pages": "285-286",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p285_hamanaka.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#HamanakaHT07"
+  },
+  "conf/ismir/WeydeWN07": {
+    "@key": "conf/ismir/WeydeWN07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Tillman Weyde",
+      "Jens Wissmann",
+      "Kerstin Neubarth"
+    ],
+    "title": "An Experiment on the Role of Pitch Intervals in Melodic Segmentation.",
+    "pages": "287-288",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p287_weyde.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#WeydeWN07"
+  },
+  "conf/ismir/KuuskankareL07": {
+    "@key": "conf/ismir/KuuskankareL07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Mika Kuuskankare",
+      "Mikael Laurson"
+    ],
+    "title": "Vivo - Visualizing Harmonic Progressions and Voice-Leading in PWGL.",
+    "pages": "289-290",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p289_kuuskankare.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#KuuskankareL07"
+  },
+  "conf/ismir/Frieler07": {
+    "@key": "conf/ismir/Frieler07",
+    "@mdate": "2011-08-15",
+    "author": "Klaus Frieler",
+    "title": "Visualizing Music on the Metrical Circle.",
+    "pages": "291-292",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p291_frieler.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Frieler07"
+  },
+  "conf/ismir/VolkGKWVG07": {
+    "@key": "conf/ismir/VolkGKWVG07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Anja Volk",
+      "J\u00f6rg Garbers",
+      "Peter van Kranenburg",
+      "Frans Wiering",
+      "Remco C. Veltkamp",
+      "Louis P. Grijp"
+    ],
+    "title": "Applying Rhythmic Similarity Based on Inner Metric Analysis to Folksong Research.",
+    "pages": "293-296",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p293_volk.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#VolkGKWVG07"
+  },
+  "conf/ismir/AntonopoulosPTCML07": {
+    "@key": "conf/ismir/AntonopoulosPTCML07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Iasonas Antonopoulos",
+      "Aggelos Pikrakis",
+      "Sergios Theodoridis",
+      "Olmo Cornelis",
+      "Dirk Moelants",
+      "Marc Leman"
+    ],
+    "title": "Music Retrieval by Rhythmic Similarity Applied on Greek and African Traditional Music.",
+    "pages": "297-300",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p297_antonopoulos.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#AntonopoulosPTCML07"
+  },
+  "conf/ismir/PikrakisT07": {
+    "@key": "conf/ismir/PikrakisT07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Aggelos Pikrakis",
+      "Sergios Theodoridis"
+    ],
+    "title": "An Application of Empirical Mode Decomposition on Tempo Induction from Music Recordings.",
+    "pages": "301-304",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p301_pikrakis.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#PikrakisT07"
+  },
+  "conf/ismir/ChuanC07": {
+    "@key": "conf/ismir/ChuanC07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ching-Hua Chuan",
+      "Elaine Chew"
+    ],
+    "title": "A Dynamic Programming Approach to the Extraction of Phrase Boundaries from Tempo Variations in Expressive Performances.",
+    "pages": "305-308",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p305_chuan.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#ChuanC07"
+  },
+  "conf/ismir/HuBD07": {
+    "@key": "conf/ismir/HuBD07",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "Mert Bay",
+      "J. Stephen Downie"
+    ],
+    "title": "Creating a Simplified Music Mood Classification Ground-Truth Set.",
+    "pages": "309-310",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p309_hu.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#HuBD07"
+  },
+  "conf/ismir/VarewyckM07": {
+    "@key": "conf/ismir/VarewyckM07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Matthias Varewyck",
+      "Jean-Pierre Martens"
+    ],
+    "title": "Assessment of State-of-the-Art Meter Analysis Systems with an Extended Meter Description Model.",
+    "pages": "311-314",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p311_varewyck.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#VarewyckM07"
+  },
+  "conf/ismir/ContSSR07": {
+    "@key": "conf/ismir/ContSSR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Arshia Cont",
+      "Diemo Schwarz",
+      "Norbert Schnell",
+      "Christopher Raphael"
+    ],
+    "title": "Evaluation of Real-Time Audio-to-Score Alignment.",
+    "pages": "315-316",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p315_cont.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#ContSSR07"
+  },
+  "conf/ismir/MullensiefenLRW07": {
+    "@key": "conf/ismir/MullensiefenLRW07",
+    "@mdate": "2017-09-12",
+    "author": [
+      "Daniel M\u00fcllensiefen",
+      "David Lewis 0001",
+      "Christophe Rhodes",
+      "Geraint A. Wiggins"
+    ],
+    "title": "Evaluating a Chord-Labelling Algorithm.",
+    "pages": "317-318",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p317_mullensiefenmullensiefen.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#MullensiefenLRW07"
+  },
+  "conf/ismir/Serra07": {
+    "@key": "conf/ismir/Serra07",
+    "@mdate": "2011-08-15",
+    "author": "Joan Serr\u00e0",
+    "title": "A Qualitative Assessment of Measures for the Evaluation of a Cover Song Identification System.",
+    "pages": "319-322",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p319_serra.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Serra07"
+  },
+  "conf/ismir/EhmannDJ07": {
+    "@key": "conf/ismir/EhmannDJ07",
+    "@mdate": "2017-03-30",
+    "author": [
+      "Andreas F. Ehmann",
+      "J. Stephen Downie",
+      "M. Cameron Jones"
+    ],
+    "title": "The Music Information Retrieval Evaluation Exchange \"Do-It-Yourself\" Web Service.",
+    "pages": "323-324",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p323_ehmann.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#EhmannDJ07"
+  },
+  "conf/ismir/LeeDJ07": {
+    "@key": "conf/ismir/LeeDJ07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jin Ha Lee",
+      "J. Stephen Downie",
+      "M. Cameron Jones"
+    ],
+    "title": "Preliminary Analyses of Information Features Provided by Users for Identifying Music.",
+    "pages": "325-328",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p325_lee.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LeeDJ07"
+  },
+  "conf/ismir/Davis07": {
+    "@key": "conf/ismir/Davis07",
+    "@mdate": "2011-08-15",
+    "author": "Elizabeth Davis",
+    "title": "Finding Music in Scholarly Sets and Series: The Index to Printed Music (IPM).",
+    "pages": "329-330",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p329_davis.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Davis07"
+  },
+  "conf/ismir/DudaNS07": {
+    "@key": "conf/ismir/DudaNS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Alexander Duda",
+      "Andreas N\u00fcrnberger",
+      "Sebastian Stober"
+    ],
+    "title": "Towards Query by Singing/Humming on Audio Databases.",
+    "pages": "331-334",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p331_duda.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#DudaNS07"
+  },
+  "conf/ismir/LittleRP07": {
+    "@key": "conf/ismir/LittleRP07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "David Little",
+      "David Raffensperger",
+      "Bryan Pardo"
+    ],
+    "title": "A Query by Humming System that Learns from Experience.",
+    "pages": "335-338",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p335_little.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LittleRP07"
+  },
+  "conf/ismir/Ellis07": {
+    "@key": "conf/ismir/Ellis07",
+    "@mdate": "2011-08-15",
+    "author": "Daniel P. W. Ellis",
+    "title": "Classifying Music Audio with Timbral and Chroma Features.",
+    "pages": "339-340",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p339_ellis.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Ellis07"
+  },
+  "conf/ismir/Flexer07": {
+    "@key": "conf/ismir/Flexer07",
+    "@mdate": "2011-08-15",
+    "author": "Arthur Flexer",
+    "title": "A Closer Look on Artist Filters for Musical Genre Classification.",
+    "pages": "341-344",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p341_flexer.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Flexer07"
+  },
+  "conf/ismir/SkowronekMP07": {
+    "@key": "conf/ismir/SkowronekMP07",
+    "@mdate": "2011-08-16",
+    "author": [
+      "Janto Skowronek",
+      "Martin F. McKinney",
+      "Steven van de Par"
+    ],
+    "title": "A Demonstrator for Automatic Music Mood Estimation.",
+    "pages": "345-346",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p345_skowronek.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#SkowronekMP07"
+  },
+  "conf/ismir/GovaertsCD07": {
+    "@key": "conf/ismir/GovaertsCD07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Sten Govaerts",
+      "Nik Corthaut",
+      "Erik Duval"
+    ],
+    "title": "Mood-ex-Machina: Towards Automation of Moody Tunes.",
+    "pages": "347-350",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p347_govaerts.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#GovaertsCD07"
+  },
+  "conf/ismir/KapurPLT07": {
+    "@key": "conf/ismir/KapurPLT07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ajay Kapur",
+      "Graham Percival",
+      "Mathieu Lagrange",
+      "George Tzanetakis"
+    ],
+    "title": "Pedagogical Transcription for Multimodal Sitar Performance.",
+    "pages": "351-352",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p351_kapur.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#KapurPLT07"
+  },
+  "conf/ismir/MoreauF07": {
+    "@key": "conf/ismir/MoreauF07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Arnaud Moreau",
+      "Arthur Flexer"
+    ],
+    "title": "Drum Transcription in Polyphonic Music Using Non-Negative Matrix Factorisation.",
+    "pages": "353-354",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p353_moreau.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#MoreauF07"
+  },
+  "conf/ismir/KasimiNR07": {
+    "@key": "conf/ismir/KasimiNR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Alia Al Kasimi",
+      "Eric Nichols",
+      "Christopher Raphael"
+    ],
+    "title": "A Simple Algorithm for Automatic Generation of Polyphonic Piano Fingerings.",
+    "pages": "355-356",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p355_kasimi.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#KasimiNR07"
+  },
+  "conf/ismir/DresslerS07": {
+    "@key": "conf/ismir/DresslerS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Karin Dressler",
+      "Sebastian Streich"
+    ],
+    "title": "Tuning Frequency Estimation Using Circular Statistics.",
+    "pages": "357-360",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p357_dressler.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#DresslerS07"
+  },
+  "conf/ismir/LawADC07": {
+    "@key": "conf/ismir/LawADC07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Edith L. M. Law",
+      "Luis von Ahn",
+      "Roger B. Dannenberg",
+      "Mike Crawford"
+    ],
+    "title": "TagATune: A Game for Music and Sound Annotation.",
+    "pages": "361-364",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p361_law.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LawADC07"
+  },
+  "conf/ismir/MandelE07": {
+    "@key": "conf/ismir/MandelE07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Michael I. Mandel",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "A Web-Based Game for Collecting Music Metadata.",
+    "pages": "365-366",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p365_mandel.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#MandelE07"
+  },
+  "conf/ismir/EckBL07": {
+    "@key": "conf/ismir/EckBL07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Douglas Eck",
+      "Thierry Bertin-Mahieux",
+      "Paul Lamere"
+    ],
+    "title": "Autotagging Music Using Supervised Machine Learning.",
+    "pages": "367-368",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p367_eck.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#EckBL07"
+  },
+  "conf/ismir/GruhneDS07": {
+    "@key": "conf/ismir/GruhneDS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Matthias Gruhne",
+      "Christian Dittmar",
+      "Konstantin Schmidt"
+    ],
+    "title": "Phoneme Recognition in Popular Music.",
+    "pages": "369-370",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p369_gruhne.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#GruhneDS07"
+  },
+  "conf/ismir/OhishiGIT07": {
+    "@key": "conf/ismir/OhishiGIT07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Yasunori Ohishi",
+      "Masataka Goto",
+      "Katunobu Itou",
+      "Kazuya Takeda"
+    ],
+    "title": "A Stochastic Representation of the Dynamics of Sung Melody.",
+    "pages": "371-372",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p371_ohishi.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#OhishiGIT07"
+  },
+  "conf/ismir/CaoLLY07": {
+    "@key": "conf/ismir/CaoLLY07",
+    "@mdate": "2014-08-06",
+    "author": [
+      "Chuan Cao",
+      "Ming Li 0026",
+      "Jian Liu",
+      "Yonghong Yan 0002"
+    ],
+    "title": "Singing Melody Extraction in Polyphonic Music by Harmonic Tracking.",
+    "pages": "373-374",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p373_cao.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#CaoLLY07"
+  },
+  "conf/ismir/MesarosVK07": {
+    "@key": "conf/ismir/MesarosVK07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Annamaria Mesaros",
+      "Tuomas Virtanen",
+      "Anssi Klapuri"
+    ],
+    "title": "Singer Identification in Polyphonic Music Using Vocal Separation and Pattern Recognition Methods.",
+    "pages": "375-378",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p375_mesaros.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#MesarosVK07"
+  },
+  "conf/ismir/RaczynskiOS07": {
+    "@key": "conf/ismir/RaczynskiOS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Stanislaw Andrzej Raczynski",
+      "Nobutaka Ono",
+      "Shigeki Sagayama"
+    ],
+    "title": "Multipitch Analysis with Harmonic Nonnegative Matrix Approximation.",
+    "pages": "381-386",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p381_raczynski.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#RaczynskiOS07"
+  },
+  "conf/ismir/NicholsR07": {
+    "@key": "conf/ismir/NicholsR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Eric Nichols",
+      "Christopher Raphael"
+    ],
+    "title": "Automatic Transcription of Music Audio Through Continuous Parameter Tracking.",
+    "pages": "387-392",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p387_nichols.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#NicholsR07"
+  },
+  "conf/ismir/YehBR07": {
+    "@key": "conf/ismir/YehBR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Chunghsin Yeh",
+      "Niels Bogaards",
+      "Axel R\u00f6bel"
+    ],
+    "title": "Synthesized Polyphonic Music Database with Verifiable Ground Truth for Multiple F0 Estimation.",
+    "pages": "393-398",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p393_yeh.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#YehBR07"
+  },
+  "conf/ismir/BarbedoLW07": {
+    "@key": "conf/ismir/BarbedoLW07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jayme Garcia Arnal Barbedo",
+      "Amauri Lopes",
+      "Patrick J. Wolfe"
+    ],
+    "title": "High Time-Resolution Estimation of Multiple Fundamental Frequencies.",
+    "pages": "399-402",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p399_barbedo.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#BarbedoLW07"
+  },
+  "conf/ismir/TorresTBL07": {
+    "@key": "conf/ismir/TorresTBL07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "David A. Torres",
+      "Douglas Turnbull",
+      "Luke Barrington",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Identifying Words that are Musically Meaningful.",
+    "pages": "405-410",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p405_torres.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#TorresTBL07"
+  },
+  "conf/ismir/LevyS07": {
+    "@key": "conf/ismir/LevyS07",
+    "@mdate": "2014-04-10",
+    "author": [
+      "Mark Levy",
+      "Mark B. Sandler"
+    ],
+    "title": "A Semantic Space for Music Derived from Social Tags.",
+    "pages": "411-416",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p411_levy.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LevyS07"
+  },
+  "conf/ismir/RaimondASG07": {
+    "@key": "conf/ismir/RaimondASG07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Yves Raimond",
+      "Samer A. Abdallah",
+      "Mark B. Sandler",
+      "Frederick Giasson"
+    ],
+    "title": "The Music Ontology.",
+    "pages": "417-422",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p417_raimond.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#RaimondASG07"
+  },
+  "conf/ismir/AucouturierPRB07": {
+    "@key": "conf/ismir/AucouturierPRB07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jean-Julien Aucouturier",
+      "Fran\u00e7ois Pachet",
+      "Pierre Roy",
+      "Anthony Beuriv\u00e9"
+    ],
+    "title": "Signal + Context = Better Classification.",
+    "pages": "425-430",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p425_aucouturier.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#AucouturierPRB07"
+  },
+  "conf/ismir/ChordiaR07": {
+    "@key": "conf/ismir/ChordiaR07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Parag Chordia",
+      "Alex Rae"
+    ],
+    "title": "Raag Recognition Using Pitch-Class and Pitch-Class Dyad Distributions.",
+    "pages": "431-436",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p431_chordia.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#ChordiaR07"
+  },
+  "conf/ismir/LeonRQ07": {
+    "@key": "conf/ismir/LeonRQ07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Pedro J. Ponce de Le\u00f3n",
+      "David Rizo",
+      "Jos\u00e9 Manuel I\u00f1esta Quereda"
+    ],
+    "title": "Towards a Human-Friendly Melody Characterization by Automatically Induced Rules.",
+    "pages": "437-440",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p437_poncedeleon.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#LeonRQ07"
+  },
+  "conf/ismir/TzanetakisJM07": {
+    "@key": "conf/ismir/TzanetakisJM07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "George Tzanetakis",
+      "Randy Jones",
+      "Kirk McNally"
+    ],
+    "title": "Stereo Panning Features for Classifying Recording Production Style.",
+    "pages": "441-444",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p441_tzanetakis.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#TzanetakisJM07"
+  },
+  "conf/ismir/KarydisNPC07": {
+    "@key": "conf/ismir/KarydisNPC07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ioannis Karydis",
+      "Alexandros Nanopoulos",
+      "Apostolos N. Papadopoulos",
+      "Emilios Cambouropoulos"
+    ],
+    "title": "VISA: The Voice Integration/Segregation Algorithm.",
+    "pages": "445-448",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p445_karydis.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#KarydisNPC07"
+  },
+  "conf/ismir/GarbersKVWVG07": {
+    "@key": "conf/ismir/GarbersKVWVG07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "J\u00f6rg Garbers",
+      "Peter van Kranenburg",
+      "Anja Volk",
+      "Frans Wiering",
+      "Remco C. Veltkamp",
+      "Louis P. Grijp"
+    ],
+    "title": "Using Pitch Stability Among a Group of Aligned Query Melodies to Retrieve Unidentified Variant Melodies.",
+    "pages": "451-456",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p451_garbers.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#GarbersKVWVG07"
+  },
+  "conf/ismir/RommingS07": {
+    "@key": "conf/ismir/RommingS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Christian Andr\u00e9 Romming",
+      "Eleanor Selfridge-Field"
+    ],
+    "title": "Algorithms for Polyphonic Music Retrieval: The Hausdorff Metric and Geometric Hashing.",
+    "pages": "457-462",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p457_romming.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#RommingS07"
+  },
+  "conf/ismir/HoashiIMS07": {
+    "@key": "conf/ismir/HoashiIMS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Keiichiro Hoashi",
+      "Hiromi Ishizaki",
+      "Kazunori Matsumoto",
+      "Fumiaki Sugaya"
+    ],
+    "title": "Content-Based Music Retrieval Using Query Integration for Users with Diverse Preferences.",
+    "pages": "463-466",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p463_hoashi.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#HoashiIMS07"
+  },
+  "conf/ismir/FujiharaG07": {
+    "@key": "conf/ismir/FujiharaG07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Hiromasa Fujihara",
+      "Masataka Goto"
+    ],
+    "title": "A Music Information Retrieval System Based on Singing Voice Timbre.",
+    "pages": "467-470",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p467_fujihara.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#FujiharaG07"
+  },
+  "conf/ismir/AllanMW07": {
+    "@key": "conf/ismir/AllanMW07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Hamish Allan",
+      "Daniel M\u00fcllensiefen",
+      "Geraint A. Wiggins"
+    ],
+    "title": "Methodological Considerations in Studies of Musical Similarity.",
+    "pages": "473-478",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p473_allan.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#AllanMW07"
+  },
+  "conf/ismir/SlaneyW07": {
+    "@key": "conf/ismir/SlaneyW07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Malcolm Slaney",
+      "William White"
+    ],
+    "title": "Similarity Based on Rating Data.",
+    "pages": "479-484",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p479_slaney.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#SlaneyW07"
+  },
+  "conf/ismir/ReedL07": {
+    "@key": "conf/ismir/ReedL07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jeremy Reed",
+      "Chin-Hui Lee"
+    ],
+    "title": "A Study on Attribute-Based Taxonomy for Music Information Retrieval.",
+    "pages": "485-490",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p485_reed.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#ReedL07"
+  },
+  "conf/ismir/Balkema07": {
+    "@key": "conf/ismir/Balkema07",
+    "@mdate": "2011-08-15",
+    "author": "Wietse Balkema",
+    "title": "Variable-Size Gaussian Mixture Models for Music Similarity Measures.",
+    "pages": "491-494",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p491_balkema.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Balkema07"
+  },
+  "conf/ismir/Sapp07": {
+    "@key": "conf/ismir/Sapp07",
+    "@mdate": "2011-08-15",
+    "author": "Craig Stuart Sapp",
+    "title": "Comparative Analysis of Multiple Musical Performances.",
+    "pages": "497-500",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p497_sapp.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#Sapp07"
+  },
+  "conf/ismir/DietK07": {
+    "@key": "conf/ismir/DietK07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "J\u00fcrgen Diet",
+      "Frank Kurth"
+    ],
+    "title": "The Probado Music Repository at the Bavarian State Library.",
+    "pages": "501-504",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p501_diet.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#DietK07"
+  },
+  "conf/ismir/KranenburgGVWGV07": {
+    "@key": "conf/ismir/KranenburgGVWGV07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Peter van Kranenburg",
+      "J\u00f6rg Garbers",
+      "Anja Volk",
+      "Frans Wiering",
+      "Louis P. Grijp",
+      "Remco C. Veltkamp"
+    ],
+    "title": "Towards Integration of MIR and Folk Song Research.",
+    "pages": "505-508",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p505_vankranenburg.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#KranenburgGVWGV07"
+  },
+  "conf/ismir/BurgoynePEF07": {
+    "@key": "conf/ismir/BurgoynePEF07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "John Ashley Burgoyne",
+      "Laurent Pugin",
+      "Greg Eustace",
+      "Ichiro Fujinaga"
+    ],
+    "title": "A Comparative Survey of Image Binarisation Algorithms for Optical Recognition on Degraded Musical Sources.",
+    "pages": "509-512",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p509_burgoyne.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#BurgoynePEF07"
+  },
+  "conf/ismir/PuginBF07": {
+    "@key": "conf/ismir/PuginBF07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Laurent Pugin",
+      "John Ashley Burgoyne",
+      "Ichiro Fujinaga"
+    ],
+    "title": "MAP Adaptation to Improve Optical Music Recognition of Early Music Documents Using Hidden Markov Models.",
+    "pages": "513-516",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p513_pugin.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#PuginBF07"
+  },
+  "conf/ismir/SeyerlehnerWS07": {
+    "@key": "conf/ismir/SeyerlehnerWS07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Klaus Seyerlehner",
+      "Gerhard Widmer",
+      "Dominik Schnitzer"
+    ],
+    "title": "From Rhythm Patterns to Perceived Tempo.",
+    "pages": "519-524",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p519_seyerlehner.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#SeyerlehnerWS07"
+  },
+  "conf/ismir/GeleijnseSK07": {
+    "@key": "conf/ismir/GeleijnseSK07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Gijs Geleijnse",
+      "Markus Schedl",
+      "Peter Knees"
+    ],
+    "title": "The Quest for Ground Truth in Musical Artist Tagging in the Social Web Era.",
+    "pages": "525-530",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p525_geleijnse.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#GeleijnseSK07"
+  },
+  "conf/ismir/SordoLC07": {
+    "@key": "conf/ismir/SordoLC07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Mohamed Sordo",
+      "Cyril Laurier",
+      "\u00d2scar Celma"
+    ],
+    "title": "Annotating Music Collections: How Content-Based Similarity Helps to Propagate Labels.",
+    "pages": "531-534",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p531_sordo.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#SordoLC07"
+  },
+  "conf/ismir/TurnbullLBL07": {
+    "@key": "conf/ismir/TurnbullLBL07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Douglas Turnbull",
+      "Ruoran Liu",
+      "Luke Barrington",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "A Game-Based Approach for Collecting Semantic Annotations of Music.",
+    "pages": "535-538",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p535_turnbull.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#TurnbullLBL07"
+  },
+  "conf/ismir/JonesDE07": {
+    "@key": "conf/ismir/JonesDE07",
+    "@mdate": "2011-08-15",
+    "author": [
+      "M. Cameron Jones",
+      "J. Stephen Downie",
+      "Andreas F. Ehmann"
+    ],
+    "title": "Human Similarity Judgments: Implications for the Design of Formal Evaluations.",
+    "pages": "539-542",
+    "year": "2007",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2007.ismir.net/proceedings/ISMIR2007_p539_jones.pdf",
+    "crossref": "conf/ismir/2007",
+    "url": "db/conf/ismir/ismir2007.html#JonesDE07"
+  },
+  "conf/ismir/WangFC08": {
+    "@key": "conf/ismir/WangFC08",
+    "@mdate": "2018-01-25",
+    "author": [
+      "Ge Wang 0002",
+      "Rebecca Fiebrink",
+      "Perry R. Cook"
+    ],
+    "title": "Music Information Retrieval in ChucK; Real-Time Prototyping for MIR Systems & Performance.",
+    "pages": "23",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#WangFC08"
+  },
+  "conf/ismir/Dubnov08": {
+    "@key": "conf/ismir/Dubnov08",
+    "@mdate": "2009-12-28",
+    "author": "Shlomo Dubnov",
+    "title": "Computational Temporal Aesthetics; Relation Between Surprise, Salience and Aesthetics in Music and Audio Signals.",
+    "pages": "23",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Dubnov08"
+  },
+  "conf/ismir/LamereP08": {
+    "@key": "conf/ismir/LamereP08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Paul Lamere",
+      "Elias Pampalk"
+    ],
+    "title": "Social Tags and Music Information Retrieval.",
+    "pages": "24",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#LamereP08"
+  },
+  "conf/ismir/Selfridge-FieldS08": {
+    "@key": "conf/ismir/Selfridge-FieldS08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Eleanor Selfridge-Field",
+      "Craig Stuart Sapp"
+    ],
+    "title": "Survey of Symbolic Data for Music Applications.",
+    "pages": "24",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Selfridge-FieldS08"
+  },
+  "conf/ismir/ScholzR08": {
+    "@key": "conf/ismir/ScholzR08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Ricardo Scholz",
+      "Geber Ramalho"
+    ],
+    "title": "COCHONUT: Recognizing Complex Chords from MIDI Guitar Sequences.",
+    "pages": "27-32",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_200.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#ScholzR08"
+  },
+  "conf/ismir/ZhangG08": {
+    "@key": "conf/ismir/ZhangG08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Xinglin Zhang",
+      "David Gerhard"
+    ],
+    "title": "Chord Recognition using Instrument Voicing Constraints.",
+    "pages": "33-38",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_241.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#ZhangG08"
+  },
+  "conf/ismir/SumiIYKOO08": {
+    "@key": "conf/ismir/SumiIYKOO08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Kouhei Sumi",
+      "Katsutoshi Itoyama",
+      "Kazuyoshi Yoshii",
+      "Kazunori Komatani",
+      "Tetsuya Ogata",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Automatic Chord Recognition Based on Probabilistic Integration of Chord Transition and Bass Pitch Estimation.",
+    "pages": "39-44",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_236.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#SumiIYKOO08"
+  },
+  "conf/ismir/MauchD08": {
+    "@key": "conf/ismir/MauchD08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Matthias Mauch",
+      "Simon Dixon"
+    ],
+    "title": "A Discrete Mixture Model for Chord Labelling.",
+    "pages": "45-50",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_214.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#MauchD08"
+  },
+  "conf/ismir/HaasVW08": {
+    "@key": "conf/ismir/HaasVW08",
+    "@mdate": "2015-11-04",
+    "author": [
+      "W. Bas de Haas",
+      "Remco C. Veltkamp",
+      "Frans Wiering"
+    ],
+    "title": "Tonal Pitch Step Distance: a Similarity Measure for Chord Progressions.",
+    "pages": "51-56",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_252.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#HaasVW08"
+  },
+  "conf/ismir/ChuanC08": {
+    "@key": "conf/ismir/ChuanC08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Ching-Hua Chuan",
+      "Elaine Chew"
+    ],
+    "title": "Evaluating and Visualizing Effectiveness of Style Emulation in Musical Accompaniment.",
+    "pages": "57-62",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_179.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#ChuanC08"
+  },
+  "conf/ismir/AngladeD08": {
+    "@key": "conf/ismir/AngladeD08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Amelie Anglade",
+      "Simon Dixon"
+    ],
+    "title": "Characterisation of Harmony With Inductive Logic Programming.",
+    "pages": "63-68",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_189.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#AngladeD08"
+  },
+  "conf/ismir/BergeronC08": {
+    "@key": "conf/ismir/BergeronC08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Mathieu Bergeron",
+      "Darrell Conklin"
+    ],
+    "title": "Structured Polyphonic Patterns.",
+    "pages": "69-74",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_177.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#BergeronC08"
+  },
+  "conf/ismir/MaxwellE08": {
+    "@key": "conf/ismir/MaxwellE08",
+    "@mdate": "2013-12-05",
+    "author": [
+      "James B. Maxwell",
+      "Arne Eigenfeldt"
+    ],
+    "title": "A Music Database and Query System for Recombinant Composition.",
+    "pages": "75-80",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_158.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#MaxwellE08"
+  },
+  "conf/ismir/RafailidisNMC08": {
+    "@key": "conf/ismir/RafailidisNMC08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Dimitrios Rafailidis",
+      "Alexandros Nanopoulos",
+      "Yannis Manolopoulos",
+      "Emilios Cambouropoulos"
+    ],
+    "title": "Detection of Stream Segments in Symbolic Musical Data.",
+    "pages": "83-88",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_163.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#RafailidisNMC08"
+  },
+  "conf/ismir/PearceMW08": {
+    "@key": "conf/ismir/PearceMW08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Marcus Pearce",
+      "Daniel M\u00fcllensiefen",
+      "Geraint A. Wiggins"
+    ],
+    "title": "A Comparison of Statistical and Rule-Based Models of Melodic Segmentation.",
+    "pages": "89-94",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_228.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#PearceMW08"
+  },
+  "conf/ismir/SkalakHP08": {
+    "@key": "conf/ismir/SkalakHP08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Michael Skalak",
+      "Jinyu Han",
+      "Bryan Pardo"
+    ],
+    "title": "Speeding Melody Search With Vantage Point Trees.",
+    "pages": "95-100",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_216.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#SkalakHP08"
+  },
+  "conf/ismir/VolkKGWVG08": {
+    "@key": "conf/ismir/VolkKGWVG08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Anja Volk",
+      "Peter van Kranenburg",
+      "J\u00f6rg Garbers",
+      "Frans Wiering",
+      "Remco C. Veltkamp",
+      "Louis P. Grijp"
+    ],
+    "title": "A Manual Annotation Method for Melodic Similarity and the Study of Melody Feature Sets.",
+    "pages": "101-106",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_165.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#VolkKGWVG08"
+  },
+  "conf/ismir/HamanakaHT08": {
+    "@key": "conf/ismir/HamanakaHT08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Masatoshi Hamanaka",
+      "Keiji Hirata",
+      "Satoshi Tojo"
+    ],
+    "title": "Melody Expectation Method Based on GTTM and TPS.",
+    "pages": "107-112",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_142.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#HamanakaHT08"
+  },
+  "conf/ismir/TsaiLL08": {
+    "@key": "conf/ismir/TsaiLL08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Wei-Ho Tsai",
+      "Shih-Jie Liao",
+      "Catherine Lai"
+    ],
+    "title": "Automatic Identification of Simultaneous Singers in Duet Recordings.",
+    "pages": "115-120",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_188.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#TsaiLL08"
+  },
+  "conf/ismir/FengNH08": {
+    "@key": "conf/ismir/FengNH08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Ling Feng",
+      "Andreas Brinch Nielsen",
+      "Lars Kai Hansen"
+    ],
+    "title": "Vocal Segment Classification in Popular Music.",
+    "pages": "121-126",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_201.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#FengNH08"
+  },
+  "conf/ismir/LittleP08": {
+    "@key": "conf/ismir/LittleP08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "David Little",
+      "Bryan Pardo"
+    ],
+    "title": "Learning Musical Instruments from Mixtures of Audio with Weak Labels.",
+    "pages": "127-132",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_239.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#LittleP08"
+  },
+  "conf/ismir/ItoyamaGKOO08": {
+    "@key": "conf/ismir/ItoyamaGKOO08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Katsutoshi Itoyama",
+      "Masataka Goto",
+      "Kazunori Komatani",
+      "Tetsuya Ogata",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Instrument Equalizer for Query-by-Example Retrieval: Improving Sound Source Separation Based on Integrated Harmonic and Inharmonic Models.",
+    "pages": "133-138",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_264.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#ItoyamaGKOO08"
+  },
+  "conf/ismir/OnoMKS08": {
+    "@key": "conf/ismir/OnoMKS08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Nobutaka Ono",
+      "Kenichi Miyamoto",
+      "Hirokazu Kameoka",
+      "Shigeki Sagayama"
+    ],
+    "title": "A Real-time Equalizer of Harmonic and Percussive Components in Music Signals.",
+    "pages": "139-144",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_120.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#OnoMKS08"
+  },
+  "conf/ismir/Knopke08": {
+    "@key": "conf/ismir/Knopke08",
+    "@mdate": "2009-12-28",
+    "author": "Ian Knopke",
+    "title": "The PerlHumdrum and PerlLilypond Toolkits for Symbolic Music Information Retrieval.",
+    "pages": "147-152",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_253.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Knopke08"
+  },
+  "conf/ismir/FiebrinkWC08": {
+    "@key": "conf/ismir/FiebrinkWC08",
+    "@mdate": "2018-01-25",
+    "author": [
+      "Rebecca Fiebrink",
+      "Ge Wang 0002",
+      "Perry R. Cook"
+    ],
+    "title": "Support for MIR Prototyping and Real-Time Applications in the ChucK Programming Language.",
+    "pages": "153-158",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_151.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#FiebrinkWC08"
+  },
+  "conf/ismir/MagnoS08": {
+    "@key": "conf/ismir/MagnoS08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Terence Magno",
+      "Carl Sable"
+    ],
+    "title": "A Comparison of Signal Based Music Recommendation to Genre Labels, Collaborative Filtering, Musicological Analysis, Human Recommendation and Random Baseline.",
+    "pages": "161-166",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_157.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#MagnoS08"
+  },
+  "conf/ismir/MohB08": {
+    "@key": "conf/ismir/MohB08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Yvonne Moh",
+      "Joachim M. Buhmann"
+    ],
+    "title": "Kernel Expansion for Online Preference Tracking.",
+    "pages": "167-172",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_119.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#MohB08"
+  },
+  "conf/ismir/FlexerSGW08": {
+    "@key": "conf/ismir/FlexerSGW08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Arthur Flexer",
+      "Dominik Schnitzer",
+      "Martin Gasser",
+      "Gerhard Widmer"
+    ],
+    "title": "Playlist Generation using Start and End Songs.",
+    "pages": "173-178",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_143.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#FlexerSGW08"
+  },
+  "conf/ismir/DoplerSPK08": {
+    "@key": "conf/ismir/DoplerSPK08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Markus Dopler",
+      "Markus Schedl",
+      "Tim Pohle",
+      "Peter Knees"
+    ],
+    "title": "Accessing Music Collections Via Representative Cluster Prototypes in a Hierarchical Organization Scheme.",
+    "pages": "179-184",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_169.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#DoplerSPK08"
+  },
+  "conf/ismir/CunninghamZ08": {
+    "@key": "conf/ismir/CunninghamZ08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Sally Jo Cunningham",
+      "Edmond Zhang"
+    ],
+    "title": "Development of a Music Organizer for Children.",
+    "pages": "185-190",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_123.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#CunninghamZ08"
+  },
+  "conf/ismir/NiitsumaTDOS08": {
+    "@key": "conf/ismir/NiitsumaTDOS08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Masahiro Niitsuma",
+      "Hiroshi Takaesu",
+      "Hazuki Demachi",
+      "Masaki Oono",
+      "Hiroaki Saito"
+    ],
+    "title": "Development of an Automatic Music Selection System Based on Runner's Step Frequency.",
+    "pages": "193-198",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_167.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#NiitsumaTDOS08"
+  },
+  "conf/ismir/MurataNYTTOHT08": {
+    "@key": "conf/ismir/MurataNYTTOHT08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Kazumasa Murata",
+      "Kazuhiro Nakadai",
+      "Kazuyoshi Yoshii",
+      "Ryu Takeda",
+      "Toyotaka Torii",
+      "Hiroshi G. Okuno",
+      "Yuji Hasegawa",
+      "Hiroshi Tsujino"
+    ],
+    "title": "A Robot Singer with Music Recognition Based on Real-Time Beat Tracking.",
+    "pages": "199-204",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_199.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#MurataNYTTOHT08"
+  },
+  "conf/ismir/GasserFW08": {
+    "@key": "conf/ismir/GasserFW08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Martin Gasser",
+      "Arthur Flexer",
+      "Gerhard Widmer"
+    ],
+    "title": "Streamcatcher: Integrated Visualization of Music Clips and Online Audio Streams.",
+    "pages": "205-210",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_178.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#GasserFW08"
+  },
+  "conf/ismir/YoshiiG08": {
+    "@key": "conf/ismir/YoshiiG08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Kazuyoshi Yoshii",
+      "Masataka Goto"
+    ],
+    "title": "Music Thumbnailer: Visualizing Musical Pieces in Thumbnail Images Based on Acoustic Features.",
+    "pages": "211-216",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_166.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#YoshiiG08"
+  },
+  "conf/ismir/SymeonidisRNM08": {
+    "@key": "conf/ismir/SymeonidisRNM08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Panagiotis Symeonidis",
+      "Maria M. Ruxanda",
+      "Alexandros Nanopoulos",
+      "Yannis Manolopoulos"
+    ],
+    "title": "Ternary Semantic Analysis of Social Tags for Personalized Music Recommendation.",
+    "pages": "219-224",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_102.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#SymeonidisRNM08"
+  },
+  "conf/ismir/TurnbullBL08": {
+    "@key": "conf/ismir/TurnbullBL08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Douglas Turnbull",
+      "Luke Barrington",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Five Approaches to Collecting Tags for Music.",
+    "pages": "225-230",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_128.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#TurnbullBL08"
+  },
+  "conf/ismir/KimSE08": {
+    "@key": "conf/ismir/KimSE08",
+    "@mdate": "2012-10-26",
+    "author": [
+      "Youngmoo E. Kim",
+      "Erik M. Schmidt",
+      "Lloyd Emelle"
+    ],
+    "title": "MoodSwings: A Collaborative Game for Music Mood Label Collection.",
+    "pages": "231-236",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_257.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#KimSE08"
+  },
+  "conf/ismir/DuanLZ08": {
+    "@key": "conf/ismir/DuanLZ08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Zhiyao Duan",
+      "Lie Lu",
+      "Changshui Zhang"
+    ],
+    "title": "Collective Annotation of Music from Multiple Semantic Categories.",
+    "pages": "237-242",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_250.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#DuanLZ08"
+  },
+  "conf/ismir/PeetersFR08": {
+    "@key": "conf/ismir/PeetersFR08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Geoffroy Peeters",
+      "David Fenech",
+      "Xavier Rodet"
+    ],
+    "title": "MCIpa: A Music Content Information Player and Annotator for Discovering Music.",
+    "pages": "243-248",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_190.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#PeetersFR08"
+  },
+  "conf/ismir/CorthautGVD08": {
+    "@key": "conf/ismir/CorthautGVD08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Nik Corthaut",
+      "Sten Govaerts",
+      "Katrien Verbert",
+      "Erik Duval"
+    ],
+    "title": "Connecting the Dots: Music Metadata Generation, Schemas and Applications.",
+    "pages": "249-254",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_213.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#CorthautGVD08"
+  },
+  "conf/ismir/SordoCBG08": {
+    "@key": "conf/ismir/SordoCBG08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Mohamed Sordo",
+      "\u00d2scar Celma",
+      "Martin Blech",
+      "Enric Guaus"
+    ],
+    "title": "The Quest for Musical Genres: Do the Experts and the Wisdom of Crowds Agree?",
+    "pages": "255-260",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_267.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#SordoCBG08"
+  },
+  "conf/ismir/RaimondS08": {
+    "@key": "conf/ismir/RaimondS08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Yves Raimond",
+      "Mark B. Sandler"
+    ],
+    "title": "A Web of Musical Information.",
+    "pages": "263-268",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_109.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#RaimondS08"
+  },
+  "conf/ismir/JacobsonSF08": {
+    "@key": "conf/ismir/JacobsonSF08",
+    "@mdate": "2010-01-11",
+    "author": [
+      "Kurt Jacobson",
+      "Mark B. Sandler",
+      "Benjamin Fields"
+    ],
+    "title": "Using Audio Analysis and Network Structure to Identify Communities in On-Line Social Networks of Artists.",
+    "pages": "269-274",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_118.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#JacobsonSF08"
+  },
+  "conf/ismir/BaccigalupoPD08": {
+    "@key": "conf/ismir/BaccigalupoPD08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Claudio Baccigalupo",
+      "Enric Plaza",
+      "Justin Donaldson"
+    ],
+    "title": "Uncovering Affinity of Artists to Multiple Genres from Social Behaviour Data.",
+    "pages": "275-280",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_131.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#BaccigalupoPD08"
+  },
+  "conf/ismir/FujiharaGO08": {
+    "@key": "conf/ismir/FujiharaGO08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Hiromasa Fujihara",
+      "Masataka Goto",
+      "Jun Ogata"
+    ],
+    "title": "Hyperlinking Lyrics: A Method for Creating Hyperlinks Between Phrases in Song Lyrics.",
+    "pages": "281-286",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_111.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#FujiharaGO08"
+  },
+  "conf/ismir/KleedorferKP08": {
+    "@key": "conf/ismir/KleedorferKP08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Florian Kleedorfer",
+      "Peter Knees",
+      "Tim Pohle"
+    ],
+    "title": "Oh Oh Oh Whoah! Towards Automatic Topic Detection In Song Lyrics.",
+    "pages": "287-292",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_211.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#KleedorferKP08"
+  },
+  "conf/ismir/RileyHG08": {
+    "@key": "conf/ismir/RileyHG08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Matthew Riley",
+      "Eric Heinen",
+      "Joydeep Ghosh"
+    ],
+    "title": "A Text Retrieval Approach to Content-Based Audio Hashing.",
+    "pages": "295-300",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_220.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#RileyHG08"
+  },
+  "conf/ismir/MiottoO08": {
+    "@key": "conf/ismir/MiottoO08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Riccardo Miotto",
+      "Nicola Orio"
+    ],
+    "title": "A Music Identification System Based on Chroma Indexing and Statistical Modeling.",
+    "pages": "301-306",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_234.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#MiottoO08"
+  },
+  "conf/ismir/GodfreyC08": {
+    "@key": "conf/ismir/GodfreyC08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Mark Godfrey",
+      "Parag Chordia"
+    ],
+    "title": "Hubs and Homogeneity: Improving Content-Based Music Modeling.",
+    "pages": "307-312",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_266.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#GodfreyC08"
+  },
+  "conf/ismir/SlaneyWW08": {
+    "@key": "conf/ismir/SlaneyWW08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Malcolm Slaney",
+      "Kilian Q. Weinberger",
+      "William White"
+    ],
+    "title": "Learning a Metric for Music Similarity.",
+    "pages": "313-318",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_148.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#SlaneyWW08"
+  },
+  "conf/ismir/LiuWSTC08": {
+    "@key": "conf/ismir/LiuWSTC08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Yuxiang Liu",
+      "Ye Wang",
+      "Arun Shenoy",
+      "Wei-Ho Tsai",
+      "Lianhong Cai"
+    ],
+    "title": "Clustering Music Recordings by Their Keys.",
+    "pages": "319-324",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_161.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#LiuWSTC08"
+  },
+  "conf/ismir/TrohidisTKV08": {
+    "@key": "conf/ismir/TrohidisTKV08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Konstantinos Trohidis",
+      "Grigorios Tsoumakas",
+      "George Kalliris",
+      "Ioannis P. Vlahavas"
+    ],
+    "title": "Multi-Label Classification of Music into Emotions.",
+    "pages": "325-330",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_275.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#TrohidisTKV08"
+  },
+  "conf/ismir/DoraisamyGNSU08": {
+    "@key": "conf/ismir/DoraisamyGNSU08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Shyamala Doraisamy",
+      "Shahram Golzari",
+      "Noris Mohd. Norowi",
+      "Md Nasir Sulaiman",
+      "Nur Izura Udzir"
+    ],
+    "title": "A Study on Feature Selection and Classification Techniques for Automatic Genre Classification of Traditional Malay Music.",
+    "pages": "331-336",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_256.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#DoraisamyGNSU08"
+  },
+  "conf/ismir/MayerNR08": {
+    "@key": "conf/ismir/MayerNR08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Rudolf Mayer",
+      "Robert Neumayer",
+      "Andreas Rauber"
+    ],
+    "title": "Rhyme and Style Features for Musical Genre Classification by Song Lyrics.",
+    "pages": "337-342",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_235.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#MayerNR08"
+  },
+  "conf/ismir/ManarisKRZ08": {
+    "@key": "conf/ismir/ManarisKRZ08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Bill Z. Manaris",
+      "Dwight Krehbiel",
+      "Patrick Roos",
+      "Thomas Zalonis"
+    ],
+    "title": "Armonique: Experiments in Content-Based Similarity Retrieval using Power-Law Melodic and Timbre Metrics.",
+    "pages": "343-348",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_249.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#ManarisKRZ08"
+  },
+  "conf/ismir/HoffmanBC08": {
+    "@key": "conf/ismir/HoffmanBC08",
+    "@mdate": "2010-09-06",
+    "author": [
+      "Matthew D. Hoffman",
+      "David M. Blei",
+      "Perry R. Cook"
+    ],
+    "title": "Content-Based Musical Similarity Computation using the Hierarchical Dirichlet Process.",
+    "pages": "349-354",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_130.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#HoffmanBC08"
+  },
+  "conf/ismir/PachetR08": {
+    "@key": "conf/ismir/PachetR08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Fran\u00e7ois Pachet",
+      "Pierre Roy"
+    ],
+    "title": "Hit Song Science Is Not Yet a Science.",
+    "pages": "355-360",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_133.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#PachetR08"
+  },
+  "conf/ismir/KirlinU08": {
+    "@key": "conf/ismir/KirlinU08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Phillip B. Kirlin",
+      "Paul E. Utgoff"
+    ],
+    "title": "A Framework for Automated Schenkerian Analysis.",
+    "pages": "363-368",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_229.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#KirlinU08"
+  },
+  "conf/ismir/PaulusK08": {
+    "@key": "conf/ismir/PaulusK08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Jouni Paulus",
+      "Anssi Klapuri"
+    ],
+    "title": "Music Structure Analysis Using a Probabilistic Fitness Measure and an Integrated Musicological Model.",
+    "pages": "369-374",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_186.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#PaulusK08"
+  },
+  "conf/ismir/Lukashevich08": {
+    "@key": "conf/ismir/Lukashevich08",
+    "@mdate": "2009-12-28",
+    "author": "Hanna M. Lukashevich",
+    "title": "Towards Quantitative Measures of Evaluating Song Segmentation.",
+    "pages": "375-380",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_219.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Lukashevich08"
+  },
+  "conf/ismir/GarbersW08": {
+    "@key": "conf/ismir/GarbersW08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "J\u00f6rg Garbers",
+      "Frans Wiering"
+    ],
+    "title": "Towards Structural Alignment of Folk Songs.",
+    "pages": "381-386",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_172.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#GarbersW08"
+  },
+  "conf/ismir/MullerE08": {
+    "@key": "conf/ismir/MullerE08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Meinard M\u00fcller",
+      "Sebastian Ewert"
+    ],
+    "title": "Joint Structure Analysis with Applications to Music Annotation and Synchronization.",
+    "pages": "389-394",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_115.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#MullerE08"
+  },
+  "conf/ismir/LeeC08": {
+    "@key": "conf/ismir/LeeC08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Kyogu Lee",
+      "Markus Cremer"
+    ],
+    "title": "Segmentation-Based Lyrics-Audio Alignment using Dynamic Programming.",
+    "pages": "395-400",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_126.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#LeeC08"
+  },
+  "conf/ismir/DugganOGC08": {
+    "@key": "conf/ismir/DugganOGC08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Bryan Duggan",
+      "Brendan O'Shea",
+      "Mikel Gainza",
+      "Padraig Cunningham"
+    ],
+    "title": "Machine Annotation of Sets of Traditional Irish Dance Tunes.",
+    "pages": "401-406",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_137.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#DugganOGC08"
+  },
+  "conf/ismir/BurgoyneDPF08": {
+    "@key": "conf/ismir/BurgoyneDPF08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "John Ashley Burgoyne",
+      "Johanna Devaney",
+      "Laurent Pugin",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Enhanced Bleedthrough Correction for Early Music Documents with Recto-Verso Registration.",
+    "pages": "407-412",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_221.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#BurgoyneDPF08"
+  },
+  "conf/ismir/FremereyMKC08": {
+    "@key": "conf/ismir/FremereyMKC08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Christian Fremerey",
+      "Meinard M\u00fcller",
+      "Frank Kurth",
+      "Michael Clausen"
+    ],
+    "title": "Automatic Mapping of Scanned Sheet Music to Audio Recordings.",
+    "pages": "413-418",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_116.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#FremereyMKC08"
+  },
+  "conf/ismir/PuginHBF08": {
+    "@key": "conf/ismir/PuginHBF08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Laurent Pugin",
+      "Jason Hockman",
+      "John Ashley Burgoyne",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Gamera Versus Aruspix: Two Optical Music Recognition Approaches.",
+    "pages": "419-424",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_247.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#PuginHBF08"
+  },
+  "conf/ismir/BurredCPRS08": {
+    "@key": "conf/ismir/BurredCPRS08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Juan Jos\u00e9 Burred",
+      "Carmine-Emanuele Cella",
+      "Geoffroy Peeters",
+      "Axel R\u00f6bel",
+      "Diemo Schwarz"
+    ],
+    "title": "Using the SDIF Sound Description Interchange Format for Audio Features.",
+    "pages": "427-432",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_197.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#BurredCPRS08"
+  },
+  "conf/ismir/GansemanSD08": {
+    "@key": "conf/ismir/GansemanSD08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Joachim Ganseman",
+      "Paul Scheunders",
+      "Wim D'haes"
+    ],
+    "title": "Using XQuery on MusicXML Databases for Musicological Analysis.",
+    "pages": "433-438",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_217.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#GansemanSD08"
+  },
+  "conf/ismir/Riley08": {
+    "@key": "conf/ismir/Riley08",
+    "@mdate": "2009-12-28",
+    "author": "Jenn Riley",
+    "title": "Application of the Functional Requirements for Bibliographic Records (FRBR) to Music.",
+    "pages": "439-444",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_244.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Riley08"
+  },
+  "conf/ismir/DollMK08": {
+    "@key": "conf/ismir/DollMK08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Travis M. Doll",
+      "Raymond Migneco",
+      "Youngmoo E. Kim"
+    ],
+    "title": "Online Activities for Music Information and Acoustics Education and Psychoacoustic Data Collection.",
+    "pages": "445-450",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_246.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#DollMK08"
+  },
+  "conf/ismir/SillaKK08": {
+    "@key": "conf/ismir/SillaKK08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Carlos Nascimento Silla Jr.",
+      "Alessandro L. Koerich",
+      "Celso A. A. Kaestner"
+    ],
+    "title": "The Latin Music Database.",
+    "pages": "451-456",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_106.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#SillaKK08"
+  },
+  "conf/ismir/Winget08": {
+    "@key": "conf/ismir/Winget08",
+    "@mdate": "2009-12-28",
+    "author": "Megan A. Winget",
+    "title": "The Liner Notes Digitization Project: Providing Users with Cultural, Historical, and Critical Music Information.",
+    "pages": "457-461",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_268.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Winget08"
+  },
+  "conf/ismir/HuDLBE08": {
+    "@key": "conf/ismir/HuDLBE08",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "J. Stephen Downie",
+      "Cyril Laurier",
+      "Mert Bay",
+      "Andreas F. Ehmann"
+    ],
+    "title": "The 2007 MIREX Audio Mood Classification Task: Lessons Learned.",
+    "pages": "462-467",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_263.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#HuDLBE08"
+  },
+  "conf/ismir/DownieBEJ08": {
+    "@key": "conf/ismir/DownieBEJ08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "J. Stephen Downie",
+      "Mert Bay",
+      "Andreas F. Ehmann",
+      "M. Cameron Jones"
+    ],
+    "title": "Audio Cover Song Identification: MIREX 2006-2007 Results and Analyses.",
+    "pages": "468-474",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_265.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#DownieBEJ08"
+  },
+  "conf/ismir/InskipMR08": {
+    "@key": "conf/ismir/InskipMR08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Charlie Inskip",
+      "Andy MacFarlane",
+      "Pauline Rafferty"
+    ],
+    "title": "Music, Movies and Meaning: Communication in Film-Makers' Search for Pre-Existing Music, and the Implications for Music Information Retrieval.",
+    "pages": "477-482",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_117.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#InskipMR08"
+  },
+  "conf/ismir/RamirezPK08": {
+    "@key": "conf/ismir/RamirezPK08",
+    "@mdate": "2018-08-19",
+    "author": [
+      "Rafael Ram\u00edrez 0001",
+      "Alfonso P\u00e9rez",
+      "Stefan Kersten"
+    ],
+    "title": "Performer Identification in Celtic Violin Recordings.",
+    "pages": "483-488",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_136.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#RamirezPK08"
+  },
+  "conf/ismir/HashidaMK08": {
+    "@key": "conf/ismir/HashidaMK08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Mitsuyo Hashida",
+      "Toshie Matsui",
+      "Haruhiro Katayose"
+    ],
+    "title": "A New Music Database Describing Deviation Information of Performance Expressions.",
+    "pages": "489-494",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_173.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#HashidaMK08"
+  },
+  "conf/ismir/Molina-SolanaAG08": {
+    "@key": "conf/ismir/Molina-SolanaAG08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Miguel Molina-Solana",
+      "Josep Llu\u00eds Arcos",
+      "Emilia G\u00f3mez"
+    ],
+    "title": "Using Expressive Trends for Identifying Violin P erformers.",
+    "pages": "495-500",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_210.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Molina-SolanaAG08"
+  },
+  "conf/ismir/Sapp08": {
+    "@key": "conf/ismir/Sapp08",
+    "@mdate": "2009-12-28",
+    "author": "Craig Sapp",
+    "title": "Hybrid Numeric/Rank Similarity Metrics for Musical Performance Analysis.",
+    "pages": "501-506",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_240.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Sapp08"
+  },
+  "conf/ismir/MeintanisS08": {
+    "@key": "conf/ismir/MeintanisS08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Konstantinos A. Meintanis",
+      "Frank M. Shipman III"
+    ],
+    "title": "Creating and Evaluating Multi-Phrase Music Summaries.",
+    "pages": "507-512",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_233.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#MeintanisS08"
+  },
+  "conf/ismir/TohZW08": {
+    "@key": "conf/ismir/TohZW08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Chee-Chuan Toh",
+      "Bingjun Zhang",
+      "Ye Wang"
+    ],
+    "title": "Multiple-Feature Fusion Based Onset Detection for Solo Singing Voice.",
+    "pages": "515-520",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_127.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#TohZW08"
+  },
+  "conf/ismir/LartillotETF08": {
+    "@key": "conf/ismir/LartillotETF08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Olivier Lartillot",
+      "Tuomas Eerola",
+      "Petri Toiviainen",
+      "Jos\u00e9 Fornari"
+    ],
+    "title": "Multi-Feature Modeling of Pulse Clarity: Design, Validation and Optimization.",
+    "pages": "521-526",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_145.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#LartillotETF08"
+  },
+  "conf/ismir/RavelliRD08": {
+    "@key": "conf/ismir/RavelliRD08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Emmanuel Ravelli",
+      "Ga\u00ebl Richard",
+      "Laurent Daudet"
+    ],
+    "title": "Fast MIR in a Sparse Transform Domain.",
+    "pages": "527-532",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_141.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#RavelliRD08"
+  },
+  "conf/ismir/Camacho08": {
+    "@key": "conf/ismir/Camacho08",
+    "@mdate": "2009-12-28",
+    "author": "Arturo Camacho",
+    "title": "Detection of Pitched/Unpitched Sound using Pitch Strength Clustering.",
+    "pages": "533-537",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_274.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Camacho08"
+  },
+  "conf/ismir/WoodruffLW08": {
+    "@key": "conf/ismir/WoodruffLW08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "John Woodruff",
+      "Yipeng Li",
+      "DeLiang Wang"
+    ],
+    "title": "Resolving Overlapping Harmonics for Monaural Musical Sound Separation using Fundamental Frequency and Common Amplitude Modulation.",
+    "pages": "538-543",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_139.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#WoodruffLW08"
+  },
+  "conf/ismir/Niedermayer08": {
+    "@key": "conf/ismir/Niedermayer08",
+    "@mdate": "2009-12-28",
+    "author": "Bernhard Niedermayer",
+    "title": "Non-Negative Matrix Division for the Automatic Transcription of Polyphonic Music.",
+    "pages": "544-549",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_198.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Niedermayer08"
+  },
+  "conf/ismir/DanielED08": {
+    "@key": "conf/ismir/DanielED08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Adrien Daniel",
+      "Valentin Emiya",
+      "Bertrand David"
+    ],
+    "title": "Perceptually-Based Evaluation of the Errors Usually Made When Automatically Transcribing Music.",
+    "pages": "550-556",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_203.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#DanielED08"
+  },
+  "conf/ismir/FieldsRCJ08": {
+    "@key": "conf/ismir/FieldsRCJ08",
+    "@mdate": "2014-04-16",
+    "author": [
+      "Benjamin Fields",
+      "Christophe Rhodes",
+      "Michael A. Casey",
+      "Kurt Jacobson"
+    ],
+    "title": "Social Playlists and Bottleneck Measurements: Exploiting Musician Social Graphs Using Content-Based Dissimilarity and Pairwise Maximum Flow Values.",
+    "pages": "559-564",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_209.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#FieldsRCJ08"
+  },
+  "conf/ismir/DeliegeCP08": {
+    "@key": "conf/ismir/DeliegeCP08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Fran\u00e7ois Deli\u00e8ge",
+      "Bee Yong Chua",
+      "Torben Bach Pedersen"
+    ],
+    "title": "High-Level Audio Features: Distributed Extraction and Similarity Search.",
+    "pages": "565-570",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_225.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#DeliegeCP08"
+  },
+  "conf/ismir/ChordiaGR08": {
+    "@key": "conf/ismir/ChordiaGR08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Parag Chordia",
+      "Mark Godfrey",
+      "Alex Rae"
+    ],
+    "title": "Extending Content-Based Recommendation: The Case of Indian Classical Music.",
+    "pages": "571-576",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_271.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#ChordiaGR08"
+  },
+  "conf/ismir/MandelE08": {
+    "@key": "conf/ismir/MandelE08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Michael I. Mandel",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "Multiple-Instance Learning for Music Information Retrieval.",
+    "pages": "577-582",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_205.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#MandelE08"
+  },
+  "conf/ismir/PanagakisBK08": {
+    "@key": "conf/ismir/PanagakisBK08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Ioannis Panagakis",
+      "Emmanouil Benetos",
+      "Constantine Kotropoulos"
+    ],
+    "title": "Music Genre Classification: A Multilinear Approach.",
+    "pages": "583-588",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_181.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#PanagakisBK08"
+  },
+  "conf/ismir/RabbatP08": {
+    "@key": "conf/ismir/RabbatP08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Patrick Rabbat",
+      "Fran\u00e7ois Pachet"
+    ],
+    "title": "Direct and Inverse Inference in Music Databases: How to Make at Song Funk?",
+    "pages": "589-594",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_135.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#RabbatP08"
+  },
+  "conf/ismir/McKayF08": {
+    "@key": "conf/ismir/McKayF08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Cory McKay",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Combining Features Extracted from Audio, Symbolic and Cultural Sources.",
+    "pages": "597-602",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_259.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#McKayF08"
+  },
+  "conf/ismir/ManzagolBE08": {
+    "@key": "conf/ismir/ManzagolBE08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Pierre-Antoine Manzagol",
+      "Thierry Bertin-Mahieux",
+      "Douglas Eck"
+    ],
+    "title": "On the Use of Sparce Time Relative Auditory Codes for Music.",
+    "pages": "603-608",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_261.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#ManzagolBE08"
+  },
+  "conf/ismir/IzumitaniK08": {
+    "@key": "conf/ismir/IzumitaniK08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Tomonori Izumitani",
+      "Kunio Kashino"
+    ],
+    "title": "A Robust Musical Audio Search Method Based on Diagonal Dynamic Programming Matching of Self-Similarity Matrices.",
+    "pages": "609-613",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_114.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#IzumitaniK08"
+  },
+  "conf/ismir/BarringtonYTL08": {
+    "@key": "conf/ismir/BarringtonYTL08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Luke Barrington",
+      "Mehrdad Yazdani",
+      "Douglas Turnbull",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Combining Feature Kernels for Semantic Music Retrieval.",
+    "pages": "614-619",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_160.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#BarringtonYTL08"
+  },
+  "conf/ismir/TsuchihashiKK08": {
+    "@key": "conf/ismir/TsuchihashiKK08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Yusuke Tsuchihashi",
+      "Tetsuro Kitahara",
+      "Haruhiro Katayose"
+    ],
+    "title": "Using Bass-line Features for Content-Based MIR.",
+    "pages": "620-625",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_171.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#TsuchihashiKK08"
+  },
+  "conf/ismir/Scaringella08": {
+    "@key": "conf/ismir/Scaringella08",
+    "@mdate": "2009-12-28",
+    "author": "Nicolas Scaringella",
+    "title": "Timbre and Rhythmic TRAP-TANDEM Features for Music Information Retrieval.",
+    "pages": "626-632",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_193.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Scaringella08"
+  },
+  "conf/ismir/Flanagan08": {
+    "@key": "conf/ismir/Flanagan08",
+    "@mdate": "2009-12-28",
+    "author": "Patrick Flanagan",
+    "title": "Quantifying Metrical Ambiguity.",
+    "pages": "635-640",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_153.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#Flanagan08"
+  },
+  "conf/ismir/LimaR08": {
+    "@key": "conf/ismir/LimaR08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Ernesto Trajano de Lima",
+      "Geber Ramalho"
+    ],
+    "title": "On Rhythmic Pattern Extraction in Bossa Nova Music.",
+    "pages": "641-646",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_238.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#LimaR08"
+  },
+  "conf/ismir/WrightST08": {
+    "@key": "conf/ismir/WrightST08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Matthew Wright",
+      "W. Andrew Schloss",
+      "George Tzanetakis"
+    ],
+    "title": "Analyzing Afro-Cuban Rhythms using Rotation-Aware Clave Template Matching with Dynamic Programming.",
+    "pages": "647-652",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_273.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#WrightST08"
+  },
+  "conf/ismir/HolzapfelS08": {
+    "@key": "conf/ismir/HolzapfelS08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Andre Holzapfel",
+      "Yannis Stylianou"
+    ],
+    "title": "Beat Tracking using Group Delay Based Onset Detection.",
+    "pages": "653-658",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_174.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#HolzapfelS08"
+  },
+  "conf/ismir/XiaoTLZ08": {
+    "@key": "conf/ismir/XiaoTLZ08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Linxing Xiao",
+      "Aibo Tian",
+      "Wen Li",
+      "Jie Zhou"
+    ],
+    "title": "Using Statistic Model to Capture the Association between Timbre and Perceived Tempo.",
+    "pages": "659-662",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_231.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#XiaoTLZ08"
+  },
+  "conf/ismir/ThulT08": {
+    "@key": "conf/ismir/ThulT08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Eric Thul",
+      "Godfried T. Toussaint"
+    ],
+    "title": "Rhythm Complexity Measures: A Comparison of Mathematical Models of Human Perception and Performance.",
+    "pages": "663-668",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_125.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#ThulT08"
+  },
+  "conf/ismir/OgiharaL08": {
+    "@key": "conf/ismir/OgiharaL08",
+    "@mdate": "2017-09-18",
+    "author": [
+      "Mitsunori Ogihara",
+      "Tao Li 0001"
+    ],
+    "title": "N-Gram Chord Profiles for Composer Style Representation.",
+    "pages": "671-676",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_107.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#OgiharaL08"
+  },
+  "conf/ismir/LemstromMM08": {
+    "@key": "conf/ismir/LemstromMM08",
+    "@mdate": "2010-11-08",
+    "author": [
+      "Kjell Lemstr\u00f6m",
+      "Niko Mikkil\u00e4",
+      "Veli M\u00e4kinen"
+    ],
+    "title": "Fast Index Based Filters for Music Retrieval.",
+    "pages": "677-682",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_132.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#LemstromMM08"
+  },
+  "conf/ismir/TypkeW08": {
+    "@key": "conf/ismir/TypkeW08",
+    "@mdate": "2009-12-28",
+    "author": [
+      "Rainer Typke",
+      "Agatha Walczak-Typke"
+    ],
+    "title": "A Tunneling-Vantage Indexing Method for Non-Metrics.",
+    "pages": "683-688",
+    "year": "2008",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2008.ismir.net/papers/ISMIR2008_110.pdf",
+    "crossref": "conf/ismir/2008",
+    "url": "db/conf/ismir/ismir2008.html#TypkeW08"
+  },
+  "conf/ismir/DownieBC09": {
+    "@key": "conf/ismir/DownieBC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "J. Stephen Downie",
+      "Donald Byrd",
+      "Tim Crawford"
+    ],
+    "title": "Ten Years of ISMIR: Reflections on Challenges and Opportunities.",
+    "pages": "13-18",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/keynote1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#DownieBC09"
+  },
+  "conf/ismir/BrethertonSSPEBL09": {
+    "@key": "conf/ismir/BrethertonSSPEBL09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "David Bretherton",
+      "Daniel A. Smith",
+      "Monica M. C. Schraefel",
+      "Richard Polfreman",
+      "Mark Everist",
+      "Jeanice Brooks",
+      "Joe Lambert"
+    ],
+    "title": "Integrating Musicology's Heterogeneous Data Sources for Better Exploration.",
+    "pages": "27-32",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS1-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#BrethertonSSPEBL09"
+  },
+  "conf/ismir/JacobsonRS09": {
+    "@key": "conf/ismir/JacobsonRS09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Kurt Jacobson",
+      "Yves Raimond",
+      "Mark B. Sandler"
+    ],
+    "title": "An Ecosystem for Transparent Music Similarity in an Open World.",
+    "pages": "33-38",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS1-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#JacobsonRS09"
+  },
+  "conf/ismir/HankinsonPF09": {
+    "@key": "conf/ismir/HankinsonPF09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Andrew Hankinson",
+      "Laurent Pugin",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Interfaces for Document Representation in Digital Music Libraries.",
+    "pages": "39-44",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS1-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HankinsonPF09"
+  },
+  "conf/ismir/GodoyJ09": {
+    "@key": "conf/ismir/GodoyJ09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Rolf Inge God\u00f8y",
+      "Alexander Refsum Jensenius"
+    ],
+    "title": "Body Movement in Music Information Retrieval.",
+    "pages": "45-50",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS1-4.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#GodoyJ09"
+  },
+  "conf/ismir/GrachtenW09": {
+    "@key": "conf/ismir/GrachtenW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Maarten Grachten",
+      "Gerhard Widmer"
+    ],
+    "title": "Who Is Who in the End? Recognizing Pianists by Their Final Ritardandi.",
+    "pages": "51-56",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS1-5.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#GrachtenW09"
+  },
+  "conf/ismir/LeeJD09": {
+    "@key": "conf/ismir/LeeJD09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jin Ha Lee",
+      "M. Cameron Jones",
+      "J. Stephen Downie"
+    ],
+    "title": "An Analysis of ISMIR Proceedings: Patterns of Authorship, Topic, and Citation.",
+    "pages": "57-62",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#LeeJD09"
+  },
+  "conf/ismir/GrachtenSPW09": {
+    "@key": "conf/ismir/GrachtenSPW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Maarten Grachten",
+      "Markus Schedl",
+      "Tim Pohle",
+      "Gerhard Widmer"
+    ],
+    "title": "The ISMIR Cloud: A Decade of ISMIR Conferences at Your Fingertips.",
+    "pages": "63-68",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#GrachtenSPW09"
+  },
+  "conf/ismir/MullerKSEC09": {
+    "@key": "conf/ismir/MullerKSEC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Meinard M\u00fcller",
+      "Verena Konz",
+      "Andi Scharfstein",
+      "Sebastian Ewert",
+      "Michael Clausen"
+    ],
+    "title": "Towards Automated Extraction of Tempo Parameters from Expressive Music Recordings.",
+    "pages": "69-74",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#MullerKSEC09"
+  },
+  "conf/ismir/Marolt09": {
+    "@key": "conf/ismir/Marolt09",
+    "@mdate": "2011-08-15",
+    "author": "Matija Marolt",
+    "title": "Probabilistic Segmentation and Labeling of Ethnomusicological Field Recordings.",
+    "pages": "75-80",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-4.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Marolt09"
+  },
+  "conf/ismir/LangloisM09": {
+    "@key": "conf/ismir/LangloisM09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Thibault Langlois",
+      "Gon\u00e7alo Marques"
+    ],
+    "title": "A Music Classification Method based on Timbral Features.",
+    "pages": "81-86",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-5.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#LangloisM09"
+  },
+  "conf/ismir/Stolzenburg09": {
+    "@key": "conf/ismir/Stolzenburg09",
+    "@mdate": "2011-08-15",
+    "author": "Frieder Stolzenburg",
+    "title": "A Periodicity-based Theory for Harmony Perception and Scales.",
+    "pages": "87-92",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-6.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Stolzenburg09"
+  },
+  "conf/ismir/Kobayashi09": {
+    "@key": "conf/ismir/Kobayashi09",
+    "@mdate": "2011-08-15",
+    "author": "Yoshiyuki Kobayashi",
+    "title": "Automatic Generation of Musical Instrument Detector by Using Evolutionary Learning Method.",
+    "pages": "93-98",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-7.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Kobayashi09"
+  },
+  "conf/ismir/HolzapfelS09": {
+    "@key": "conf/ismir/HolzapfelS09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Andre Holzapfel",
+      "Yannis Stylianou"
+    ],
+    "title": "Rhythmic Similarity in Traditional Turkish Music.",
+    "pages": "99-104",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-8.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HolzapfelS09"
+  },
+  "conf/ismir/BenetosHS09": {
+    "@key": "conf/ismir/BenetosHS09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Emmanouil Benetos",
+      "Andre Holzapfel",
+      "Yannis Stylianou"
+    ],
+    "title": "Pitched Instrument Onset Detection based on Auditory Spectra.",
+    "pages": "105-110",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-9.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#BenetosHS09"
+  },
+  "conf/ismir/BaurLB09": {
+    "@key": "conf/ismir/BaurLB09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Dominikus Baur",
+      "Tim Langer",
+      "Andreas Butz"
+    ],
+    "title": "Shades of Music: Letting Users Discover Sub-Song Similarities.",
+    "pages": "111-116",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-10.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#BaurLB09"
+  },
+  "conf/ismir/Degara-QuintelaPT09": {
+    "@key": "conf/ismir/Degara-QuintelaPT09",
+    "@mdate": "2017-07-24",
+    "author": [
+      "Norberto Degara-Quintela",
+      "Antonio S. Pena",
+      "Soledad Torres-Guijarro"
+    ],
+    "title": "A Comparison of Score-Level Fusion Rules for Onset Detection in Music Signals.",
+    "pages": "117-122",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-11.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Degara-QuintelaPT09"
+  },
+  "conf/ismir/HuCY09": {
+    "@key": "conf/ismir/HuCY09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Yajie Hu",
+      "Xiaoou Chen",
+      "Deshun Yang"
+    ],
+    "title": "Lyric-based Song Emotion Detection with Affective Lexicon and Fuzzy Clustering Method.",
+    "pages": "123-128",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-12.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HuCY09"
+  },
+  "conf/ismir/SeyerlehnerKSW09": {
+    "@key": "conf/ismir/SeyerlehnerKSW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Klaus Seyerlehner",
+      "Peter Knees",
+      "Dominik Schnitzer",
+      "Gerhard Widmer"
+    ],
+    "title": "Browsing Music Recommendation Networks.",
+    "pages": "129-134",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-13.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#SeyerlehnerKSW09"
+  },
+  "conf/ismir/IshizakiHT09": {
+    "@key": "conf/ismir/IshizakiHT09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Hiromi Ishizaki",
+      "Keiichiro Hoashi",
+      "Yasuhiro Takishima"
+    ],
+    "title": "Full-Automatic DJ Mixing System with Optimal Tempo Adjustment based on Measurement Function of User Discomfort.",
+    "pages": "135-140",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-14.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#IshizakiHT09"
+  },
+  "conf/ismir/Gross-AmblardRAC09": {
+    "@key": "conf/ismir/Gross-AmblardRAC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "David Gross-Amblard",
+      "Philippe Rigaux",
+      "Lylia Abrouk",
+      "Nadine Cullot"
+    ],
+    "title": "Fingering Watermarking in Symbolic Digital Scores.",
+    "pages": "141-146",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-15.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Gross-AmblardRAC09"
+  },
+  "conf/ismir/YangLLC09": {
+    "@key": "conf/ismir/YangLLC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Yi-Hsuan Yang",
+      "Yu-Ching Lin",
+      "Ann Lee",
+      "Homer H. Chen"
+    ],
+    "title": "Improving Musical Concept Detection by Ordinal Regression and Context Fusion.",
+    "pages": "147-152",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-16.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#YangLLC09"
+  },
+  "conf/ismir/OudreGF09": {
+    "@key": "conf/ismir/OudreGF09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Laurent Oudre",
+      "Yves Grenier",
+      "C\u00e9dric F\u00e9votte"
+    ],
+    "title": "Template-based Chord Recognition : Influence of the Chord Types.",
+    "pages": "153-158",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-17.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#OudreGF09"
+  },
+  "conf/ismir/KarydisNGS09": {
+    "@key": "conf/ismir/KarydisNGS09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ioannis Karydis",
+      "Alexandros Nanopoulos",
+      "Hans-Henning Gabriel",
+      "Myra Spiliopoulou"
+    ],
+    "title": "Tag-Aware Spectral Clustering of Music Items.",
+    "pages": "159-164",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-18.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#KarydisNGS09"
+  },
+  "conf/ismir/SantoroC09": {
+    "@key": "conf/ismir/SantoroC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Christopher Santoro",
+      "Corey Cheng"
+    ],
+    "title": "Multiple F0 Estimation in the Transform Domain.",
+    "pages": "165-170",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-19.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#SantoroC09"
+  },
+  "conf/ismir/Juhasz09": {
+    "@key": "conf/ismir/Juhasz09",
+    "@mdate": "2011-08-15",
+    "author": "Zolt\u00e1n Juh\u00e1sz",
+    "title": "Motive Identification in 22 Folksong Corpora Using Dynamic Time Warping and Self Organizing Maps.",
+    "pages": "171-176",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS1-20.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Juhasz09"
+  },
+  "conf/ismir/GruhneDG09": {
+    "@key": "conf/ismir/GruhneDG09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Matthias Gruhne",
+      "Christian Dittmar",
+      "Daniel G\u00e4rtner"
+    ],
+    "title": "Improving Rhythmic Similarity Computation by Beat Histogram Transformations.",
+    "pages": "177-182",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS2-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#GruhneDG09"
+  },
+  "conf/ismir/ChordiaR09": {
+    "@key": "conf/ismir/ChordiaR09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Parag Chordia",
+      "Alex Rae"
+    ],
+    "title": "Using Source Separation to Improve Tempo Detection.",
+    "pages": "183-188",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS2-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#ChordiaR09"
+  },
+  "conf/ismir/GroscheM09": {
+    "@key": "conf/ismir/GroscheM09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Peter Grosche",
+      "Meinard M\u00fcller"
+    ],
+    "title": "A Mid-Level Representation for Capturing Dominant Tempo and Pulse Information in Music Recordings.",
+    "pages": "189-194",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS2-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#GroscheM09"
+  },
+  "conf/ismir/LubbersJ09": {
+    "@key": "conf/ismir/LubbersJ09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Dominik L\u00fcbbers",
+      "Matthias Jarke"
+    ],
+    "title": "Adaptive Multimodal Exploration of Music Collections.",
+    "pages": "195-200",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#LubbersJ09"
+  },
+  "conf/ismir/HsuCJL09": {
+    "@key": "conf/ismir/HsuCJL09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Chao-Ling Hsu",
+      "Liang-Yu Chen",
+      "Jyh-Shing Roger Jang",
+      "Hsing-Ji Li"
+    ],
+    "title": "Singing Pitch Extraction from Monaural Polyphonic Songs by Contextual Audio Modeling and Singing Harmonic Enhancement.",
+    "pages": "201-206",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HsuCJL09"
+  },
+  "conf/ismir/HoashiHITK09": {
+    "@key": "conf/ismir/HoashiHITK09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Keiichiro Hoashi",
+      "Shuhei Hamawaki",
+      "Hiromi Ishizaki",
+      "Yasuhiro Takishima",
+      "Jiro Katto"
+    ],
+    "title": "Usability Evaluation of Visualization Interfaces for Content-based Music Retrieval Systems.",
+    "pages": "207-212",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HoashiHITK09"
+  },
+  "conf/ismir/LinLTW09": {
+    "@key": "conf/ismir/LinLTW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Heng-Yi Lin",
+      "Yin-Tzu Lin",
+      "Ming-Chun Tien",
+      "Ja-Ling Wu"
+    ],
+    "title": "Music Paste: Concatenating Music Clips based on Chroma and Rhythm Features.",
+    "pages": "213-218",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-4.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#LinLTW09"
+  },
+  "conf/ismir/TsunooOS09": {
+    "@key": "conf/ismir/TsunooOS09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Emiru Tsunoo",
+      "Nobutaka Ono",
+      "Shigeki Sagayama"
+    ],
+    "title": "Musical Bass-Line Pattern Clustering and Its Application to Audio Genre Classification.",
+    "pages": "219-224",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-5.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#TsunooOS09"
+  },
+  "conf/ismir/SerraZLS09": {
+    "@key": "conf/ismir/SerraZLS09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Joan Serr\u00e0",
+      "Massimiliano Zanin",
+      "Cyril Laurier",
+      "Mohamed Sordo"
+    ],
+    "title": "Unsupervised Detection of Cover Song Sets: Accuracy Improvement and Original Identification.",
+    "pages": "225-230",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-6.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#SerraZLS09"
+  },
+  "conf/ismir/MauchND09": {
+    "@key": "conf/ismir/MauchND09",
+    "@mdate": "2016-08-30",
+    "author": [
+      "Matthias Mauch",
+      "Katy C. Noland",
+      "Simon Dixon"
+    ],
+    "title": "Using Musical Structure to Enhance Automatic Chord Transcription.",
+    "pages": "231-236",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-7.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#MauchND09"
+  },
+  "conf/ismir/MacRitchieNB09": {
+    "@key": "conf/ismir/MacRitchieNB09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jennifer MacRitchie",
+      "Bryony Buck",
+      "Nicholas J. Bailey"
+    ],
+    "title": "Visualising Musical Structure Through Performance Gesture.",
+    "pages": "237-242",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-8.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#MacRitchieNB09"
+  },
+  "conf/ismir/HaroH09": {
+    "@key": "conf/ismir/HaroH09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Mart\u00edn Haro",
+      "Perfecto Herrera"
+    ],
+    "title": "From Low-Level to Song-Level Percussion Descriptors of Polyphonic Music.",
+    "pages": "243-248",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-9.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HaroH09"
+  },
+  "conf/ismir/PanagakisKA09": {
+    "@key": "conf/ismir/PanagakisKA09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Yannis Panagakis",
+      "Constantine Kotropoulos",
+      "Gonzalo R. Arce"
+    ],
+    "title": "Music Genre Classification Using Locality Preserving Non-Negative Tensor Factorization and Sparse Representations.",
+    "pages": "249-254",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-10.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#PanagakisKA09"
+  },
+  "conf/ismir/SalamonR09": {
+    "@key": "conf/ismir/SalamonR09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Justin Salamon",
+      "Martin Rohrmeier"
+    ],
+    "title": "A Quantitative Evaluation of a Two Stage Retrieval Approach for a Melodic Query by Example System.",
+    "pages": "255-260",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-11.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#SalamonR09"
+  },
+  "conf/ismir/GovaertsD09": {
+    "@key": "conf/ismir/GovaertsD09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Sten Govaerts",
+      "Erik Duval"
+    ],
+    "title": "A Web-based Approach to Determine the Origin of an Artist..",
+    "pages": "261-266",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-12.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#GovaertsD09"
+  },
+  "conf/ismir/Schepens09": {
+    "@key": "conf/ismir/Schepens09",
+    "@mdate": "2011-08-15",
+    "author": "Wijnand Schepens",
+    "title": "Chronicle: Representation of Complex Time Structures.",
+    "pages": "267-272",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-13.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Schepens09"
+  },
+  "conf/ismir/SchmidtWK09": {
+    "@key": "conf/ismir/SchmidtWK09",
+    "@mdate": "2012-10-26",
+    "author": [
+      "Erik M. Schmidt",
+      "Kris West",
+      "Youngmoo E. Kim"
+    ],
+    "title": "Efficient Acoustic Feature Extraction for Music Information Retrieval Using Programmable Gate Arrays.",
+    "pages": "273-278",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-14.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#SchmidtWK09"
+  },
+  "conf/ismir/FerraroHII09": {
+    "@key": "conf/ismir/FerraroHII09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Pascal Ferraro",
+      "Pierre Hanna",
+      "Laurent Imbert",
+      "Thomas Izard"
+    ],
+    "title": "Accelerating Query-by-Humming on GPU.",
+    "pages": "279-284",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-15.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#FerraroHII09"
+  },
+  "conf/ismir/RafiiP09": {
+    "@key": "conf/ismir/RafiiP09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Zafar Rafii",
+      "Bryan Pardo"
+    ],
+    "title": "Learning to Control a Reverberator Using Subjective Perceptual Descriptors.",
+    "pages": "285-290",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-16.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#RafiiP09"
+  },
+  "conf/ismir/HamanakaT09": {
+    "@key": "conf/ismir/HamanakaT09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Masatoshi Hamanaka",
+      "Satoshi Tojo"
+    ],
+    "title": "Interactive Gttm Analyzer.",
+    "pages": "291-296",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-17.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HamanakaT09"
+  },
+  "conf/ismir/DannenbergW09": {
+    "@key": "conf/ismir/DannenbergW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Roger B. Dannenberg",
+      "Larry A. Wasserman"
+    ],
+    "title": "Estimating the Error Distribution of a Single Tap Sequence without Ground Truth.",
+    "pages": "297-302",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-18.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#DannenbergW09"
+  },
+  "conf/ismir/McKayBTF09": {
+    "@key": "conf/ismir/McKayBTF09",
+    "@mdate": "2017-08-08",
+    "author": [
+      "Cory McKay",
+      "John Ashley Burgoyne",
+      "Jessica Thompson 0001",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Using ACE XML 2.0 to Store and Share Feature, Instance and Class Data for Musical Classification.",
+    "pages": "303-308",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-19.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#McKayBTF09"
+  },
+  "conf/ismir/CancelaRL09": {
+    "@key": "conf/ismir/CancelaRL09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Pablo Cancela",
+      "Mart\u00edn Rocamora",
+      "Ernesto L\u00f3pez"
+    ],
+    "title": "An Efficient Multi-Resolution Spectral Transform for Music Analysis.",
+    "pages": "309-314",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-20.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#CancelaRL09"
+  },
+  "conf/ismir/BayED09": {
+    "@key": "conf/ismir/BayED09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Mert Bay",
+      "Andreas F. Ehmann",
+      "J. Stephen Downie"
+    ],
+    "title": "Evaluation of Multiple-F0 Estimation and Tracking Systems.",
+    "pages": "315-320",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS2-21.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#BayED09"
+  },
+  "conf/ismir/FuhrmannHH09": {
+    "@key": "conf/ismir/FuhrmannHH09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ferdinand Fuhrmann",
+      "Mart\u00edn Haro",
+      "Perfecto Herrera"
+    ],
+    "title": "Scalability, Generality and Temporal Aspects in Automatic Recognition of Predominant Musical Instruments in Polyphonic Music.",
+    "pages": "321-326",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS3-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#FuhrmannHH09"
+  },
+  "conf/ismir/HeittolaKV09": {
+    "@key": "conf/ismir/HeittolaKV09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Toni Heittola",
+      "Anssi Klapuri",
+      "Tuomas Virtanen"
+    ],
+    "title": "Musical Instrument Recognition in Polyphonic Audio Using Source-Filter Model for Sound Separation.",
+    "pages": "327-332",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS3-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HeittolaKV09"
+  },
+  "conf/ismir/DuanHP09": {
+    "@key": "conf/ismir/DuanHP09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Zhiyao Duan",
+      "Jinyu Han",
+      "Bryan Pardo"
+    ],
+    "title": "Harmonically Informed Multi-Pitch Tracking.",
+    "pages": "333-338",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS3-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#DuanHP09"
+  },
+  "conf/ismir/YoshiiG09": {
+    "@key": "conf/ismir/YoshiiG09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Kazuyoshi Yoshii",
+      "Masataka Goto"
+    ],
+    "title": "Continuous pLSI and Smoothing Techniques for Hybrid Music Recommendation.",
+    "pages": "339-344",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS4-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#YoshiiG09"
+  },
+  "conf/ismir/MailletEDL09": {
+    "@key": "conf/ismir/MailletEDL09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Fran\u00e7ois Maillet",
+      "Douglas Eck",
+      "Guillaume Desjardins",
+      "Paul Lamere"
+    ],
+    "title": "Steerable Playlist Generation by Learning Song Similarity from Radio Station Playlists.",
+    "pages": "345-350",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS4-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#MailletEDL09"
+  },
+  "conf/ismir/BosteelsPK09": {
+    "@key": "conf/ismir/BosteelsPK09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Klaas Bosteels",
+      "Elias Pampalk",
+      "Etienne E. Kerre"
+    ],
+    "title": "Evaluating and Analysing Dynamic Playlist Generation Heuristics Using Radio Logs and Fuzzy Set Theory.",
+    "pages": "351-356",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS4-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#BosteelsPK09"
+  },
+  "conf/ismir/BarringtonOL09": {
+    "@key": "conf/ismir/BarringtonOL09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Luke Barrington",
+      "Reid Oda",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Smarter than Genius? Human Evaluation of Music Recommender Systems.",
+    "pages": "357-362",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS4-4.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#BarringtonOL09"
+  },
+  "conf/ismir/WangWSLO09": {
+    "@key": "conf/ismir/WangWSLO09",
+    "@mdate": "2017-09-18",
+    "author": [
+      "Fei Wang 0001",
+      "Xin Wang 0013",
+      "Bo Shao",
+      "Tao Li 0001",
+      "Mitsunori Ogihara"
+    ],
+    "title": "Tag Integrated Multi-Label Music Style Classification with Hypergraph.",
+    "pages": "363-368",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS5-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#WangWSLO09"
+  },
+  "conf/ismir/HoffmanBC09": {
+    "@key": "conf/ismir/HoffmanBC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Matthew D. Hoffman",
+      "David M. Blei",
+      "Perry R. Cook"
+    ],
+    "title": "Easy As CBA: A Simple Probabilistic Model for Tagging Music.",
+    "pages": "369-374",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS5-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HoffmanBC09"
+  },
+  "conf/ismir/KimTT09": {
+    "@key": "conf/ismir/KimTT09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Joon Hee Kim",
+      "Brian Tomasik",
+      "Douglas Turnbull"
+    ],
+    "title": "Using Artist Similarity to Propagate Semantic Information.",
+    "pages": "375-380",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS5-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#KimTT09"
+  },
+  "conf/ismir/LaurierSSH09": {
+    "@key": "conf/ismir/LaurierSSH09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Cyril Laurier",
+      "Mohamed Sordo",
+      "Joan Serr\u00e0",
+      "Perfecto Herrera"
+    ],
+    "title": "Music Mood Representations from Social Tags.",
+    "pages": "381-386",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS5-4.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#LaurierSSH09"
+  },
+  "conf/ismir/LawWMBD09": {
+    "@key": "conf/ismir/LawWMBD09",
+    "@mdate": "2011-08-16",
+    "author": [
+      "Edith Law",
+      "Kris West",
+      "Michael I. Mandel",
+      "Mert Bay",
+      "J. Stephen Downie"
+    ],
+    "title": "Evaluation of Algorithms Using Games: The Case of Music Tagging.",
+    "pages": "387-392",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS5-5.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#LawWMBD09"
+  },
+  "conf/ismir/KakoOKKT09": {
+    "@key": "conf/ismir/KakoOKKT09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Tatsuya Kako",
+      "Yasunori Ohishi",
+      "Hirokazu Kameoka",
+      "Kunio Kashino",
+      "Kazuya Takeda"
+    ],
+    "title": "Automatic Identification for Singing Style based on Sung Melodic Contour Characterized in Phase Plane.",
+    "pages": "393-398",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#KakoOKKT09"
+  },
+  "conf/ismir/HamelWE09": {
+    "@key": "conf/ismir/HamelWE09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Philippe Hamel",
+      "Sean Wood",
+      "Douglas Eck"
+    ],
+    "title": "Automatic Identification of Instrument Classes in Polyphonic and Poly-Instrument Audio.",
+    "pages": "399-404",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HamelWE09"
+  },
+  "conf/ismir/TomasikKLATWT09": {
+    "@key": "conf/ismir/TomasikKLATWT09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Brian Tomasik",
+      "Joon Hee Kim",
+      "Margaret Ladlow",
+      "Malcolm Augat",
+      "Derek Tingle",
+      "Rich Wicentowski",
+      "Douglas Turnbull"
+    ],
+    "title": "Using Regression to Combine Data Sources for Semantic Music Discovery.",
+    "pages": "405-410",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#TomasikKLATWT09"
+  },
+  "conf/ismir/HuDE09": {
+    "@key": "conf/ismir/HuDE09",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "J. Stephen Downie",
+      "Andreas F. Ehmann"
+    ],
+    "title": "Lyric Text Mining in Music Mood Classification.",
+    "pages": "411-416",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-4.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HuDE09"
+  },
+  "conf/ismir/XuNKK09": {
+    "@key": "conf/ismir/XuNKK09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Xin Xu",
+      "Masaki Naito",
+      "Tsuneo Kato",
+      "Hisashi Kawai"
+    ],
+    "title": "Robust and Fast Lyric Search based on Phonetic Confusion Matrix.",
+    "pages": "417-422",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-5.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#XuNKK09"
+  },
+  "conf/ismir/Kirlin09": {
+    "@key": "conf/ismir/Kirlin09",
+    "@mdate": "2011-08-15",
+    "author": "Phillip B. Kirlin",
+    "title": "Using Harmonic and Melodic Analyses to Automate the Initial Stages of Schenkerian Analysis.",
+    "pages": "423-428",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-6.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Kirlin09"
+  },
+  "conf/ismir/MaxwellPE09": {
+    "@key": "conf/ismir/MaxwellPE09",
+    "@mdate": "2013-12-05",
+    "author": [
+      "James B. Maxwell",
+      "Philippe Pasquier",
+      "Arne Eigenfeldt"
+    ],
+    "title": "Hierarchical Sequential Memory for Music: A Cognitive Model.",
+    "pages": "429-434",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-7.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#MaxwellPE09"
+  },
+  "conf/ismir/ThompsonMBF09": {
+    "@key": "conf/ismir/ThompsonMBF09",
+    "@mdate": "2017-08-08",
+    "author": [
+      "Jessica Thompson 0001",
+      "Cory McKay",
+      "John Ashley Burgoyne",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Additions and Improvements in the ACE 2.0 Music Classifier.",
+    "pages": "435-440",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-8.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#ThompsonMBF09"
+  },
+  "conf/ismir/HuS09": {
+    "@key": "conf/ismir/HuS09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Diane Hu",
+      "Lawrence K. Saul"
+    ],
+    "title": "A Probabilistic Topic Model for Unsupervised Learning of Musical Key-Profiles.",
+    "pages": "441-446",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-9.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HuS09"
+  },
+  "conf/ismir/TidharFKS09": {
+    "@key": "conf/ismir/TidharFKS09",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Dan Tidhar",
+      "Gy\u00f6rgy Fazekas",
+      "Sefki Kolozali",
+      "Mark B. Sandler"
+    ],
+    "title": "Publishing Music Similarity Features on the Semantic Web.",
+    "pages": "447-452",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-10.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#TidharFKS09"
+  },
+  "conf/ismir/AbesserLDS09": {
+    "@key": "conf/ismir/AbesserLDS09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jakob Abe\u00dfer",
+      "Hanna M. Lukashevich",
+      "Christian Dittmar",
+      "Gerald Schuller"
+    ],
+    "title": "Genre Classification Using Bass-Related High-Level Features and Playing Styles.",
+    "pages": "453-458",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-11.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#AbesserLDS09"
+  },
+  "conf/ismir/LukashevichADG09": {
+    "@key": "conf/ismir/LukashevichADG09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Hanna M. Lukashevich",
+      "Jakob Abe\u00dfer",
+      "Christian Dittmar",
+      "Holger Gro\u00dfmann"
+    ],
+    "title": "From Multi-Labeling to Multi-Domain-Labeling: A Novel Two-Dimensional Approach to Music Genre Classification.",
+    "pages": "459-464",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-12.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#LukashevichADG09"
+  },
+  "conf/ismir/DiakopoulosVHMK09": {
+    "@key": "conf/ismir/DiakopoulosVHMK09",
+    "@mdate": "2012-01-23",
+    "author": [
+      "Dimitri Diakopoulos",
+      "Owen Vallis",
+      "Jordan Hochenbaum",
+      "Jim W. Murphy",
+      "Ajay Kapur"
+    ],
+    "title": "21st Century Electronica: MIR Techniques for Classification and Performance.",
+    "pages": "465-470",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-13.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#DiakopoulosVHMK09"
+  },
+  "conf/ismir/NicholsMBR09": {
+    "@key": "conf/ismir/NicholsMBR09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Eric Nichols",
+      "Dan Morris",
+      "Sumit Basu",
+      "Christopher Raphael"
+    ],
+    "title": "Relationships Between Lyrics and Melody in Popular Music.",
+    "pages": "471-476",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-14.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#NicholsMBR09"
+  },
+  "conf/ismir/Kato09": {
+    "@key": "conf/ismir/Kato09",
+    "@mdate": "2011-08-15",
+    "author": "Makoto P. Kato",
+    "title": "RhythMiXearch: Searching for Unknown Music by Mixing Known Music.",
+    "pages": "477-482",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-15.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Kato09"
+  },
+  "conf/ismir/MartinRH09": {
+    "@key": "conf/ismir/MartinRH09",
+    "@mdate": "2016-07-06",
+    "author": [
+      "Benjamin Martin 0001",
+      "Matthias Robine",
+      "Pierre Hanna"
+    ],
+    "title": "Musical Structure Retrieval by Aligning Self-Similarity Matrices.",
+    "pages": "483-488",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-16.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#MartinRH09"
+  },
+  "conf/ismir/MoelantsCL09": {
+    "@key": "conf/ismir/MoelantsCL09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Dirk Moelants",
+      "Olmo Cornelis",
+      "Marc Leman"
+    ],
+    "title": "Exploring African Tone Scales.",
+    "pages": "489-494",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-17.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#MoelantsCL09"
+  },
+  "conf/ismir/MontecchioO09": {
+    "@key": "conf/ismir/MontecchioO09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Nicola Montecchio",
+      "Nicola Orio"
+    ],
+    "title": "A Discrete Filter Bank Approach to Audio to Score Matching for Polyphonic Music.",
+    "pages": "495-500",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-18.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#MontecchioO09"
+  },
+  "conf/ismir/BattenbergW09": {
+    "@key": "conf/ismir/BattenbergW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Eric Battenberg",
+      "David Wessel"
+    ],
+    "title": "Accelerating Non-Negative Matrix Factorization for Audio Source Separation on Multi-Core and Many-Core Architectures.",
+    "pages": "501-506",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-19.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#BattenbergW09"
+  },
+  "conf/ismir/KranenburgVWV09": {
+    "@key": "conf/ismir/KranenburgVWV09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Peter van Kranenburg",
+      "Anja Volk",
+      "Frans Wiering",
+      "Remco C. Veltkamp"
+    ],
+    "title": "Musical Models for Melody Alignment.",
+    "pages": "507-512",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-20.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#KranenburgVWV09"
+  },
+  "conf/ismir/McFeeL09": {
+    "@key": "conf/ismir/McFeeL09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Brian McFee",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Heterogeneous Embedding for Subjective Artist Similarity.",
+    "pages": "513-518",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-21.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#McFeeL09"
+  },
+  "conf/ismir/NiitsumaFT09": {
+    "@key": "conf/ismir/NiitsumaFT09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Masahiro Niitsuma",
+      "Tsutomu Fujinami",
+      "Yo Tomita"
+    ],
+    "title": "The Intersection of Computational Analysis and Music Manuscripts: A New Model for Bach Source Studies of the 21st Century.",
+    "pages": "519-524",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS3-22.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#NiitsumaFT09"
+  },
+  "conf/ismir/PohleSSKW09": {
+    "@key": "conf/ismir/PohleSSKW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Tim Pohle",
+      "Dominik Schnitzer",
+      "Markus Schedl",
+      "Peter Knees",
+      "Gerhard Widmer"
+    ],
+    "title": "On Rhythm and General Music Similarity.",
+    "pages": "525-530",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS6-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#PohleSSKW09"
+  },
+  "conf/ismir/Bello09": {
+    "@key": "conf/ismir/Bello09",
+    "@mdate": "2011-08-15",
+    "author": "Juan Pablo Bello",
+    "title": "Grouping Recorded Music by Structural Similarity.",
+    "pages": "531-536",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS6-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Bello09"
+  },
+  "conf/ismir/SchnitzerFW09": {
+    "@key": "conf/ismir/SchnitzerFW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Dominik Schnitzer",
+      "Arthur Flexer",
+      "Gerhard Widmer"
+    ],
+    "title": "A Filter-and-Refine Indexing Method for Fast Similarity Search in Millions of Music Tracks.",
+    "pages": "537-542",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS6-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#SchnitzerFW09"
+  },
+  "conf/ismir/OrioR09": {
+    "@key": "conf/ismir/OrioR09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Nicola Orio",
+      "Antonio Rod\u00e0"
+    ],
+    "title": "A Measure of Melodic Similarity based on a Graph Representation of the Music Structure.",
+    "pages": "543-548",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS7-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#OrioR09"
+  },
+  "conf/ismir/HaasRVW09": {
+    "@key": "conf/ismir/HaasRVW09",
+    "@mdate": "2015-11-04",
+    "author": [
+      "W. Bas de Haas",
+      "Martin Rohrmeier",
+      "Remco C. Veltkamp",
+      "Frans Wiering"
+    ],
+    "title": "Modeling Harmonic Similarity Using a Generative Grammar of Tonal Harmony.",
+    "pages": "549-554",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS7-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HaasRVW09"
+  },
+  "conf/ismir/Raphael09": {
+    "@key": "conf/ismir/Raphael09",
+    "@mdate": "2011-08-15",
+    "author": "Christopher Raphael",
+    "title": "Symbolic and Structural Representation of Melodic Expression.",
+    "pages": "555-560",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS7-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Raphael09"
+  },
+  "conf/ismir/KhadkevichO09": {
+    "@key": "conf/ismir/KhadkevichO09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Maksim Khadkevich",
+      "Maurizio Omologo"
+    ],
+    "title": "Use of Hidden Markov Models and Factored Language Models for Automatic Chord Recognition.",
+    "pages": "561-566",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS7-4.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#KhadkevichO09"
+  },
+  "conf/ismir/FergusonC09": {
+    "@key": "conf/ismir/FergusonC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Sam Ferguson",
+      "Densil Cabrera"
+    ],
+    "title": "Auditory Spectral Summarisation for Audio Signals with Musical Applications.",
+    "pages": "567-572",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS7-5.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#FergusonC09"
+  },
+  "conf/ismir/LiemH09": {
+    "@key": "conf/ismir/LiemH09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Cynthia C. S. Liem",
+      "Alan Hanjalic"
+    ],
+    "title": "Cover Song Retrieval: A Comparative Study of System Component Choices.",
+    "pages": "573-578",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS7-6.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#LiemH09"
+  },
+  "conf/ismir/KneesPSSSW09": {
+    "@key": "conf/ismir/KneesPSSSW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Peter Knees",
+      "Tim Pohle",
+      "Markus Schedl",
+      "Dominik Schnitzer",
+      "Klaus Seyerlehner",
+      "Gerhard Widmer"
+    ],
+    "title": "Augmenting Text-based Music Retrieval with Audio Similarity: Advantages and Limitations.",
+    "pages": "579-584",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#KneesPSSSW09"
+  },
+  "conf/ismir/Niedermayer09": {
+    "@key": "conf/ismir/Niedermayer09",
+    "@mdate": "2011-08-15",
+    "author": "Bernhard Niedermayer",
+    "title": "Improving Accuracy of Polyphonic Music-to-Score Alignment.",
+    "pages": "585-590",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Niedermayer09"
+  },
+  "conf/ismir/LemstromW09": {
+    "@key": "conf/ismir/LemstromW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Kjell Lemstr\u00f6m",
+      "Geraint A. Wiggins"
+    ],
+    "title": "Formalizing Invariances for Content-based Music Retrieval.",
+    "pages": "591-596",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#LemstromW09"
+  },
+  "conf/ismir/BohakM09": {
+    "@key": "conf/ismir/BohakM09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ciril Bohak",
+      "Matija Marolt"
+    ],
+    "title": "Calculating Similarity of Folk Song Variants with Melody-based Features.",
+    "pages": "597-602",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-4.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#BohakM09"
+  },
+  "conf/ismir/WeilSDR09": {
+    "@key": "conf/ismir/WeilSDR09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jan Weil",
+      "Thomas Sikora",
+      "Jean-Louis Durrieu",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "Automatic Generation of Lead Sheets from Polyphonic Music Signals.",
+    "pages": "603-608",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-5.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#WeilSDR09"
+  },
+  "conf/ismir/ReedUSUSL09": {
+    "@key": "conf/ismir/ReedUSUSL09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jeremy Reed",
+      "Yushi Ueda",
+      "Sabato Marco Siniscalchi",
+      "Yuuki Uchiyama",
+      "Shigeki Sagayama",
+      "Chin-Hui Lee"
+    ],
+    "title": "Minimum Classification Error Training to Improve Isolated Chord Recognition.",
+    "pages": "609-614",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-6.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#ReedUSUSL09"
+  },
+  "conf/ismir/Klapuri09": {
+    "@key": "conf/ismir/Klapuri09",
+    "@mdate": "2011-08-15",
+    "author": "Anssi Klapuri",
+    "title": "A Method for Visualizing the Pitch Content of Polyphonic Music Signals.",
+    "pages": "615-620",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-7.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Klapuri09"
+  },
+  "conf/ismir/EerolaLT09": {
+    "@key": "conf/ismir/EerolaLT09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Tuomas Eerola",
+      "Olivier Lartillot",
+      "Petri Toiviainen"
+    ],
+    "title": "Prediction of Multidimensional Emotional Ratings in Music from Audio Using Multivariate Regression Models.",
+    "pages": "621-626",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-8.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#EerolaLT09"
+  },
+  "conf/ismir/LiSF09": {
+    "@key": "conf/ismir/LiSF09",
+    "@mdate": "2011-08-16",
+    "author": [
+      "Beinan Li",
+      "Jordan B. L. Smith",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Optical Audio Reconstruction for Stereo Phonograph Records Using White Light Interferometry.",
+    "pages": "627-632",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-9.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#LiSF09"
+  },
+  "conf/ismir/KoenigsteinS09": {
+    "@key": "conf/ismir/KoenigsteinS09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Noam Koenigstein",
+      "Yuval Shavitt"
+    ],
+    "title": "Song Ranking based on Piracy in Peer-to-Peer Networks.",
+    "pages": "633-638",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-10.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#KoenigsteinS09"
+  },
+  "conf/ismir/RobineHL09": {
+    "@key": "conf/ismir/RobineHL09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Matthias Robine",
+      "Pierre Hanna",
+      "Mathieu Lagrange"
+    ],
+    "title": "Meter Class Profiles for Music Similarity and Retrieval.",
+    "pages": "639-644",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-11.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#RobineHL09"
+  },
+  "conf/ismir/FremereyCEM09": {
+    "@key": "conf/ismir/FremereyCEM09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Christian Fremerey",
+      "Michael Clausen",
+      "Sebastian Ewert",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Sheet Music-Audio Identification.",
+    "pages": "645-650",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-12.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#FremereyCEM09"
+  },
+  "conf/ismir/HanRDH09": {
+    "@key": "conf/ismir/HanRDH09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Byeong-jun Han",
+      "Seungmin Rho",
+      "Roger B. Dannenberg",
+      "Eenjun Hwang"
+    ],
+    "title": "SMERS: Music Emotion Recognition Using Support Vector Regression.",
+    "pages": "651-656",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-13.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HanRDH09"
+  },
+  "conf/ismir/BischoffFPNLS09": {
+    "@key": "conf/ismir/BischoffFPNLS09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Kerstin Bischoff",
+      "Claudiu S. Firan",
+      "Raluca Paiu",
+      "Wolfgang Nejdl",
+      "Cyril Laurier",
+      "Mohamed Sordo"
+    ],
+    "title": "Music Mood and Theme Classification - a Hybrid Approach.",
+    "pages": "657-662",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-14.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#BischoffFPNLS09"
+  },
+  "conf/ismir/GansemanSD09": {
+    "@key": "conf/ismir/GansemanSD09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Joachim Ganseman",
+      "Paul Scheunders",
+      "Wim D'haes"
+    ],
+    "title": "Using XML-Formatted Scores in Real-Time Applications.",
+    "pages": "663-668",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-15.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#GansemanSD09"
+  },
+  "conf/ismir/AngladeRD09": {
+    "@key": "conf/ismir/AngladeRD09",
+    "@mdate": "2018-08-19",
+    "author": [
+      "Amelie Anglade",
+      "Rafael Ram\u00edrez 0001",
+      "Simon Dixon"
+    ],
+    "title": "Genre Classification Using Harmony Rules Induced from Automatic Chord Transcriptions.",
+    "pages": "669-674",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-16.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#AngladeRD09"
+  },
+  "conf/ismir/JuliaJ09": {
+    "@key": "conf/ismir/JuliaJ09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Carles Fernandes Juli\u00e0",
+      "Sergi Jord\u00e0"
+    ],
+    "title": "SongExplorer: A Tabletop Application for Exploring Large Collections of Songs.",
+    "pages": "675-680",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-17.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#JuliaJ09"
+  },
+  "conf/ismir/JeonMC09": {
+    "@key": "conf/ismir/JeonMC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Woojay Jeon",
+      "Changxue Ma",
+      "Yan Ming Cheng"
+    ],
+    "title": "An Efficient Signal-Matching Approach to Melody Indexing and Search Using Continuous Pitch Contours and Wavelets.",
+    "pages": "681-686",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-18.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#JeonMC09"
+  },
+  "conf/ismir/Izmirli09": {
+    "@key": "conf/ismir/Izmirli09",
+    "@mdate": "2011-08-15",
+    "author": "\u00d6zg\u00fcr Izmirli",
+    "title": "Tonal-Atonal Classification of Music Audio Using Diffusion Maps.",
+    "pages": "687-692",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-19.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#Izmirli09"
+  },
+  "conf/ismir/ParkLW09": {
+    "@key": "conf/ismir/ParkLW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Tae Hong Park",
+      "Zhiye Li",
+      "Wen Wu"
+    ],
+    "title": "Easy Does It: The Electro-Acoustic Music Analysis Toolbox.",
+    "pages": "693-698",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-20.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#ParkLW09"
+  },
+  "conf/ismir/KuuskankareL09": {
+    "@key": "conf/ismir/KuuskankareL09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Mika Kuuskankare",
+      "Mikael Laurson"
+    ],
+    "title": "MIR in ENP - Rule-based Music Information Retrieval from Symbolic Music Notation.",
+    "pages": "699-704",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-21.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#KuuskankareL09"
+  },
+  "conf/ismir/SuYLC09": {
+    "@key": "conf/ismir/SuYLC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Min-Yian Su",
+      "Yi-Hsuan Yang",
+      "Yu-Ching Lin",
+      "Homer H. Chen"
+    ],
+    "title": "An Integrated Approach to Music Boundary Detection.",
+    "pages": "705-710",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/PS4-22.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#SuYLC09"
+  },
+  "conf/ismir/HirjeeB09": {
+    "@key": "conf/ismir/HirjeeB09",
+    "@mdate": "2011-08-18",
+    "author": [
+      "Hussein Hirjee",
+      "Daniel G. Brown 0001"
+    ],
+    "title": "Automatic Detection of Internal and Imperfect Rhymes in Rap Lyrics.",
+    "pages": "711-716",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS8-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HirjeeB09"
+  },
+  "conf/ismir/ThomasFDC09": {
+    "@key": "conf/ismir/ThomasFDC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Verena Thomas",
+      "Christian Fremerey",
+      "David Damm",
+      "Michael Clausen"
+    ],
+    "title": "Slave: A Score-Lyrics-Audio-Video-Explorer.",
+    "pages": "717-722",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS8-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#ThomasFDC09"
+  },
+  "conf/ismir/NicholsB09": {
+    "@key": "conf/ismir/NicholsB09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Eric Nichols",
+      "Donald Byrd"
+    ],
+    "title": "Lyric Extraction and Recognition on Digital Images of Early Music Sources.",
+    "pages": "723-728",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS8-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#NicholsB09"
+  },
+  "conf/ismir/HillewaereMC09": {
+    "@key": "conf/ismir/HillewaereMC09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ruben Hillewaere",
+      "Bernard Manderick",
+      "Darrell Conklin"
+    ],
+    "title": "Global Feature Versus Event Models for Folk Song Classification.",
+    "pages": "729-734",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS9-1.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#HillewaereMC09"
+  },
+  "conf/ismir/MullerGW09": {
+    "@key": "conf/ismir/MullerGW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Meinard M\u00fcller",
+      "Peter Grosche",
+      "Frans Wiering"
+    ],
+    "title": "Robust Segmentation and Annotation of Folk Song Recordings.",
+    "pages": "735-740",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS9-2.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#MullerGW09"
+  },
+  "conf/ismir/BadeNSGW09": {
+    "@key": "conf/ismir/BadeNSGW09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Korinna Bade",
+      "Andreas N\u00fcrnberger",
+      "Sebastian Stober",
+      "J\u00f6rg Garbers",
+      "Frans Wiering"
+    ],
+    "title": "Supporting Folk-Song Research by Automatic Metric Learning and Ranking.",
+    "pages": "741-746",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS9-3.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#BadeNSGW09"
+  },
+  "conf/ismir/CunninghamN09": {
+    "@key": "conf/ismir/CunninghamN09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Sally Jo Cunningham",
+      "David M. Nichols"
+    ],
+    "title": "Exploring Social Music Behavior: An Investigation of Music Selection at Parties.",
+    "pages": "747-752",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS9-4.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#CunninghamN09"
+  },
+  "conf/ismir/GomezHH09": {
+    "@key": "conf/ismir/GomezHH09",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Emilia G\u00f3mez",
+      "Mart\u00edn Haro",
+      "Perfecto Herrera"
+    ],
+    "title": "Music and Geography: Content Description of Musical Audio from Different Parts of the World.",
+    "pages": "753-758",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS9-5.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#GomezHH09"
+  },
+  "conf/ismir/ProutskovaC09": {
+    "@key": "conf/ismir/ProutskovaC09",
+    "@mdate": "2014-04-16",
+    "author": [
+      "Polina Proutskova",
+      "Michael A. Casey"
+    ],
+    "title": "You Call That Singing? Ensemble Classification for Multi-Cultural Collections of Music Recordings.",
+    "pages": "759-764",
+    "year": "2009",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2009.ismir.net/proceedings/OS9-6.pdf",
+    "crossref": "conf/ismir/2009",
+    "url": "db/conf/ismir/ismir2009.html#ProutskovaC09"
+  },
+  "conf/ismir/CollinsTLWG10": {
+    "@key": "conf/ismir/CollinsTLWG10",
+    "@mdate": "2014-03-29",
+    "author": [
+      "Tom Collins",
+      "Jeremy Thurlow",
+      "Robin C. Laney",
+      "Alistair Willis",
+      "Paul H. Garthwaite"
+    ],
+    "title": "A Comparative Evaluation of Algorithms for Discovering Translational Patterns in Baroque Keyboard Works.",
+    "pages": "3-8",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-2.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#CollinsTLWG10"
+  },
+  "conf/ismir/KonzME10": {
+    "@key": "conf/ismir/KonzME10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Verena Konz",
+      "Meinard M\u00fcller",
+      "Sebastian Ewert"
+    ],
+    "title": "A Multi-Perspective Evaluation Framework for Chord Recognition.",
+    "pages": "9-14",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-3.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#KonzME10"
+  },
+  "conf/ismir/MiottoO10": {
+    "@key": "conf/ismir/MiottoO10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Riccardo Miotto",
+      "Nicola Orio"
+    ],
+    "title": "A Probabilistic Approach to Merge Context and Content Information for Music Retrieval.",
+    "pages": "15-20",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-4.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MiottoO10"
+  },
+  "conf/ismir/GrindlayE10": {
+    "@key": "conf/ismir/GrindlayE10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Graham Grindlay",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "A Probabilistic Subspace Model for Multi-instrument Polyphonic Transcription.",
+    "pages": "21-26",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-5.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#GrindlayE10"
+  },
+  "conf/ismir/CozLKA10": {
+    "@key": "conf/ismir/CozLKA10",
+    "@mdate": "2012-08-30",
+    "author": [
+      "Maxime Le Coz",
+      "H\u00e9l\u00e8ne Lachambre",
+      "Lionel Koenig",
+      "R\u00e9gine Andr\u00e9-Obrecht"
+    ],
+    "title": "A Segmentation-based Tempo Induction Method.",
+    "pages": "27-32",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-6.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#CozLKA10"
+  },
+  "conf/ismir/VatolkinTB10": {
+    "@key": "conf/ismir/VatolkinTB10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Igor Vatolkin",
+      "Wolfgang M. Theimer",
+      "Martin Botteck"
+    ],
+    "title": "AMUSE (Advanced MUSic Explorer) - A Multitool Framework for Music Data Analysis.",
+    "pages": "33-38",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-8.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#VatolkinTB10"
+  },
+  "conf/ismir/JoderER10": {
+    "@key": "conf/ismir/JoderER10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Cyril Joder",
+      "Slim Essid",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "An Improved Hierarchical Approach for Music-to-symbolic Score Alignment.",
+    "pages": "39-45",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-9.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#JoderER10"
+  },
+  "conf/ismir/WangJW10": {
+    "@key": "conf/ismir/WangJW10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Chung-Che Wang",
+      "Jyh-Shing Roger Jang",
+      "Wennen Wang"
+    ],
+    "title": "An Improved Query by Singing/Humming System Using Melody and Lyrics Information.",
+    "pages": "45-50",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-10.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#WangJW10"
+  },
+  "conf/ismir/HankinsonPF10": {
+    "@key": "conf/ismir/HankinsonPF10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Andrew Hankinson",
+      "Laurent Pugin",
+      "Ichiro Fujinaga"
+    ],
+    "title": "An Interchange Format for Optical Music Recognition Applications.",
+    "pages": "51-56",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-11.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HankinsonPF10"
+  },
+  "conf/ismir/WangLO10": {
+    "@key": "conf/ismir/WangLO10",
+    "@mdate": "2017-09-17",
+    "author": [
+      "Dingding Wang 0001",
+      "Tao Li 0001",
+      "Mitsunori Ogihara"
+    ],
+    "title": "Are Tags Better Than Audio? The Effect of Joint Use of Tags and Audio Content Features for Artistic Style Clustering.",
+    "pages": "57-62",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-12.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#WangLO10"
+  },
+  "conf/ismir/FunasawaIHTK10": {
+    "@key": "conf/ismir/FunasawaIHTK10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Shintaro Funasawa",
+      "Hiromi Ishizaki",
+      "Keiichiro Hoashi",
+      "Yasuhiro Takishima",
+      "Jiro Katto"
+    ],
+    "title": "Automated Music Slideshow Generation Using Web Images Based on Lyrics.",
+    "pages": "63-68",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-13.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#FunasawaIHTK10"
+  },
+  "conf/ismir/Humphrey10": {
+    "@key": "conf/ismir/Humphrey10",
+    "@mdate": "2011-08-15",
+    "author": "Eric Humphrey",
+    "title": "Automatic Characterization of Digital Music for Rhythmic Auditory Stimulation.",
+    "pages": "69-74",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-14.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Humphrey10"
+  },
+  "conf/ismir/ZaanenK10": {
+    "@key": "conf/ismir/ZaanenK10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Menno van Zaanen",
+      "Pieter Kanters"
+    ],
+    "title": "Automatic Mood Classification Using TF*IDF Based on Lyrics.",
+    "pages": "75-80",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-15.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#ZaanenK10"
+  },
+  "conf/ismir/CovielloBCL10": {
+    "@key": "conf/ismir/CovielloBCL10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Emanuele Coviello",
+      "Luke Barrington",
+      "Antoni B. Chan",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Automatic Music Tagging With Time Series Models.",
+    "pages": "81-86",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-16.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#CovielloBCL10"
+  },
+  "conf/ismir/RumpMTOS10": {
+    "@key": "conf/ismir/RumpMTOS10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Halfdan Rump",
+      "Shigeki Miyabe",
+      "Emiru Tsunoo",
+      "Nobutaka Ono",
+      "Shigeki Sagayama"
+    ],
+    "title": "Autoregressive MFCC Models for Genre Classification Improved by Harmonic-percussion Separation.",
+    "pages": "87-92",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-17.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#RumpMTOS10"
+  },
+  "conf/ismir/AbesserBLS10": {
+    "@key": "conf/ismir/AbesserBLS10",
+    "@mdate": "2015-11-04",
+    "author": [
+      "Jakob Abe\u00dfer",
+      "Paul Br\u00e4uer",
+      "Hanna M. Lukashevich",
+      "Gerald Schuller"
+    ],
+    "title": "Bass Playing Style Detection Based on High-level Features and Pattern Similarity.",
+    "pages": "93-98",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-18.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#AbesserBLS10"
+  },
+  "conf/ismir/Smith10": {
+    "@key": "conf/ismir/Smith10",
+    "@mdate": "2011-08-15",
+    "author": "Leigh M. Smith",
+    "title": "Beat Critic: Beat Tracking Octave Error Identification By Metrical Profile Analysis.",
+    "pages": "99-104",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-19.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Smith10"
+  },
+  "conf/ismir/LuCYW10": {
+    "@key": "conf/ismir/LuCYW10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Qi Lu",
+      "Xiaoou Chen",
+      "Deshun Yang",
+      "Jun Wang"
+    ],
+    "title": "Boosting for Multi-Modal Music Emotion Classification.",
+    "pages": "105-110",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-20.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#LuCYW10"
+  },
+  "conf/ismir/Bertin-MahieuxWE10": {
+    "@key": "conf/ismir/Bertin-MahieuxWE10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Thierry Bertin-Mahieux",
+      "Ron J. Weiss",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "Clustering Beat-Chroma Patterns in a Large Music Database.",
+    "pages": "111-116",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-21.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Bertin-MahieuxWE10"
+  },
+  "conf/ismir/SchedlPKK10": {
+    "@key": "conf/ismir/SchedlPKK10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Markus Schedl",
+      "Tim Pohle",
+      "Noam Koenigstein",
+      "Peter Knees"
+    ],
+    "title": "What's Hot? Estimating Country-specific Artist Popularity.",
+    "pages": "117-122",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-22.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#SchedlPKK10"
+  },
+  "conf/ismir/WeissB10": {
+    "@key": "conf/ismir/WeissB10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ron J. Weiss",
+      "Juan Pablo Bello"
+    ],
+    "title": "Identifying Repeated Patterns in Music Using Sparse Convolutive Non-negative Matrix Factorization.",
+    "pages": "123-128",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-23.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#WeissB10"
+  },
+  "conf/ismir/KellyGDC10": {
+    "@key": "conf/ismir/KellyGDC10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Cillian Kelly",
+      "Mikel Gainza",
+      "David Dorran",
+      "Eugene Coyle"
+    ],
+    "title": "Locating Tune Changes and Providing a Semantic Labelling of Sets of Irish Traditional Tunes.",
+    "pages": "129-134",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-24.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#KellyGDC10"
+  },
+  "conf/ismir/MauchD10": {
+    "@key": "conf/ismir/MauchD10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Matthias Mauch",
+      "Simon Dixon"
+    ],
+    "title": "Approximate Note Transcription for the Improved Identification of Difficult Chords.",
+    "pages": "135-140",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-25.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MauchD10"
+  },
+  "conf/ismir/RocherRHO10": {
+    "@key": "conf/ismir/RocherRHO10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Thomas Rocher",
+      "Matthias Robine",
+      "Pierre Hanna",
+      "Laurent Oudre"
+    ],
+    "title": "Concurrent Estimation of Chords and Keys from Audio.",
+    "pages": "141-146",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-26.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#RocherRHO10"
+  },
+  "conf/ismir/HirjeeB10": {
+    "@key": "conf/ismir/HirjeeB10",
+    "@mdate": "2011-08-18",
+    "author": [
+      "Hussein Hirjee",
+      "Daniel G. Brown 0001"
+    ],
+    "title": "Solving Misheard Lyric Search Queries Using a Probabilistic Model of Speech Sounds.",
+    "pages": "147-152",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-27.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HirjeeB10"
+  },
+  "conf/ismir/KoenigsteinLMS10": {
+    "@key": "conf/ismir/KoenigsteinLMS10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Noam Koenigstein",
+      "Gert R. G. Lanckriet",
+      "Brian McFee",
+      "Yuval Shavitt"
+    ],
+    "title": "Collaborative Filtering Based on P2P Networks.",
+    "pages": "153-158",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-28.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#KoenigsteinLMS10"
+  },
+  "conf/ismir/HrybykK10": {
+    "@key": "conf/ismir/HrybykK10",
+    "@mdate": "2013-06-20",
+    "author": [
+      "Alex Hrybyk",
+      "Youngmoo E. Kim"
+    ],
+    "title": "Combined Audio and Video Analysis for Guitar Chord Identification.",
+    "pages": "159-164",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-29.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HrybykK10"
+  },
+  "conf/ismir/Ahonen10": {
+    "@key": "conf/ismir/Ahonen10",
+    "@mdate": "2011-08-15",
+    "author": "Teppo E. Ahonen",
+    "title": "Combining Chroma Features For Cover Version Identification.",
+    "pages": "165-170",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-30.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Ahonen10"
+  },
+  "conf/ismir/FlexerSGP10": {
+    "@key": "conf/ismir/FlexerSGP10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Arthur Flexer",
+      "Dominik Schnitzer",
+      "Martin Gasser",
+      "Tim Pohle"
+    ],
+    "title": "Combining Features Reduces Hubness in Audio Similarity.",
+    "pages": "171-176",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-31.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#FlexerSGP10"
+  },
+  "conf/ismir/Collins10": {
+    "@key": "conf/ismir/Collins10",
+    "@mdate": "2011-08-15",
+    "author": "Nick Collins",
+    "title": "Computational Analysis of Musical Influence: A Musicological Case Study Using MIR Tools.",
+    "pages": "177-182",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-32.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Collins10"
+  },
+  "conf/ismir/Lee10": {
+    "@key": "conf/ismir/Lee10",
+    "@mdate": "2011-08-15",
+    "author": "Jin Ha Lee",
+    "title": "Crowdsourcing Music Similarity Judgments using Mechanical Turk.",
+    "pages": "183-188",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-33.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Lee10"
+  },
+  "conf/ismir/BimbotBSV10": {
+    "@key": "conf/ismir/BimbotBSV10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Fr\u00e9d\u00e9ric Bimbot",
+      "Olivier Le Blouch",
+      "Gabriel Sargent",
+      "Emmanuel Vincent"
+    ],
+    "title": "Decomposition Into Autonomous and Comparable Blocks: A Structural Description of Music Pieces.",
+    "pages": "189-194",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-34.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#BimbotBSV10"
+  },
+  "conf/ismir/AngelesMF10": {
+    "@key": "conf/ismir/AngelesMF10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Bruno Angeles",
+      "Cory McKay",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Discovering Metadata Inconsistencies.",
+    "pages": "195-200",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-35.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#AngelesMF10"
+  },
+  "conf/ismir/ConklinB10": {
+    "@key": "conf/ismir/ConklinB10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Darrell Conklin",
+      "Mathieu Bergeron"
+    ],
+    "title": "Discovery of Contrapuntal Patterns.",
+    "pages": "201-206",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-36.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#ConklinB10"
+  },
+  "conf/ismir/Pinto10": {
+    "@key": "conf/ismir/Pinto10",
+    "@mdate": "2011-08-15",
+    "author": "Alberto Pinto",
+    "title": "Eigenvector-based Relational Motif Discovery.",
+    "pages": "207-212",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-37.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Pinto10"
+  },
+  "conf/ismir/McKayBHSVF10": {
+    "@key": "conf/ismir/McKayBHSVF10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Cory McKay",
+      "John Ashley Burgoyne",
+      "Jason Hockman",
+      "Jordan B. L. Smith",
+      "Gabriel Vigliensoni",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Evaluating the Genre Classification Performance of Lyrical Features Relative to Audio, Symbolic and Cultural Features.",
+    "pages": "213-218",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-38.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#McKayBHSVF10"
+  },
+  "conf/ismir/GansemanSMA10": {
+    "@key": "conf/ismir/GansemanSMA10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Joachim Ganseman",
+      "Paul Scheunders",
+      "Gautham J. Mysore",
+      "Jonathan S. Abel"
+    ],
+    "title": "Evaluation of a Score-informed Source Separation System.",
+    "pages": "219-224",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-39.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#GansemanSMA10"
+  },
+  "conf/ismir/Molina-SolanaGW10": {
+    "@key": "conf/ismir/Molina-SolanaGW10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Miguel Molina-Solana",
+      "Maarten Grachten",
+      "Gerhard Widmer"
+    ],
+    "title": "Evidence for Pianist-specific Rubato Style in Chopin Nocturnes.",
+    "pages": "225-230",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-40.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Molina-SolanaGW10"
+  },
+  "conf/ismir/HockmanF10": {
+    "@key": "conf/ismir/HockmanF10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jason Hockman",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Fast vs Slow: Learning Tempo Octaves from User Data.",
+    "pages": "231-236",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-41.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HockmanF10"
+  },
+  "conf/ismir/MillerRNT10": {
+    "@key": "conf/ismir/MillerRNT10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Scott Miller",
+      "Paul Reimer",
+      "Steven R. Ness",
+      "George Tzanetakis"
+    ],
+    "title": "Geoshuffle: Location-Aware, Content-based Music Browsing Using Self-organizing Tag Clouds.",
+    "pages": "237-242",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-42.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MillerRNT10"
+  },
+  "conf/ismir/FremereyMC10": {
+    "@key": "conf/ismir/FremereyMC10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Christian Fremerey",
+      "Meinard M\u00fcller",
+      "Michael Clausen"
+    ],
+    "title": "Handling Repeats and Jumps in Score-performance Synchronization.",
+    "pages": "243-248",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-43.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#FremereyMC10"
+  },
+  "conf/ismir/LiLO10": {
+    "@key": "conf/ismir/LiLO10",
+    "@mdate": "2017-09-18",
+    "author": [
+      "Jingxuan Li",
+      "Tao Li 0001",
+      "Mitsunori Ogihara"
+    ],
+    "title": "Hierarchical Co-Clustering of Artists and Tags.",
+    "pages": "249-254",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-44.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#LiLO10"
+  },
+  "conf/ismir/KimSMMRSST10": {
+    "@key": "conf/ismir/KimSMMRSST10",
+    "@mdate": "2011-11-22",
+    "author": [
+      "Youngmoo E. Kim",
+      "Erik M. Schmidt",
+      "Raymond Migneco",
+      "Brandon G. Morton",
+      "Patrick Richardson",
+      "Jeffrey J. Scott",
+      "Jacquelin A. Speck",
+      "Douglas Turnbull"
+    ],
+    "title": "State of the Art Report: Music Emotion Recognition: A State of the Art Review.",
+    "pages": "255-266",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-45.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#KimSMMRSST10"
+  },
+  "conf/ismir/KarydisRNI10": {
+    "@key": "conf/ismir/KarydisRNI10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ioannis Karydis",
+      "Milos Radovanovic",
+      "Alexandros Nanopoulos",
+      "Mirjana Ivanovic"
+    ],
+    "title": "Looking Through the \"Glass Ceiling\": A Conceptual Framework for the Problems of Spectral Similarity.",
+    "pages": "267-272",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-46.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#KarydisRNI10"
+  },
+  "conf/ismir/KoenigsteinSWW10": {
+    "@key": "conf/ismir/KoenigsteinSWW10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Noam Koenigstein",
+      "Yuval Shavitt",
+      "Ela Weinsberg",
+      "Udi Weinsberg"
+    ],
+    "title": "On the Applicability of Peer-to-peer Data in Music Information Retrieval Research.",
+    "pages": "273-278",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-47.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#KoenigsteinSWW10"
+  },
+  "conf/ismir/LidyMRLPQ10": {
+    "@key": "conf/ismir/LidyMRLPQ10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Thomas Lidy",
+      "Rudolf Mayer",
+      "Andreas Rauber",
+      "Pedro J. Ponce de Le\u00f3n",
+      "Antonio Pertusa",
+      "Jos\u00e9 Manuel I\u00f1esta Quereda"
+    ],
+    "title": "A Cartesian Ensemble of Feature Subspace Classifiers for Music Categorization.",
+    "pages": "279-284",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-48.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#LidyMRLPQ10"
+  },
+  "conf/ismir/UrbanoMML10": {
+    "@key": "conf/ismir/UrbanoMML10",
+    "@mdate": "2017-07-12",
+    "author": [
+      "Juli\u00e1n Urbano",
+      "M\u00f3nica Marrero",
+      "Diego Mart\u00edn 0001",
+      "Juan Llor\u00e9ns"
+    ],
+    "title": "Improving the Generation of Ground Truths Based on Partially Ordered Lists.",
+    "pages": "285-290",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-49.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#UrbanoMML10"
+  },
+  "conf/ismir/OliveiraGMR10": {
+    "@key": "conf/ismir/OliveiraGMR10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jo\u00e3o Lobato Oliveira",
+      "Fabien Gouyon",
+      "Luis Gustavo Martins",
+      "Lu\u00eds Paulo Reis"
+    ],
+    "title": "IBT: A Real-time Tempo and Beat Tracking System.",
+    "pages": "291-296",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-50.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#OliveiraGMR10"
+  },
+  "conf/ismir/MiottoBL10": {
+    "@key": "conf/ismir/MiottoBL10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Riccardo Miotto",
+      "Luke Barrington",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Improving Auto-tagging by Modeling Semantic Co-occurrences.",
+    "pages": "297-302",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-51.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MiottoBL10"
+  },
+  "conf/ismir/Paulus10": {
+    "@key": "conf/ismir/Paulus10",
+    "@mdate": "2011-08-15",
+    "author": "Jouni Paulus",
+    "title": "Improving Markov Model Based Music Piece Structure Labelling with Acoustic Information.",
+    "pages": "303-308",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-52.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Paulus10"
+  },
+  "conf/ismir/YoshiiG10": {
+    "@key": "conf/ismir/YoshiiG10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Kazuyoshi Yoshii",
+      "Masataka Goto"
+    ],
+    "title": "Infinite Latent Harmonic Allocation: A Nonparametric Bayesian Approach to Multipitch Analysis.",
+    "pages": "309-314",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-53.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#YoshiiG10"
+  },
+  "conf/ismir/HanR10": {
+    "@key": "conf/ismir/HanR10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Yushen Han",
+      "Christopher Raphael"
+    ],
+    "title": "Informed Source Separation of Orchestra and Soloist.",
+    "pages": "315-320",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-54.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HanR10"
+  },
+  "conf/ismir/BarbieriPER10": {
+    "@key": "conf/ismir/BarbieriPER10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Gabriele Barbieri",
+      "Fran\u00e7ois Pachet",
+      "Mirko Degli Esposti",
+      "Pierre Roy"
+    ],
+    "title": "Is There a Relation Between the Syntax and the Fitness of an Audio Feature?.",
+    "pages": "321-326",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-55.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#BarbieriPER10"
+  },
+  "conf/ismir/SchnitzerFWG10": {
+    "@key": "conf/ismir/SchnitzerFWG10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Dominik Schnitzer",
+      "Arthur Flexer",
+      "Gerhard Widmer",
+      "Martin Gasser"
+    ],
+    "title": "Islands of Gaussians: The Self Organizing Map and Gaussian Music Similarity Features.",
+    "pages": "327-332",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-56.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#SchnitzerFWG10"
+  },
+  "conf/ismir/MaroltL10": {
+    "@key": "conf/ismir/MaroltL10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Matija Marolt",
+      "Marieke Lefeber"
+    ],
+    "title": "It's Time for a Song - Transcribing Recordings of Bell-playing Clocks.",
+    "pages": "333-338",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-57.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MaroltL10"
+  },
+  "conf/ismir/HamelE10": {
+    "@key": "conf/ismir/HamelE10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Philippe Hamel",
+      "Douglas Eck"
+    ],
+    "title": "Learning Features from Music Audio with Deep Belief Networks.",
+    "pages": "339-344",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-58.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HamelE10"
+  },
+  "conf/ismir/McFeeBL10": {
+    "@key": "conf/ismir/McFeeBL10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Brian McFee",
+      "Luke Barrington",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Learning Similarity from Collaborative Filters.",
+    "pages": "345-350",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-59.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#McFeeBL10"
+  },
+  "conf/ismir/MoraGGED10": {
+    "@key": "conf/ismir/MoraGGED10",
+    "@mdate": "2018-03-29",
+    "author": [
+      "Joaqu\u00edn Mora",
+      "Francisco G\u00f3mez 0001",
+      "Emilia G\u00f3mez",
+      "Francisco Escobar-Borrego",
+      "Jos\u00e9 Miguel D\u00edaz-B\u00e1\u00f1ez"
+    ],
+    "title": "Characterization and Similarity in A Cappella Flamenco Cantes.",
+    "pages": "351-356",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-60.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MoraGGED10"
+  },
+  "conf/ismir/JoY10": {
+    "@key": "conf/ismir/JoY10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Seokhwan Jo",
+      "Chang D. Yoo"
+    ],
+    "title": "Melody Extraction from Polyphonic Audio Based on Particle Filter.",
+    "pages": "357-362",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-61.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#JoY10"
+  },
+  "conf/ismir/RaczynskiVBS10": {
+    "@key": "conf/ismir/RaczynskiVBS10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Stanislaw Andrzej Raczynski",
+      "Emmanuel Vincent",
+      "Fr\u00e9d\u00e9ric Bimbot",
+      "Shigeki Sagayama"
+    ],
+    "title": "Multiple Pitch Transcription using DBN-based Musicological Models.",
+    "pages": "363-368",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-62.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#RaczynskiVBS10"
+  },
+  "conf/ismir/DramanWL10": {
+    "@key": "conf/ismir/DramanWL10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Noor Azilah Draman",
+      "Campbell Wilson",
+      "Sea Ling"
+    ],
+    "title": "Modified Ais-based Classifier for Music Genre Classification.",
+    "pages": "369-374",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-63.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#DramanWL10"
+  },
+  "conf/ismir/MuraoNKOS10": {
+    "@key": "conf/ismir/MuraoNKOS10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Kazuma Murao",
+      "Masahiro Nakano",
+      "Yu Kitano",
+      "Nobutaka Ono",
+      "Shigeki Sagayama"
+    ],
+    "title": "Monophonic Instrument Sound Segregation by Clustering NMF Components Based on Basis Similarity and Gain Disjointness.",
+    "pages": "375-380",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-64.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MuraoNKOS10"
+  },
+  "conf/ismir/ChordiaSMA10": {
+    "@key": "conf/ismir/ChordiaSMA10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Parag Chordia",
+      "Avinash Sastry",
+      "Trishul Mallikarjuna",
+      "Aaron Albin"
+    ],
+    "title": "Multiple Viewpoints Modeling of Tabla Sequences.",
+    "pages": "381-386",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-65.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#ChordiaSMA10"
+  },
+  "conf/ismir/ChangJI10": {
+    "@key": "conf/ismir/ChangJI10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Kaichun K. Chang",
+      "Jyh-Shing Roger Jang",
+      "Costas S. Iliopoulos"
+    ],
+    "title": "Music Genre Classification via Compressive Sampling.",
+    "pages": "387-392",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-66.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#ChangJI10"
+  },
+  "conf/ismir/PanagakisKA10": {
+    "@key": "conf/ismir/PanagakisKA10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Yannis Panagakis",
+      "Constantine Kotropoulos",
+      "Gonzalo R. Arce"
+    ],
+    "title": "Sparse Multi-label Linear Embedding Within Nonnegative Tensor Factorization Applied to Music Tagging.",
+    "pages": "393-398",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-67.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#PanagakisKA10"
+  },
+  "conf/ismir/MandelEB10": {
+    "@key": "conf/ismir/MandelEB10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Michael I. Mandel",
+      "Douglas Eck",
+      "Yoshua Bengio"
+    ],
+    "title": "Learning Tags that Vary Within a Song.",
+    "pages": "399-404",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-68.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MandelEB10"
+  },
+  "conf/ismir/WangCHF10": {
+    "@key": "conf/ismir/WangCHF10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jun Wang",
+      "Xiaoou Chen",
+      "Yajie Hu",
+      "Tao Feng"
+    ],
+    "title": "Predicting High-level Music Semantics Using Social Tags via Ontology-based Reasoning.",
+    "pages": "405-410",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-69.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#WangCHF10"
+  },
+  "conf/ismir/IzmirliD10": {
+    "@key": "conf/ismir/IzmirliD10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "\u00d6zg\u00fcr Izmirli",
+      "Roger B. Dannenberg"
+    ],
+    "title": "Understanding Features and Distance Functions for Music Sequence Alignment.",
+    "pages": "411-416",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-70.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#IzmirliD10"
+  },
+  "conf/ismir/NiedermayerW10": {
+    "@key": "conf/ismir/NiedermayerW10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Bernhard Niedermayer",
+      "Gerhard Widmer"
+    ],
+    "title": "A Multi-pass Algorithm for Accurate Audio-to-Score Alignment.",
+    "pages": "417-422",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-71.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#NiedermayerW10"
+  },
+  "conf/ismir/MacraeD10": {
+    "@key": "conf/ismir/MacraeD10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Robert Macrae",
+      "Simon Dixon"
+    ],
+    "title": "Accurate Real-time Windowed Time Warping.",
+    "pages": "423-428",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-72.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MacraeD10"
+  },
+  "conf/ismir/KaiserS10": {
+    "@key": "conf/ismir/KaiserS10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Florian Kaiser",
+      "Thomas Sikora"
+    ],
+    "title": "Music Structure Discovery in Popular Music using Non-negative Matrix Factorization.",
+    "pages": "429-434",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-73.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#KaiserS10"
+  },
+  "conf/ismir/TjoaL10": {
+    "@key": "conf/ismir/TjoaL10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Steven K. Tjoa",
+      "K. J. Ray Liu"
+    ],
+    "title": "Musical Instrument Recognition using Biologically Inspired Filtering of Temporal Dictionary Atoms.",
+    "pages": "435-440",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-74.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#TjoaL10"
+  },
+  "conf/ismir/MathieuEFPR10": {
+    "@key": "conf/ismir/MathieuEFPR10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Beno\u00eet Mathieu",
+      "Slim Essid",
+      "Thomas Fillon",
+      "Jacques Prado",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "YAAFE, an Easy to Use and Efficient Audio Feature Extraction Software.",
+    "pages": "441-446",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-75.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MathieuEFPR10"
+  },
+  "conf/ismir/Schedl10": {
+    "@key": "conf/ismir/Schedl10",
+    "@mdate": "2011-08-15",
+    "author": "Markus Schedl",
+    "title": "On the Use of Microblogging Posts for Similarity Estimation and Artist Labeling.",
+    "pages": "447-452",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-76.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Schedl10"
+  },
+  "conf/ismir/HolzapfelS10": {
+    "@key": "conf/ismir/HolzapfelS10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Andre Holzapfel",
+      "Yannis Stylianou"
+    ],
+    "title": "Parataxis: Morphological Similarity in Traditional Music.",
+    "pages": "453-458",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-77.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HolzapfelS10"
+  },
+  "conf/ismir/HoninghB10": {
+    "@key": "conf/ismir/HoninghB10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Aline K. Honingh",
+      "Rens Bod"
+    ],
+    "title": "Pitch Class Set Categories as Analysis Tools for Degrees of Tonality.",
+    "pages": "459-464",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-78.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HoninghB10"
+  },
+  "conf/ismir/SchmidtK10": {
+    "@key": "conf/ismir/SchmidtK10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Erik M. Schmidt",
+      "Youngmoo E. Kim"
+    ],
+    "title": "Prediction of Time-varying Musical Mood Distributions from Audio.",
+    "pages": "465-470",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-79.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#SchmidtK10"
+  },
+  "conf/ismir/ChuanC10": {
+    "@key": "conf/ismir/ChuanC10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ching-Hua Chuan",
+      "Elaine Chew"
+    ],
+    "title": "Quantifying the Benefits of Using an Interactive Decision Support Tool for Creating Musical Accompaniment in a Particular Style.",
+    "pages": "471-476",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-80.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#ChuanC10"
+  },
+  "conf/ismir/MaezawaGO10": {
+    "@key": "conf/ismir/MaezawaGO10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Akira Maezawa",
+      "Masataka Goto",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Query-by-conducting: An Interface to Retrieve Classical-music Interpretations by Real-time Tempo Input.",
+    "pages": "477-482",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-81.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MaezawaGO10"
+  },
+  "conf/ismir/JewellRd10": {
+    "@key": "conf/ismir/JewellRd10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Michael O. Jewell",
+      "Christophe Rhodes",
+      "Mark d'Inverno"
+    ],
+    "title": "Querying Improvised Music: Do You Sound Like Yourself?.",
+    "pages": "483-488",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-82.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#JewellRd10"
+  },
+  "conf/ismir/DesseinCL10": {
+    "@key": "conf/ismir/DesseinCL10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Arnaud Dessein",
+      "Arshia Cont",
+      "Guillaume Lemaitre"
+    ],
+    "title": "Real-time Polyphonic Music Transcription with Non-negative Matrix Factorization and Beta-divergence.",
+    "pages": "489-494",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-83.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#DesseinCL10"
+  },
+  "conf/ismir/CrawfordMR10": {
+    "@key": "conf/ismir/CrawfordMR10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Tim Crawford",
+      "Matthias Mauch",
+      "Christophe Rhodes"
+    ],
+    "title": "Recognising Classical Works in Historical Recordings.",
+    "pages": "495-500",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-84.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#CrawfordMR10"
+  },
+  "conf/ismir/Marsden10": {
+    "@key": "conf/ismir/Marsden10",
+    "@mdate": "2011-08-15",
+    "author": "Alan Marsden",
+    "title": "Recognition of Variations Using Automatic Schenkerian Reduction.",
+    "pages": "501-506",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-85.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Marsden10"
+  },
+  "conf/ismir/BergstraME10": {
+    "@key": "conf/ismir/BergstraME10",
+    "@mdate": "2011-08-16",
+    "author": [
+      "James Bergstra",
+      "Michael I. Mandel",
+      "Douglas Eck"
+    ],
+    "title": "Scalable Genre and Tag Prediction with Spectral Covariance.",
+    "pages": "507-512",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-86.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#BergstraME10"
+  },
+  "conf/ismir/MakLSYL10": {
+    "@key": "conf/ismir/MakLSYL10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Chun-Man Mak",
+      "Tan Lee",
+      "Suman Senapati",
+      "Yu Ting Yeung",
+      "Wang-Kong Lam"
+    ],
+    "title": "Similarity Measures for Chinese Pop Music Based on Low-level Audio Signal Attributes.",
+    "pages": "513-518",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-87.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#MakLSYL10"
+  },
+  "conf/ismir/Gartner10": {
+    "@key": "conf/ismir/Gartner10",
+    "@mdate": "2011-08-15",
+    "author": "Daniel G\u00e4rtner",
+    "title": "Singing / Rap Classification of Isolated Vocal Tracks.",
+    "pages": "519-524",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-88.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Gartner10"
+  },
+  "conf/ismir/HsuJ10": {
+    "@key": "conf/ismir/HsuJ10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Chao-Ling Hsu",
+      "Jyh-Shing Roger Jang"
+    ],
+    "title": "Singing Pitch Extraction by Voice Vibrato / Tremolo Estimation and Instrument Partial Deletion.",
+    "pages": "525-530",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-89.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HsuJ10"
+  },
+  "conf/ismir/BaurSB10": {
+    "@key": "conf/ismir/BaurSB10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Dominikus Baur",
+      "Bartholom\u00e4us Steinmayr",
+      "Andreas Butz"
+    ],
+    "title": "SongWords: Exploring Music Collections Through Lyrics.",
+    "pages": "531-536",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-90.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#BaurSB10"
+  },
+  "conf/ismir/HillewaereMC10": {
+    "@key": "conf/ismir/HillewaereMC10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ruben Hillewaere",
+      "Bernard Manderick",
+      "Darrell Conklin"
+    ],
+    "title": "String Quartet Classification with Monophonic Models.",
+    "pages": "537-542",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-91.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HillewaereMC10"
+  },
+  "conf/ismir/KneesSPSW10": {
+    "@key": "conf/ismir/KneesSPSW10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Peter Knees",
+      "Markus Schedl",
+      "Tim Pohle",
+      "Klaus Seyerlehner",
+      "Gerhard Widmer"
+    ],
+    "title": "Supervised and Unsupervised Web Document Filtering Techniques to Improve Text-Based Music Retrieval.",
+    "pages": "543-548",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-92.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#KneesSPSW10"
+  },
+  "conf/ismir/RamirezO10": {
+    "@key": "conf/ismir/RamirezO10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Carolina Ramirez",
+      "Jun Ohya"
+    ],
+    "title": "Symbol Classification Approach for OMR of Square Notation Manuscripts.",
+    "pages": "549-554",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-93.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#RamirezO10"
+  },
+  "conf/ismir/GkiokasKC10": {
+    "@key": "conf/ismir/GkiokasKC10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Aggelos Gkiokas",
+      "Vassilios Katsouros",
+      "George Carayannis"
+    ],
+    "title": "Tempo Induction Using Filterbank Analysis and Tonal Features.",
+    "pages": "555-558",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-95.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#GkiokasKC10"
+  },
+  "conf/ismir/SammartinoTBBB10": {
+    "@key": "conf/ismir/SammartinoTBBB10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Simone Sammartino",
+      "Lorenzo J. Tard\u00f3n",
+      "Cristina de la Bandera",
+      "Isabel Barbancho",
+      "Ana M. Barbancho"
+    ],
+    "title": "The Standardized Variogram as a Novel Tool for Music Similarity Evaluation.",
+    "pages": "559-564",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-96.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#SammartinoTBBB10"
+  },
+  "conf/ismir/ChenK10": {
+    "@key": "conf/ismir/ChenK10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Ya-Xi Chen",
+      "Ren\u00e9 Kl\u00fcber"
+    ],
+    "title": "ThumbnailDJ: Visual Thumbnails of Music Content.",
+    "pages": "565-570",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-97.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#ChenK10"
+  },
+  "conf/ismir/FerrerE10": {
+    "@key": "conf/ismir/FerrerE10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Rafael Ferrer",
+      "Tuomas Eerola"
+    ],
+    "title": "Timbral Qualities of Semantic Structures of Music.",
+    "pages": "571-576",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-98.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#FerrerE10"
+  },
+  "conf/ismir/Lemstrom10": {
+    "@key": "conf/ismir/Lemstrom10",
+    "@mdate": "2011-08-15",
+    "author": "Kjell Lemstr\u00f6m",
+    "title": "Towards More Robust Geometric Content-Based Music Retrieval.",
+    "pages": "577-582",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-99.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Lemstrom10"
+  },
+  "conf/ismir/DugganO10": {
+    "@key": "conf/ismir/DugganO10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Bryan Duggan",
+      "Brendan O'Shea"
+    ],
+    "title": "Tunepal - Disseminating a Music Information Retrieval System to the Traditional Irish Music Community.",
+    "pages": "583-588",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-100.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#DugganO10"
+  },
+  "conf/ismir/EybenBSG10": {
+    "@key": "conf/ismir/EybenBSG10",
+    "@mdate": "2015-06-17",
+    "author": [
+      "Florian Eyben",
+      "Sebastian B\u00f6ck",
+      "Bj\u00f6rn W. Schuller",
+      "Alex Graves"
+    ],
+    "title": "Universal Onset Detection with Bidirectional Long Short-Term Memory Neural Networks.",
+    "pages": "589-594",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-101.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#EybenBSG10"
+  },
+  "conf/ismir/LagrangeS10": {
+    "@key": "conf/ismir/LagrangeS10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Mathieu Lagrange",
+      "Joan Serr\u00e0"
+    ],
+    "title": "Unsupervised Accuracy Improvement for Cover Song Detection Using Spectral Connectivity Network.",
+    "pages": "595-600",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-102.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#LagrangeS10"
+  },
+  "conf/ismir/Laplante10": {
+    "@key": "conf/ismir/Laplante10",
+    "@mdate": "2011-08-15",
+    "author": "Audrey Laplante",
+    "title": "Users' Relevance Criteria in Music Retrieval in Everyday Life: An Exploratory Study.",
+    "pages": "601-606",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-103.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#Laplante10"
+  },
+  "conf/ismir/VigliensoniMF10": {
+    "@key": "conf/ismir/VigliensoniMF10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Gabriel Vigliensoni",
+      "Cory McKay",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Using jWebMiner 2.0 to Improve Music Classification Performance by Combining Different Types of Features Mined from the Web.",
+    "pages": "607-612",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-104.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#VigliensoniMF10"
+  },
+  "conf/ismir/SchullerKWER10": {
+    "@key": "conf/ismir/SchullerKWER10",
+    "@mdate": "2015-06-17",
+    "author": [
+      "Bj\u00f6rn W. Schuller",
+      "Christoph Kozielski",
+      "Felix Weninger",
+      "Florian Eyben",
+      "Gerhard Rigoll"
+    ],
+    "title": "Vocalist Gender Recognition in Recorded Popular Music.",
+    "pages": "613-618",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-105.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#SchullerKWER10"
+  },
+  "conf/ismir/HuD10": {
+    "@key": "conf/ismir/HuD10",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "J. Stephen Downie"
+    ],
+    "title": "When Lyrics Outperform Audio for Music Mood Classification: A Feature Analysis.",
+    "pages": "619-624",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-106.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#HuD10"
+  },
+  "conf/ismir/PaulusMK10": {
+    "@key": "conf/ismir/PaulusMK10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jouni Paulus",
+      "Meinard M\u00fcller",
+      "Anssi Klapuri"
+    ],
+    "title": "State of the Art Report: Audio-Based Music Structure Analysis.",
+    "pages": "625-636",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-107.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#PaulusMK10"
+  },
+  "conf/ismir/CuthbertA10": {
+    "@key": "conf/ismir/CuthbertA10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Michael Scott Cuthbert",
+      "Christopher Ariza"
+    ],
+    "title": "Music21: A Toolkit for Computer-Aided Musicology and Symbolic Music Data.",
+    "pages": "637-642",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-108.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#CuthbertA10"
+  },
+  "conf/ismir/ScottMMHDK10": {
+    "@key": "conf/ismir/ScottMMHDK10",
+    "@mdate": "2017-08-17",
+    "author": [
+      "Jeffrey J. Scott",
+      "Raymond Migneco",
+      "Brandon G. Morton",
+      "Christian M. Hahn",
+      "Paul J. Diefenbach",
+      "Youngmoo E. Kim"
+    ],
+    "title": "An Audio Processing Library for MIR Application Development in Flash.",
+    "pages": "643-648",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-109.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#ScottMMHDK10"
+  },
+  "conf/ismir/GroscheMS10": {
+    "@key": "conf/ismir/GroscheMS10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Peter Grosche",
+      "Meinard M\u00fcller",
+      "Craig Stuart Sapp"
+    ],
+    "title": "What Makes Beat Tracking Difficult? A Case Study on Chopin Mazurkas.",
+    "pages": "649-654",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-110.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#GroscheMS10"
+  },
+  "conf/ismir/InskipMR10": {
+    "@key": "conf/ismir/InskipMR10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Charlie Inskip",
+      "Andy MacFarlane",
+      "Pauline Rafferty"
+    ],
+    "title": "Upbeat and Quirky, With a Bit of a Build: Interpretive Repertoires in Creative Music Search.",
+    "pages": "655-661",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-111.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#InskipMR10"
+  },
+  "conf/ismir/VincentROS10": {
+    "@key": "conf/ismir/VincentROS10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Emmanuel Vincent",
+      "Stanislaw Andrzej Raczynski",
+      "Nobutaka Ono",
+      "Shigeki Sagayama"
+    ],
+    "title": "A Roadmap Towards Versatile MIR.",
+    "pages": "662-664",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-113.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#VincentROS10"
+  },
+  "conf/ismir/WolkowiczK10": {
+    "@key": "conf/ismir/WolkowiczK10",
+    "@mdate": "2011-08-15",
+    "author": [
+      "Jacek Wolkowicz",
+      "Vlado Keselj"
+    ],
+    "title": "Predicting Development of Research in Music Based on Parallels with Natural Language Processing.",
+    "pages": "665-667",
+    "year": "2010",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2010.ismir.net/proceedings/ismir2010-114.pdf",
+    "crossref": "conf/ismir/2010",
+    "url": "db/conf/ismir/ismir2010.html#WolkowiczK10"
+  },
+  "conf/ismir/Dressler11": {
+    "@key": "conf/ismir/Dressler11",
+    "@mdate": "2011-12-06",
+    "author": "Karin Dressler",
+    "title": "An Auditory Streaming Approach for Melody Extraction from Polyphonic Music.",
+    "pages": "19-24",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS1-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Dressler11"
+  },
+  "conf/ismir/ChienWJ11": {
+    "@key": "conf/ismir/ChienWJ11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Yu-Ren Chien",
+      "Hsin-Min Wang",
+      "Shyh-Kang Jeng"
+    ],
+    "title": "An Acoustic-Phonetic Approach to Vocal Melody Extraction.",
+    "pages": "25-30",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS1-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#ChienWJ11"
+  },
+  "conf/ismir/DaidoHIMI11": {
+    "@key": "conf/ismir/DaidoHIMI11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Ryunosuke Daido",
+      "Seongjun Hahm",
+      "Masashi Ito",
+      "Shozo Makino",
+      "Akinori Ito"
+    ],
+    "title": "A System for Evaluating Singing Enthusiasm for Karaoke.",
+    "pages": "31-36",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS1-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#DaidoHIMI11"
+  },
+  "conf/ismir/WeningerWS11": {
+    "@key": "conf/ismir/WeningerWS11",
+    "@mdate": "2015-06-17",
+    "author": [
+      "Felix Weninger",
+      "Martin W\u00f6llmer",
+      "Bj\u00f6rn W. Schuller"
+    ],
+    "title": "Automatic Assessment of Singer Traits in Popular Music: Gender, Age, Height and Race.",
+    "pages": "37-42",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS1-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#WeningerWS11"
+  },
+  "conf/ismir/UnalCGN11": {
+    "@key": "conf/ismir/UnalCGN11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Erdem Unal",
+      "Elaine Chew",
+      "Panayiotis G. Georgiou",
+      "Shrikanth Narayanan"
+    ],
+    "title": "A Preplexity Based Cover Song Matching System for Short Length Queries.",
+    "pages": "43-48",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#UnalCGN11"
+  },
+  "conf/ismir/BanderaBTSB11": {
+    "@key": "conf/ismir/BanderaBTSB11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Cristina de la Bandera",
+      "Ana M. Barbancho",
+      "Lorenzo J. Tard\u00f3n",
+      "Simone Sammartino",
+      "Isabel Barbancho"
+    ],
+    "title": "Humming Method for Content-Based Music Information Retrieval.",
+    "pages": "49-54",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#BanderaBTSB11"
+  },
+  "conf/ismir/McFeeL11": {
+    "@key": "conf/ismir/McFeeL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Brian McFee",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Large-scale music similarity search with spatial trees.",
+    "pages": "55-60",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#McFeeL11"
+  },
+  "conf/ismir/Garcia-DiezSSF11": {
+    "@key": "conf/ismir/Garcia-DiezSSF11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Silvia Garc\u00eda-D\u00edez",
+      "Marco Saerens",
+      "Mathieu Senelle",
+      "Fran\u00e7ois Fouss"
+    ],
+    "title": "A simple-cycles weighted kernel based on harmony structure for similarity retrieval.",
+    "pages": "61-66",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Garcia-DiezSSF11"
+  },
+  "conf/ismir/HaasMVW11": {
+    "@key": "conf/ismir/HaasMVW11",
+    "@mdate": "2015-11-04",
+    "author": [
+      "W. Bas de Haas",
+      "Jos\u00e9 Pedro Magalh\u00e3es",
+      "Remco C. Veltkamp",
+      "Frans Wiering"
+    ],
+    "title": "HarmTrace: Improving Harmonic Similarity Estimation Using Functional Harmony Analysis.",
+    "pages": "67-72",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-5.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#HaasMVW11"
+  },
+  "conf/ismir/WolffW11": {
+    "@key": "conf/ismir/WolffW11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Daniel Wolff",
+      "Tillman Weyde"
+    ],
+    "title": "Adapting Metrics for Music Similarity Using Comparative Ratings.",
+    "pages": "73-78",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-6.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#WolffW11"
+  },
+  "conf/ismir/SchnitzerFSW11": {
+    "@key": "conf/ismir/SchnitzerFSW11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Dominik Schnitzer",
+      "Arthur Flexer",
+      "Markus Schedl",
+      "Gerhard Widmer"
+    ],
+    "title": "Using Mutual Proximity to Improve Content-Based Audio Similarity.",
+    "pages": "79-84",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-7.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SchnitzerFSW11"
+  },
+  "conf/ismir/WangLWJ11": {
+    "@key": "conf/ismir/WangLWJ11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Ju-Chiang Wang",
+      "Hung-Shin Lee",
+      "Hsin-Min Wang",
+      "Shyh-Kang Jeng"
+    ],
+    "title": "Learning the Similarity of Audio Music in Bag-of-frames Representation from Tagged Music Data.",
+    "pages": "85-90",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-8.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#WangLWJ11"
+  },
+  "conf/ismir/AhonenLL11": {
+    "@key": "conf/ismir/AhonenLL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Teppo E. Ahonen",
+      "Kjell Lemstr\u00f6m",
+      "Simo Linkola"
+    ],
+    "title": "Compression-based Similarity Measures in Symbolic, Polyphonic Music.",
+    "pages": "91-96",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-9.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#AhonenLL11"
+  },
+  "conf/ismir/BogdanovH11": {
+    "@key": "conf/ismir/BogdanovH11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Dmitry Bogdanov",
+      "Perfecto Herrera"
+    ],
+    "title": "How Much Metadata Do We Need in Music Recommendation? A Subjective Evaluation Using Preference Sets.",
+    "pages": "97-102",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-10.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#BogdanovH11"
+  },
+  "conf/ismir/HuO11": {
+    "@key": "conf/ismir/HuO11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Yajie Hu",
+      "Mitsunori Ogihara"
+    ],
+    "title": "NextOne Player: A Music Recommendation System Based on User Behavior.",
+    "pages": "103-108",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-11.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#HuO11"
+  },
+  "conf/ismir/Lee11": {
+    "@key": "conf/ismir/Lee11",
+    "@mdate": "2011-12-06",
+    "author": "Jin Ha Lee",
+    "title": "How Similar Is Too Similar?: Exploring Users' Perceptions of Similarity in Playlist Evaluation.",
+    "pages": "109-114",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-12.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Lee11"
+  },
+  "conf/ismir/GangBLRHB11": {
+    "@key": "conf/ismir/GangBLRHB11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Ren Gang",
+      "Gregory Bocko",
+      "Justin Lundberg",
+      "Stephen Roessner",
+      "Dave Headlam",
+      "Mark F. Bocko"
+    ],
+    "title": "A Real-Time Signal Processing Framework of Musical Expressive Feature Extraction Using Matlab.",
+    "pages": "115-120",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-13.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#GangBLRHB11"
+  },
+  "conf/ismir/FenetRG11": {
+    "@key": "conf/ismir/FenetRG11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "S\u00e9bastien Fenet",
+      "Ga\u00ebl Richard",
+      "Yves Grenier"
+    ],
+    "title": "A Scalable Audio Fingerprint Method with Robustness to Pitch-Shifting.",
+    "pages": "121-126",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-14.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#FenetRG11"
+  },
+  "conf/ismir/SchreiberGM11": {
+    "@key": "conf/ismir/SchreiberGM11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Hendrik Schreiber",
+      "Peter Grosche",
+      "Meinard M\u00fcller"
+    ],
+    "title": "A Re-ordering Strategy for Accelerating Index-based Audio Fingerprinting.",
+    "pages": "127-132",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-15.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SchreiberGM11"
+  },
+  "conf/ismir/XiaoSK11": {
+    "@key": "conf/ismir/XiaoSK11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Qingmei Xiao",
+      "Motoyuki Suzuki",
+      "Kenji Kita"
+    ],
+    "title": "Fast Hamming Space Search for Audio Fingerprinting Systems.",
+    "pages": "133-138",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-16.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#XiaoSK11"
+  },
+  "conf/ismir/XiaLDH11": {
+    "@key": "conf/ismir/XiaLDH11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Guangyu Xia",
+      "Dawen Liang",
+      "Roger B. Dannenberg",
+      "Mark Harvilla"
+    ],
+    "title": "Segmentation, Clustering, and Display in a Personal Audio Database for Musicians.",
+    "pages": "139-144",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-17.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#XiaLDH11"
+  },
+  "conf/ismir/GulluniEBR11": {
+    "@key": "conf/ismir/GulluniEBR11",
+    "@mdate": "2016-07-11",
+    "author": [
+      "S\u00e9bastien Gulluni",
+      "Slim Essid",
+      "Olivier Buisson",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "An Interactive System for Electro-Acoustic Music Analysis.",
+    "pages": "145-150",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS1-18.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#GulluniEBR11"
+  },
+  "conf/ismir/Serra11": {
+    "@key": "conf/ismir/Serra11",
+    "@mdate": "2011-12-06",
+    "author": "Xavier Serra",
+    "title": "A Multicultural Approach in Music Information Research.",
+    "pages": "151-156",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS2-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Serra11"
+  },
+  "conf/ismir/SerraKMS11": {
+    "@key": "conf/ismir/SerraKMS11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Joan Serr\u00e0",
+      "Gopala K. Koduri",
+      "Marius Miron",
+      "Xavier Serra"
+    ],
+    "title": "Assessing the Tuning of Sung Indian Classical Music.",
+    "pages": "157-162",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS2-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SerraKMS11"
+  },
+  "conf/ismir/KranenburgBNT11": {
+    "@key": "conf/ismir/KranenburgBNT11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Peter van Kranenburg",
+      "D\u00e1niel P\u00e9ter Bir\u00f3",
+      "Steven R. Ness",
+      "George Tzanetakis"
+    ],
+    "title": "A Computational Investigation of Melodic Contour Stability in Jewish Torah Trope Performance Traditions.",
+    "pages": "163-168",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS2-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#KranenburgBNT11"
+  },
+  "conf/ismir/SixC11": {
+    "@key": "conf/ismir/SixC11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Joren Six",
+      "Olmo Cornelis"
+    ],
+    "title": "Tarsos - a Platform to Explore Pitch Scales in Non-Western and Western Music.",
+    "pages": "169-174",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS2-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SixC11"
+  },
+  "conf/ismir/NamNLS11": {
+    "@key": "conf/ismir/NamNLS11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Juhan Nam",
+      "Jiquan Ngiam",
+      "Honglak Lee",
+      "Malcolm Slaney"
+    ],
+    "title": "A Classification-Based Polyphonic Piano Transcription Approach Using Learned Feature Representations.",
+    "pages": "175-180",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#NamNLS11"
+  },
+  "conf/ismir/NakashikaTA11": {
+    "@key": "conf/ismir/NakashikaTA11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Toru Nakashika",
+      "Tetsuya Takiguchi",
+      "Yasuo Ariki"
+    ],
+    "title": "Constrained Spectrum Generation Using A Probabilistic Spectrum Envelope for Mixed Music Analysis.",
+    "pages": "181-184",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#NakashikaTA11"
+  },
+  "conf/ismir/VelascoL11": {
+    "@key": "conf/ismir/VelascoL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Marc J. Velasco",
+      "Edward W. Large"
+    ],
+    "title": "Pulse Detection in Syncopated Rhythms Using Neural Oscillators.",
+    "pages": "185-190",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#VelascoL11"
+  },
+  "conf/ismir/WuLJCLW11": {
+    "@key": "conf/ismir/WuLJCLW11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Fu-Hai Frank Wu",
+      "Tsung-Chi Lee",
+      "Jyh-Shing Roger Jang",
+      "Kaichun K. Chang",
+      "Chun-Hung Lu",
+      "Wen-Nan Wang"
+    ],
+    "title": "A Two-Fold Dynamic Programming Approach to Beat Tracking for Audio Music with Time-Varying Tempo.",
+    "pages": "191-196",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#WuLJCLW11"
+  },
+  "conf/ismir/TryfouHM11": {
+    "@key": "conf/ismir/TryfouHM11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Georgina Tryfou",
+      "Aki H\u00e4rm\u00e4",
+      "Athanasios Mouchtaris"
+    ],
+    "title": "Tempo Estimation Based on Linear Prediction and Perceptual Modelling.",
+    "pages": "197-202",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-5.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#TryfouHM11"
+  },
+  "conf/ismir/ThoshkahnaNK11": {
+    "@key": "conf/ismir/ThoshkahnaNK11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Balaji Thoshkahna",
+      "Fran\u00e7ois Xavier Nsabimana",
+      "Ramakrishnan R. Kalpathi"
+    ],
+    "title": "A Transient Detection Algorithm for Audio Using Iterative Analysis of STFT.",
+    "pages": "203-208",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-6.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#ThoshkahnaNK11"
+  },
+  "conf/ismir/AbesserL11": {
+    "@key": "conf/ismir/AbesserL11",
+    "@mdate": "2015-11-04",
+    "author": [
+      "Jakob Abe\u00dfer",
+      "Olivier Lartillot"
+    ],
+    "title": "Modeling Musical Attributes to Characterize Two-Track Recordings with Bass and Drums.",
+    "pages": "209-214",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-7.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#AbesserL11"
+  },
+  "conf/ismir/MullerE11": {
+    "@key": "conf/ismir/MullerE11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Meinard M\u00fcller",
+      "Sebastian Ewert"
+    ],
+    "title": "Chroma Toolbox: Matlab Implementations for Extracting Variants of Chroma-Based Audio Features.",
+    "pages": "215-220",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-8.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MullerE11"
+  },
+  "conf/ismir/Chuan11": {
+    "@key": "conf/ismir/Chuan11",
+    "@mdate": "2011-12-06",
+    "author": "Ching-Hua Chuan",
+    "title": "A Comparison of Statistical and Rule-Based Models for Style-Specific Harmonization.",
+    "pages": "221-226",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-9.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Chuan11"
+  },
+  "conf/ismir/JooPJY11": {
+    "@key": "conf/ismir/JooPJY11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Sihyun Joo",
+      "Sanghun Park",
+      "Seokhwan Jo",
+      "Chang D. Yoo"
+    ],
+    "title": "Melody Extraction based on Harmonic Coded Structure.",
+    "pages": "227-232",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-10.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#JooPJY11"
+  },
+  "conf/ismir/MauchFYG11": {
+    "@key": "conf/ismir/MauchFYG11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Matthias Mauch",
+      "Hiromasa Fujihara",
+      "Kazuyoshi Yoshii",
+      "Masataka Goto"
+    ],
+    "title": "Timbre and Melody Features for the Recognition of Vocal Activity and Instrumental Solos in Polyphonic Music.",
+    "pages": "233-238",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-11.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MauchFYG11"
+  },
+  "conf/ismir/FuhrmannH11": {
+    "@key": "conf/ismir/FuhrmannH11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Ferdinand Fuhrmann",
+      "Perfecto Herrera"
+    ],
+    "title": "Quantifying the Relevance of Locally Extracted Information for Musical Instrument Recognition from Entire Pieces of Music.",
+    "pages": "239-244",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-12.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#FuhrmannH11"
+  },
+  "conf/ismir/EwertM11": {
+    "@key": "conf/ismir/EwertM11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Sebastian Ewert",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Score-Informed Voice Separation For Piano Recordings.",
+    "pages": "245-250",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-13.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#EwertM11"
+  },
+  "conf/ismir/ThoshkahnaK11": {
+    "@key": "conf/ismir/ThoshkahnaK11",
+    "@mdate": "2011-12-07",
+    "author": [
+      "Balaji Thoshkahna",
+      "Ramakrishnan R. Kalpathi"
+    ],
+    "title": "A Postprocessing Technique for Improved Harmonic/Percussion Separation for Polyphonic Music.",
+    "pages": "251-256",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-14.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#ThoshkahnaK11"
+  },
+  "conf/ismir/TjoaL11": {
+    "@key": "conf/ismir/TjoaL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Steven K. Tjoa",
+      "K. J. Ray Liu"
+    ],
+    "title": "Factorization of Overlapping Harmonic Sounds Using Approximate Matching Pursuit.",
+    "pages": "257-262",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-15.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#TjoaL11"
+  },
+  "conf/ismir/KoduriMSS11": {
+    "@key": "conf/ismir/KoduriMSS11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Gopala K. Koduri",
+      "Marius Miron",
+      "Joan Serr\u00e0",
+      "Xavier Serra"
+    ],
+    "title": "Computational Approaches for the Understanding of Melody in Carnatic Music.",
+    "pages": "263-268",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-16.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#KoduriMSS11"
+  },
+  "conf/ismir/SenturkC11": {
+    "@key": "conf/ismir/SenturkC11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Sertan Sent\u00fcrk",
+      "Parag Chordia"
+    ],
+    "title": "Modeling Melodic Improvisation in Turkish Folk Music Using Variable-Length Markov Models.",
+    "pages": "269-274",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-17.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.htmlSenturkC11"
+  },
+  "conf/ismir/Abdoli11": {
+    "@key": "conf/ismir/Abdoli11",
+    "@mdate": "2011-12-06",
+    "author": "Sajjad Abdoli",
+    "title": "Iranian Traditional Music Dastgah Classification.",
+    "pages": "275-280",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-18.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Abdoli11"
+  },
+  "conf/ismir/DixonTB11": {
+    "@key": "conf/ismir/DixonTB11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Simon Dixon",
+      "Dan Tidhar",
+      "Emmanouil Benetos"
+    ],
+    "title": "The Temperament Police: The Truth, the Ground Truth, and Nothing but the Truth.",
+    "pages": "281-286",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-19.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#DixonTB11"
+  },
+  "conf/ismir/BimbotDSV11": {
+    "@key": "conf/ismir/BimbotDSV11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Fr\u00e9d\u00e9ric Bimbot",
+      "Emmanuel Deruty",
+      "Gabriel Sargent",
+      "Emmanuel Vincent"
+    ],
+    "title": "Methodology and Resources for The Structural Segmentation of Music Pieces into Autonomous and Comparable Blocks.",
+    "pages": "287-292",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS2-20.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#BimbotDSV11"
+  },
+  "conf/ismir/HankinsonRF11": {
+    "@key": "conf/ismir/HankinsonRF11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Andrew Hankinson",
+      "Perry Roland",
+      "Ichiro Fujinaga"
+    ],
+    "title": "The Music Encoding Initiative as a Document-Encoding Framework.",
+    "pages": "293-298",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS3-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#HankinsonRF11"
+  },
+  "conf/ismir/Juhasz11": {
+    "@key": "conf/ismir/Juhasz11",
+    "@mdate": "2011-12-06",
+    "author": "Zolt\u00e1n Juh\u00e1sz",
+    "title": "Low Dimensional Visualization of Folk Music Systems Using the Self Organizing Cloud.",
+    "pages": "299-304",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS3-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Juhasz11"
+  },
+  "conf/ismir/RaphaelW11": {
+    "@key": "conf/ismir/RaphaelW11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Christopher Raphael",
+      "Jingya Wang"
+    ],
+    "title": "New Approaches to Optical Music Recognition.",
+    "pages": "305-310",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS3-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#RaphaelW11"
+  },
+  "conf/ismir/GotoYFMN11": {
+    "@key": "conf/ismir/GotoYFMN11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Masataka Goto",
+      "Kazuyoshi Yoshii",
+      "Hiromasa Fujihara",
+      "Matthias Mauch",
+      "Tomoyasu Nakano"
+    ],
+    "title": "Songle: A Web Service for Active Music Listening Improved by User Contributions.",
+    "pages": "311-316",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS4-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#GotoYFMN11"
+  },
+  "conf/ismir/Levy11": {
+    "@key": "conf/ismir/Levy11",
+    "@mdate": "2011-12-06",
+    "author": "Mark Levy",
+    "title": "Improving Perceptual Tempo Estimation with Crowd-Sourced Annotations.",
+    "pages": "317-322",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS4-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Levy11"
+  },
+  "conf/ismir/SchedlKB11": {
+    "@key": "conf/ismir/SchedlKB11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Markus Schedl",
+      "Peter Knees",
+      "Sebastian B\u00f6ck"
+    ],
+    "title": "Investigating the Similarity Space of Music Artists on the Micro-Blogosphere.",
+    "pages": "323-328",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS4-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SchedlKB11"
+  },
+  "conf/ismir/BryanW11": {
+    "@key": "conf/ismir/BryanW11",
+    "@mdate": "2018-01-25",
+    "author": [
+      "Nicholas J. Bryan",
+      "Ge Wang 0002"
+    ],
+    "title": "Musical Influence Network Analysis and Rank of Sample-Based Music.",
+    "pages": "329-334",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS4-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#BryanW11"
+  },
+  "conf/ismir/WeiglG11": {
+    "@key": "conf/ismir/WeiglG11",
+    "@mdate": "2018-08-15",
+    "author": [
+      "David M. Weigl",
+      "Catherine Guastavino"
+    ],
+    "title": "User studies in the Music Information Retrieval Literature.",
+    "pages": "335-340",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS5-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#WeiglG11"
+  },
+  "conf/ismir/Laplante11": {
+    "@key": "conf/ismir/Laplante11",
+    "@mdate": "2011-12-06",
+    "author": "Audrey Laplante",
+    "title": "Social Capital and Music Discovery: An Examination of the Ties through Which Late Adolescents Discover New Music.",
+    "pages": "341-346",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS5-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Laplante11"
+  },
+  "conf/ismir/StowellD11": {
+    "@key": "conf/ismir/StowellD11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Dan Stowell",
+      "Simon Dixon"
+    ],
+    "title": "MIR in School? Lessons from Ethnographic Observation of Secondary School Music Classes.",
+    "pages": "347-352",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS5-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#StowellD11"
+  },
+  "conf/ismir/BarthetD11": {
+    "@key": "conf/ismir/BarthetD11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Mathieu Barthet",
+      "Simon Dixon"
+    ],
+    "title": "Ethnographic Observations of Musicologists at the British Library: Implications for Music Information Retrieval.",
+    "pages": "353-358",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS5-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#BarthetD11"
+  },
+  "conf/ismir/Viro11": {
+    "@key": "conf/ismir/Viro11",
+    "@mdate": "2011-12-06",
+    "author": "Vladimir Viro",
+    "title": "Peachnote: Music Score Search and Analysis Platform.",
+    "pages": "359-362",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Viro11"
+  },
+  "conf/ismir/ConstantinMFR11": {
+    "@key": "conf/ismir/ConstantinMFR11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Cam\u00e9lia Constantin",
+      "C\u00e9dric du Mouza",
+      "Zo\u00e9 Faget",
+      "Philippe Rigaux"
+    ],
+    "title": "The Melodic Signature Index for Fast Content-based Retrieval of Symbolic Scores Camelia Constantin.",
+    "pages": "363-368",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#ConstantinMFR11"
+  },
+  "conf/ismir/LaitinenL11": {
+    "@key": "conf/ismir/LaitinenL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Mika Laitinen",
+      "Kjell Lemstr\u00f6m"
+    ],
+    "title": "Dynamic Programming in Transposition and Time-Warp Invariant Polyphonic Content-Based Music Retrieval.",
+    "pages": "369-374",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#LaitinenL11"
+  },
+  "conf/ismir/LeveGASGG11": {
+    "@key": "conf/ismir/LeveGASGG11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Florence Lev\u00e9",
+      "Richard Groult",
+      "Guillaume Arnaud",
+      "Cyril S\u00e9guin",
+      "R\u00e9mi Gaymay",
+      "Mathieu Giraud"
+    ],
+    "title": "Rhythm Extraction from Polyphony Symbolic Music.",
+    "pages": "375-380",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#LeveGASGG11"
+  },
+  "conf/ismir/SiorosG11": {
+    "@key": "conf/ismir/SiorosG11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "George Sioros",
+      "Carlos Guedes"
+    ],
+    "title": "Complexity Driven Recombination of MIDI Loops.",
+    "pages": "381-386",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-5.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SiorosG11"
+  },
+  "conf/ismir/CuthbertAF11": {
+    "@key": "conf/ismir/CuthbertAF11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Michael Scott Cuthbert",
+      "Christopher Ariza",
+      "Lisa Friedland"
+    ],
+    "title": "Feature Extraction and Machine Learning on Symbolic Music using the music21 Toolkit.",
+    "pages": "387-392",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-6.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#CuthbertAF11"
+  },
+  "conf/ismir/KirlinJ11": {
+    "@key": "conf/ismir/KirlinJ11",
+    "@mdate": "2016-08-22",
+    "author": [
+      "Phillip B. Kirlin",
+      "David D. Jensen"
+    ],
+    "title": "Probabilistic Modeling of Hierarchical Music Analysis.",
+    "pages": "393-398",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-7.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#KirlinJ11"
+  },
+  "conf/ismir/BraggCS11": {
+    "@key": "conf/ismir/BraggCS11",
+    "@mdate": "2013-11-10",
+    "author": [
+      "Jonathan Bragg",
+      "Elaine Chew",
+      "Stuart M. Shieber"
+    ],
+    "title": "Neo-Riemannian Cycle Detection with Weighted Finite-State Transducers.",
+    "pages": "399-404",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-8.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#BraggCS11"
+  },
+  "conf/ismir/BuggeJMS11": {
+    "@key": "conf/ismir/BuggeJMS11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Esben Paul Bugge",
+      "Kim Lundsteen Juncher",
+      "Brian S\u00f8borg Mathiasen",
+      "Jakob Grue Simonsen"
+    ],
+    "title": "Using Sequence Alignment and Voting to Improve Optical Music Recognition from Multiple Recognizers.",
+    "pages": "405-410",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-9.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#BuggeJMS11"
+  },
+  "conf/ismir/ThomasWC11": {
+    "@key": "conf/ismir/ThomasWC11",
+    "@mdate": "2018-07-11",
+    "author": [
+      "Verena Thomas",
+      "Christian Wagner 0003",
+      "Michael Clausen"
+    ],
+    "title": "OCR based post processing of OMR for the recovery of transposing instruments in complex orchestral scores.",
+    "pages": "411-416",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-10.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#ThomasWC11"
+  },
+  "conf/ismir/NiitsumaT11": {
+    "@key": "conf/ismir/NiitsumaT11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Masahiro Niitsuma",
+      "Yo Tomita"
+    ],
+    "title": "Classifying Bach's Handwritten C-Clefs.",
+    "pages": "417-422",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-11.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#NiitsumaT11"
+  },
+  "conf/ismir/VigliensoniBHF11": {
+    "@key": "conf/ismir/VigliensoniBHF11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Gabriel Vigliensoni",
+      "John Ashley Burgoyne",
+      "Andrew Hankinson",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Automatic Pitch Detection in Printed Square Notation.",
+    "pages": "423-428",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-12.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#VigliensoniBHF11"
+  },
+  "conf/ismir/NeubarthBC11": {
+    "@key": "conf/ismir/NeubarthBC11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Kerstin Neubarth",
+      "Mathieu Bergeron",
+      "Darrell Conklin"
+    ],
+    "title": "Associations between Musicology and Music Information Retrieval.",
+    "pages": "429-434",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-13.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#NeubarthBC11"
+  },
+  "conf/ismir/WangO11": {
+    "@key": "conf/ismir/WangO11",
+    "@mdate": "2017-09-18",
+    "author": [
+      "Dingding Wang 0001",
+      "Mitsunori Ogihara"
+    ],
+    "title": "Potential Relationship Discovery in Tag-Aware Music Style Clustering and Artist Social Networks.",
+    "pages": "435-440",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-14.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#WangO11"
+  },
+  "conf/ismir/GunaratnaSM11": {
+    "@key": "conf/ismir/GunaratnaSM11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Charith Gunaratna",
+      "Evan Stoner",
+      "Ronaldo Menezes"
+    ],
+    "title": "Using Network Sciences to Rank Musicians and Composers in Brazilian Popular Music.",
+    "pages": "441-446",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-15.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#GunaratnaSM11"
+  },
+  "conf/ismir/CorreaLC11": {
+    "@key": "conf/ismir/CorreaLC11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "D\u00e9bora C. Corr\u00eaa",
+      "Alexandre L. M. Levada",
+      "Luciano da F. Costa"
+    ],
+    "title": "Finding Community Structure in Music Genres Networks.",
+    "pages": "447-452",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-16.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#CorreaLC11"
+  },
+  "conf/ismir/MacraeD11": {
+    "@key": "conf/ismir/MacraeD11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Robert Macrae",
+      "Simon Dixon"
+    ],
+    "title": "Guitar Tab Mining, Analysis and Ranking.",
+    "pages": "453-458",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-17.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MacraeD11"
+  },
+  "conf/ismir/McKayB11": {
+    "@key": "conf/ismir/McKayB11",
+    "@mdate": "2017-12-04",
+    "author": [
+      "Cory McKay",
+      "David Bainbridge 0001"
+    ],
+    "title": "A Musical Web Mining and Audio Feature Extraction Extension to The Greenstone Digital Library Software.",
+    "pages": "459-464",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-18.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#McKayB11"
+  },
+  "conf/ismir/KolozaliBFS11": {
+    "@key": "conf/ismir/KolozaliBFS11",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Sefki Kolozali",
+      "Mathieu Barthet",
+      "Gy\u00f6rgy Fazekas",
+      "Mark B. Sandler"
+    ],
+    "title": "Knowledge Representation Issues in Musical Instrument Ontology Design.",
+    "pages": "465-470",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-19.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#KolozaliBFS11"
+  },
+  "conf/ismir/FazekasS11": {
+    "@key": "conf/ismir/FazekasS11",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Gy\u00f6rgy Fazekas",
+      "Mark B. Sandler"
+    ],
+    "title": "The Studio Ontology Framework.",
+    "pages": "471-476",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS3-20.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#FazekasS11"
+  },
+  "conf/ismir/ChenL11": {
+    "@key": "conf/ismir/ChenL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Ruofeng Chen",
+      "Ming Li"
+    ],
+    "title": "Music Structural Segmentation by Combining Harmonic and Timbral Information.",
+    "pages": "477-482",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#ChenL11"
+  },
+  "conf/ismir/SargentBV11": {
+    "@key": "conf/ismir/SargentBV11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Gabriel Sargent",
+      "Fr\u00e9d\u00e9ric Bimbot",
+      "Emmanuel Vincent"
+    ],
+    "title": "A Regularity-Constrained Viterbi Algorithm and Its Application to The Structural Segmentation of Songs.",
+    "pages": "483-488",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SargentBV11"
+  },
+  "conf/ismir/MauchL11": {
+    "@key": "conf/ismir/MauchL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Matthias Mauch",
+      "Mark Levy"
+    ],
+    "title": "Structural Change on Multiple Time Scales as a Correlate of Musical Complexity.",
+    "pages": "489-494",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MauchL11"
+  },
+  "conf/ismir/PanagakisKA11": {
+    "@key": "conf/ismir/PanagakisKA11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Yannis Panagakis",
+      "Constantine Kotropoulos",
+      "Gonzalo R. Arce"
+    ],
+    "title": "l1-Graph Based Music Structure Analysis.",
+    "pages": "495-500",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#PanagakisKA11"
+  },
+  "conf/ismir/FosterKP11": {
+    "@key": "conf/ismir/FosterKP11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Peter Foster",
+      "Anssi Klapuri",
+      "Mark D. Plumbley"
+    ],
+    "title": "Causal Prediction of Continuous-Valued Music Features.",
+    "pages": "501-506",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-5.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#FosterKP11"
+  },
+  "conf/ismir/MartinHTDF11": {
+    "@key": "conf/ismir/MartinHTDF11",
+    "@mdate": "2016-07-06",
+    "author": [
+      "Benjamin Martin 0001",
+      "Pierre Hanna",
+      "Ta Vinh Thong",
+      "Myriam Desainte-Catherine",
+      "Pascal Ferraro"
+    ],
+    "title": "Exemplar-based Assignment of Large Missing Audio Parts using String Matching on Tonal Features.",
+    "pages": "507-512",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-6.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MartinHTDF11"
+  },
+  "conf/ismir/DuanP11": {
+    "@key": "conf/ismir/DuanP11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Zhiyao Duan",
+      "Bryan Pardo"
+    ],
+    "title": "Aligning Semi-Improvised Music Audio with Its Lead Sheet.",
+    "pages": "513-518",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-7.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#DuanP11"
+  },
+  "conf/ismir/LiemH11": {
+    "@key": "conf/ismir/LiemH11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Cynthia C. S. Liem",
+      "Alan Hanjalic"
+    ],
+    "title": "Expressive Timing from Cross-Performance and Audio-based Alignment Patterns: An Extended Case Study.",
+    "pages": "519-524",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-8.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#LiemH11"
+  },
+  "conf/ismir/OtsukaNOO11": {
+    "@key": "conf/ismir/OtsukaNOO11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Takuma Otsuka",
+      "Kazuhiro Nakadai",
+      "Tetsuya Ogata",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Incremental Bayesian Audio-to-Score Alignment with Flexible Harmonic Structure Models.",
+    "pages": "525-530",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-9.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#OtsukaNOO11"
+  },
+  "conf/ismir/OkumuraSK11": {
+    "@key": "conf/ismir/OkumuraSK11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Kenta Okumura",
+      "Shinji Sako",
+      "Tadashi Kitamura"
+    ],
+    "title": "Stochastic Modeling of a Musical Performance with Expressive Representations from the Musical Score.",
+    "pages": "531-536",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-10.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#OkumuraSK11"
+  },
+  "conf/ismir/McFeeL11a": {
+    "@key": "conf/ismir/McFeeL11a",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Brian McFee",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "The Natural Language of Playlists.",
+    "pages": "537-542",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-11.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#McFeeL11a"
+  },
+  "conf/ismir/NiedermayerBW11": {
+    "@key": "conf/ismir/NiedermayerBW11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Bernhard Niedermayer",
+      "Sebastian B\u00f6ck",
+      "Gerhard Widmer"
+    ],
+    "title": "On the Importance of \"Real\" Audio Data for MIR Algorithm Evaluation at the Note-Level - A Comparative Study.",
+    "pages": "543-548",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-12.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#NiedermayerBW11"
+  },
+  "conf/ismir/SpeckSMK11": {
+    "@key": "conf/ismir/SpeckSMK11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Jacquelin A. Speck",
+      "Erik M. Schmidt",
+      "Brandon G. Morton",
+      "Youngmoo E. Kim"
+    ],
+    "title": "A Comparative Study of Collaborative vs. Traditional Musical Mood Annotation.",
+    "pages": "549-554",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-13.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SpeckSMK11"
+  },
+  "conf/ismir/SmithBFRD11": {
+    "@key": "conf/ismir/SmithBFRD11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Jordan Bennett Louis Smith",
+      "John Ashley Burgoyne",
+      "Ichiro Fujinaga",
+      "David De Roure",
+      "J. Stephen Downie"
+    ],
+    "title": "Design and creation of a large-scale database of structural annotations.",
+    "pages": "555-560",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-14.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SmithBFRD11"
+  },
+  "conf/ismir/EhmannBDFR11": {
+    "@key": "conf/ismir/EhmannBDFR11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Andreas F. Ehmann",
+      "Mert Bay",
+      "J. Stephen Downie",
+      "Ichiro Fujinaga",
+      "David De Roure"
+    ],
+    "title": "Music Structure Segmentation Algorithm Evaluation: Expanding on MIREX 2010 Analyses and Datasets.",
+    "pages": "561-566",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-15.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#EhmannBDFR11"
+  },
+  "conf/ismir/NessTDST11": {
+    "@key": "conf/ismir/NessTDST11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Steven R. Ness",
+      "Shawn Trail",
+      "Peter F. Driessen",
+      "W. Andrew Schloss",
+      "George Tzanetakis"
+    ],
+    "title": "Music Information Robotics: Coping Strategies for Musically Challenged Robots.",
+    "pages": "567-572",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-16.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#NessTDST11"
+  },
+  "conf/ismir/KnightUF11": {
+    "@key": "conf/ismir/KnightUF11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Trevor Knight",
+      "Finn Upham",
+      "Ichiro Fujinaga"
+    ],
+    "title": "The potential for automatic assessment of trumpet tone quality.",
+    "pages": "573-578",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-17.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#KnightUF11"
+  },
+  "conf/ismir/TopelC11": {
+    "@key": "conf/ismir/TopelC11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Spencer S. Topel",
+      "Michael A. Casey"
+    ],
+    "title": "Elementary Sources: Latent Component Analysis for Music Composition.",
+    "pages": "579-584",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-18.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#TopelC11"
+  },
+  "conf/ismir/MattekC11": {
+    "@key": "conf/ismir/MattekC11",
+    "@mdate": "2016-02-17",
+    "author": [
+      "Alison Mattek",
+      "Michael A. Casey"
+    ],
+    "title": "Cross-Modal Aesthetics from A Feature Extraction Perspective: A Pilot Study.",
+    "pages": "585-590",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS4-19.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MattekC11"
+  },
+  "conf/ismir/Bertin-MahieuxEWL11": {
+    "@key": "conf/ismir/Bertin-MahieuxEWL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Thierry Bertin-Mahieux",
+      "Daniel P. W. Ellis",
+      "Brian Whitman",
+      "Paul Lamere"
+    ],
+    "title": "The Million Song Dataset.",
+    "pages": "591-596",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS6-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Bertin-MahieuxEWL11"
+  },
+  "conf/ismir/UrbanoMMM11": {
+    "@key": "conf/ismir/UrbanoMMM11",
+    "@mdate": "2017-07-12",
+    "author": [
+      "Juli\u00e1n Urbano",
+      "Diego Mart\u00edn 0001",
+      "M\u00f3nica Marrero",
+      "Jorge Morato"
+    ],
+    "title": "Audio Music Similarity and Retrieval: Evaluation Power and Stability.",
+    "pages": "597-602",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS6-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#UrbanoMMM11"
+  },
+  "conf/ismir/OrioRMSML11": {
+    "@key": "conf/ismir/OrioRMSML11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Nicola Orio",
+      "David Rizo",
+      "Riccardo Miotto",
+      "Markus Schedl",
+      "Nicola Montecchio",
+      "Olivier Lartillot"
+    ],
+    "title": "MusiCLEF: a Benchmark Activity in Multimodal Music Information Retrieval.",
+    "pages": "603-608",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS6-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#OrioRMSML11"
+  },
+  "conf/ismir/Urbano11": {
+    "@key": "conf/ismir/Urbano11",
+    "@mdate": "2011-12-06",
+    "author": "Juli\u00e1n Urbano",
+    "title": "Information Retrieval Meta-Evaluation: Challenges and Opportunities in the Music Domain.",
+    "pages": "609-614",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS6-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#Urbano11"
+  },
+  "conf/ismir/MullerGJ11": {
+    "@key": "conf/ismir/MullerGJ11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Meinard M\u00fcller",
+      "Peter Grosche",
+      "Nanzhu Jiang"
+    ],
+    "title": "A Segment-Based Fitness Measure for Capturing Repetitive Structures of Music Recordings.",
+    "pages": "615-620",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS7-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MullerGJ11"
+  },
+  "conf/ismir/ScottK11": {
+    "@key": "conf/ismir/ScottK11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Jeffrey J. Scott",
+      "Youngmoo E. Kim"
+    ],
+    "title": "Analysis of Acoustic Features for Automated Multi-Track Mixing.",
+    "pages": "621-626",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS7-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#ScottK11"
+  },
+  "conf/ismir/MontecchioC11": {
+    "@key": "conf/ismir/MontecchioC11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Nicola Montecchio",
+      "Arshia Cont"
+    ],
+    "title": "Accelerating The Mixing Phase In Studio Recording Productions By Automatic Audio Alignment.",
+    "pages": "627-632",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS7-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MontecchioC11"
+  },
+  "conf/ismir/BurgoyneWF11": {
+    "@key": "conf/ismir/BurgoyneWF11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "John Ashley Burgoyne",
+      "Jonathan Wild",
+      "Ichiro Fujinaga"
+    ],
+    "title": "An Expert Ground Truth Set for Audio Chord Recognition and Music Analysis.",
+    "pages": "633-638",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS8-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#BurgoyneWF11"
+  },
+  "conf/ismir/McVicarNBS11": {
+    "@key": "conf/ismir/McVicarNBS11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Matt McVicar",
+      "Yizhao Ni",
+      "Tijl De Bie",
+      "Ra\u00fal Santos-Rodriguez"
+    ],
+    "title": "Leveraging Noisy Online Databases for Use in Chord Recognition.",
+    "pages": "639-644",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS8-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#McVicarNBS11"
+  },
+  "conf/ismir/YoshiiG11": {
+    "@key": "conf/ismir/YoshiiG11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Kazuyoshi Yoshii",
+      "Masataka Goto"
+    ],
+    "title": "A Vocabulary-Free Infinity-Gram Model for Nonparametric Bayesian Chord Progression Analysis.",
+    "pages": "645-650",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS8-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#YoshiiG11"
+  },
+  "conf/ismir/ChoB11": {
+    "@key": "conf/ismir/ChoB11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Taemin Cho",
+      "Juan Pablo Bello"
+    ],
+    "title": "A Feature Smoothing Method for Chord Recognition Using Recurrence Plots.",
+    "pages": "651-656",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS8-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#ChoB11"
+  },
+  "conf/ismir/AndenM11": {
+    "@key": "conf/ismir/AndenM11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Joakim And\u00e9n",
+      "St\u00e9phane Mallat"
+    ],
+    "title": "Multiscale Scattering for Audio Classification.",
+    "pages": "657-662",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#AndenM11"
+  },
+  "conf/ismir/FoucardELR11": {
+    "@key": "conf/ismir/FoucardELR11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "R\u00e9mi Foucard",
+      "Slim Essid",
+      "Mathieu Lagrange",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "Multi-scale temporal fusion by boosting for music classification.",
+    "pages": "663-668",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#FoucardELR11"
+  },
+  "conf/ismir/DielemanBS11": {
+    "@key": "conf/ismir/DielemanBS11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Sander Dieleman",
+      "Philemon Brakel",
+      "Benjamin Schrauwen"
+    ],
+    "title": "Audio-based Music Classification with a Pretrained Convolutional Network.",
+    "pages": "669-674",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#DielemanBS11"
+  },
+  "conf/ismir/MayerR11": {
+    "@key": "conf/ismir/MayerR11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Rudolf Mayer",
+      "Andreas Rauber"
+    ],
+    "title": "Music Genre Classification by Ensembles of Audio and Lyrics Features.",
+    "pages": "675-680",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-4.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MayerR11"
+  },
+  "conf/ismir/HenaffJKL11": {
+    "@key": "conf/ismir/HenaffJKL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Mikael Henaff",
+      "Kevin Jarrett",
+      "Koray Kavukcuoglu",
+      "Yann LeCun"
+    ],
+    "title": "Unsupervised Learning of Sparse Features for Scalable Audio Classification.",
+    "pages": "681-686",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-5.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#HenaffJKL11"
+  },
+  "conf/ismir/PapadopoulosK11": {
+    "@key": "conf/ismir/PapadopoulosK11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "H\u00e9l\u00e8ne Papadopoulos",
+      "Matthieu Kowalski"
+    ],
+    "title": "Sparse Signal Decomposition on Hybrid Dictionaries Using Musical Priors.",
+    "pages": "687-692",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-6.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#PapadopoulosK11"
+  },
+  "conf/ismir/AnanHBT11": {
+    "@key": "conf/ismir/AnanHBT11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Yoko Anan",
+      "Kohei Hatano",
+      "Hideo Bannai",
+      "Masayuki Takeda"
+    ],
+    "title": "Music Genre Classification using Similarity Functions.",
+    "pages": "693-698",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-7.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#AnanHBT11"
+  },
+  "conf/ismir/MarquesGNP11": {
+    "@key": "conf/ismir/MarquesGNP11",
+    "@mdate": "2012-08-17",
+    "author": [
+      "Caio Miguel Marques",
+      "Ivan Rizzo Guilherme",
+      "Rodrigo Y. M. Nakamura",
+      "Jo\u00e3o P. Papa"
+    ],
+    "title": "New Trends in Musical Genre Classification Using Optimum-Path Forest.",
+    "pages": "699-704",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-8.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MarquesGNP11"
+  },
+  "conf/ismir/CovielloML11": {
+    "@key": "conf/ismir/CovielloML11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Emanuele Coviello",
+      "Riccardo Miotto",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Combining Content-Based Auto-Taggers with Decision-Fusion.",
+    "pages": "705-710",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-9.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#CovielloML11"
+  },
+  "conf/ismir/XieBTC11": {
+    "@key": "conf/ismir/XieBTC11",
+    "@mdate": "2015-03-02",
+    "author": [
+      "Bo Xie 0002",
+      "Wei Bian",
+      "Dacheng Tao",
+      "Parag Chordia"
+    ],
+    "title": "Music Tagging with Regularized Logistic Regression.",
+    "pages": "711-716",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-10.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#XieBTC11"
+  },
+  "conf/ismir/SandenZ11": {
+    "@key": "conf/ismir/SandenZ11",
+    "@mdate": "2011-12-07",
+    "author": [
+      "Chris Sanden",
+      "John Z. Zhang"
+    ],
+    "title": "An Empirical Study of Multi-Label Classifiers for Music Tag Annotation.",
+    "pages": "717-722",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-11.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SandenZ11"
+  },
+  "conf/ismir/EllisCL11": {
+    "@key": "conf/ismir/EllisCL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Katherine Ellis",
+      "Emanuele Coviello",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Semantic Annotation and Retrieval of Music using a Bag of Systems Representation.",
+    "pages": "723-728",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-12.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#EllisCL11"
+  },
+  "conf/ismir/HamelLBE11": {
+    "@key": "conf/ismir/HamelLBE11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Philippe Hamel",
+      "Simon Lemieux",
+      "Yoshua Bengio",
+      "Douglas Eck"
+    ],
+    "title": "Temporal Pooling and Multiscale Learning for Automatic Annotation and Ranking of Music Audio.",
+    "pages": "729-734",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-13.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#HamelLBE11"
+  },
+  "conf/ismir/MannCL11": {
+    "@key": "conf/ismir/MannCL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Mark Mann",
+      "Trevor J. Cox",
+      "Francis F. Li"
+    ],
+    "title": "Music Mood Classification of Television Theme Tunes.",
+    "pages": "735-740",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-14.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MannCL11"
+  },
+  "conf/ismir/DaviesAMC11": {
+    "@key": "conf/ismir/DaviesAMC11",
+    "@mdate": "2011-12-07",
+    "author": [
+      "Sam Davies",
+      "Penelope Allen",
+      "Mark Mann",
+      "Trevor J. Cox"
+    ],
+    "title": "Musical Moods: A Mass Participation Experiment for Affective Classification of Music.",
+    "pages": "741-746",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-15.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#DaviesAMC11"
+  },
+  "conf/ismir/VaizmanGL11": {
+    "@key": "conf/ismir/VaizmanGL11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Yonatan Vaizman",
+      "Roni Y. Granot",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Modeling Dynamic Patterns for Emotional Content in Music.",
+    "pages": "747-752",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-16.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#VaizmanGL11"
+  },
+  "conf/ismir/CabredoLN11": {
+    "@key": "conf/ismir/CabredoLN11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Rafael Cabredo",
+      "Roberto S. Legaspi",
+      "Masayuki Numao"
+    ],
+    "title": "Identifying Emotion Segments in Music by Discovering Motifs in Physiological Data.",
+    "pages": "753-758",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-17.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#CabredoLN11"
+  },
+  "conf/ismir/SchullerWD11": {
+    "@key": "conf/ismir/SchullerWD11",
+    "@mdate": "2015-06-17",
+    "author": [
+      "Bj\u00f6rn W. Schuller",
+      "Felix Weninger",
+      "Johannes Dorfner"
+    ],
+    "title": "Multi-Modal Non-Prototypical Music Mood Analysis in Continuous Space: Reliability and Performances.",
+    "pages": "759-764",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-18.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SchullerWD11"
+  },
+  "conf/ismir/WangCYW11": {
+    "@key": "conf/ismir/WangCYW11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Xing Wang",
+      "Xiaoou Chen",
+      "Deshun Yang",
+      "Yuqian Wu"
+    ],
+    "title": "Music Emotion Classification of Chinese Songs based on Lyrics Using TF*IDF and Rhyme.",
+    "pages": "765-770",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-19.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#WangCYW11"
+  },
+  "conf/ismir/BennettML11": {
+    "@key": "conf/ismir/BennettML11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Christopher Bennett",
+      "Richard McNeer",
+      "Colby Leider"
+    ],
+    "title": "Urgency Analysis of Audible Alarms in The Operating Room.",
+    "pages": "771-776",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/PS6-20.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#BennettML11"
+  },
+  "conf/ismir/SchmidtK11": {
+    "@key": "conf/ismir/SchmidtK11",
+    "@mdate": "2012-10-26",
+    "author": [
+      "Erik M. Schmidt",
+      "Youngmoo E. Kim"
+    ],
+    "title": "Modeling Musical Emotion Dynamics with Conditional Random Fields.",
+    "pages": "777-782",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS9-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#SchmidtK11"
+  },
+  "conf/ismir/McVicarFB11": {
+    "@key": "conf/ismir/McVicarFB11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Matt McVicar",
+      "Tim Freeman",
+      "Tijl De Bie"
+    ],
+    "title": "Mining the Correlation between Lyrical and Audio Features and the Emergence of Mood.",
+    "pages": "783-788",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS9-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#McVicarFB11"
+  },
+  "conf/ismir/HuY11": {
+    "@key": "conf/ismir/HuY11",
+    "@mdate": "2018-08-16",
+    "author": [
+      "Xiao Hu 0001",
+      "Bei Yu"
+    ],
+    "title": "Exploring The Relationship Between Mood and Creativity in Rock Lyrics.",
+    "pages": "789-794",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS9-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#HuY11"
+  },
+  "conf/ismir/MarquesDLG11": {
+    "@key": "conf/ismir/MarquesDLG11",
+    "@mdate": "2012-01-04",
+    "author": [
+      "Gon\u00e7alo Marques",
+      "Marcos Aur\u00e9lio Domingues",
+      "Thibault Langlois",
+      "Fabien Gouyon"
+    ],
+    "title": "Three Current Issues In Music Autotagging.",
+    "pages": "795-800",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS10-1.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#MarquesDLG11"
+  },
+  "conf/ismir/ChandrasekharSR11": {
+    "@key": "conf/ismir/ChandrasekharSR11",
+    "@mdate": "2011-12-06",
+    "author": [
+      "Vijay Chandrasekhar",
+      "Matt Sharifi",
+      "David A. Ross"
+    ],
+    "title": "Survey and Evaluation of Audio Fingerprinting Schemes for Mobile Query-by-Example Applications.",
+    "pages": "801-806",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS10-2.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#ChandrasekharSR11"
+  },
+  "conf/ismir/ZacharakisPPR11": {
+    "@key": "conf/ismir/ZacharakisPPR11",
+    "@mdate": "2015-11-04",
+    "author": [
+      "Asteris I. Zacharakis",
+      "Konstantinos Pastiadis",
+      "Georgios Papadelis",
+      "Joshua D. Reiss"
+    ],
+    "title": "An Investigation of Musical Timbre: Uncovering Salient Semantic Descriptors and Perceptual Dimensions.",
+    "pages": "807-812",
+    "year": "2011",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2011.ismir.net/papers/OS10-3.pdf",
+    "crossref": "conf/ismir/2011",
+    "url": "db/conf/ismir/ismir2011.html#ZacharakisPPR11"
+  },
+  "conf/ismir/Collins12": {
+    "@key": "conf/ismir/Collins12",
+    "@mdate": "2012-10-25",
+    "author": "Nick Collins",
+    "title": "Influence in Early Electronic Dance Music: An Audio Content Analysis Investigation.",
+    "pages": "1-6",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/001-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#Collins12"
+  },
+  "conf/ismir/NeubarthGJC12": {
+    "@key": "conf/ismir/NeubarthGJC12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Kerstin Neubarth",
+      "Izaro Goienetxea",
+      "Colin Johnson",
+      "Darrell Conklin"
+    ],
+    "title": "Association Mining of Folk Music Genres and Toponyms.",
+    "pages": "7-12",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/007-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#NeubarthGJC12"
+  },
+  "conf/ismir/OzaslanSA12": {
+    "@key": "conf/ismir/OzaslanSA12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Tan Hakan \u00d6zaslan",
+      "Xavier Serra",
+      "Josep Llu\u00eds Arcos"
+    ],
+    "title": "Characterization of Embellishments in Ney Performances of Makam Music in Turkey.",
+    "pages": "13-18",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/13-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#OzaslanSA12"
+  },
+  "conf/ismir/YangH12": {
+    "@key": "conf/ismir/YangH12",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Yi-Hsuan Yang",
+      "Xiao Hu 0001"
+    ],
+    "title": "Cross-cultural Music Mood Classification: A Comparison on English and Chinese Songs.",
+    "pages": "19-24",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/019-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#YangH12"
+  },
+  "conf/ismir/PeetersF12": {
+    "@key": "conf/ismir/PeetersF12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Geoffroy Peeters",
+      "Kar\u00ebn Fort"
+    ],
+    "title": "Towards a (Better) Definition of the Description of Annotated MIR Corpora.",
+    "pages": "25-30",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/025-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#PeetersF12"
+  },
+  "conf/ismir/WatsonM12": {
+    "@key": "conf/ismir/WatsonM12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Diane Watson",
+      "Regan L. Mandryk"
+    ],
+    "title": "Modeling Musical Mood From Audio Features and Listening Context on an In-Situ Data Set.",
+    "pages": "31-36",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/031-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#WatsonM12"
+  },
+  "conf/ismir/BattenbergW12": {
+    "@key": "conf/ismir/BattenbergW12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Eric Battenberg",
+      "David Wessel"
+    ],
+    "title": "Analyzing Drum Patterns Using Conditional Deep Belief Networks.",
+    "pages": "37-42",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/037-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#BattenbergW12"
+  },
+  "conf/ismir/UnalBK12": {
+    "@key": "conf/ismir/UnalBK12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Erdem \u00dcnal",
+      "Baris Bozkurt",
+      "Mustafa Kemal Karaosmanoglu"
+    ],
+    "title": "N-gram Based Statistical Makam Detection on Makam Music in Turkey Using Symbolic Data.",
+    "pages": "43-48",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/043-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#UnalBK12"
+  },
+  "conf/ismir/BockKS12": {
+    "@key": "conf/ismir/BockKS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Sebastian B\u00f6ck",
+      "Florian Krebs",
+      "Markus Schedl"
+    ],
+    "title": "Evaluating the Online Capabilities of Onset Detection Methods.",
+    "pages": "49-54",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/049-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#BockKS12"
+  },
+  "conf/ismir/GroscheSMA12": {
+    "@key": "conf/ismir/GroscheSMA12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Peter Grosche",
+      "Joan Serr\u00e0",
+      "Meinard M\u00fcller",
+      "Josep Llu\u00eds Arcos"
+    ],
+    "title": "Structure-Based Audio Fingerprinting for Music Retrieval.",
+    "pages": "55-60",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/055-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#GroscheSMA12"
+  },
+  "conf/ismir/IzmirliS12": {
+    "@key": "conf/ismir/IzmirliS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "\u00d6zg\u00fcr Izmirli",
+      "Gyanendra Sharma"
+    ],
+    "title": "Bridging Printed Music and Audio Through Alignment Using a Mid-level Score Representation.",
+    "pages": "61-66",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/061-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#IzmirliS12"
+  },
+  "conf/ismir/SprechmannBS12": {
+    "@key": "conf/ismir/SprechmannBS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Pablo Sprechmann",
+      "Alexander M. Bronstein",
+      "Guillermo Sapiro"
+    ],
+    "title": "Real-time Online Singing Voice Separation from Monaural Recordings Using Robust Low-rank Modeling.",
+    "pages": "67-72",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/067-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SprechmannBS12"
+  },
+  "conf/ismir/FontSS12": {
+    "@key": "conf/ismir/FontSS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Frederic Font",
+      "Joan Serr\u00e0",
+      "Xavier Serra"
+    ],
+    "title": "Folksonomy-based Tag Recommendation for Online Audio Clip Sharing.",
+    "pages": "73-78",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/073-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#FontSS12"
+  },
+  "conf/ismir/YoshiiG12": {
+    "@key": "conf/ismir/YoshiiG12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Kazuyoshi Yoshii",
+      "Masataka Goto"
+    ],
+    "title": "Infinite Composite Autoregressive Models for Music Signal Analysis.",
+    "pages": "79-84",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/079-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#YoshiiG12"
+  },
+  "conf/ismir/GerberDGF12": {
+    "@key": "conf/ismir/GerberDGF12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Timoth\u00e9e Gerber",
+      "Martin Dutasta",
+      "Laurent Girin",
+      "C\u00e9dric F\u00e9votte"
+    ],
+    "title": "Professionally-produced Music Separation Guided by Covers.",
+    "pages": "85-90",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/085-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#GerberDGF12"
+  },
+  "conf/ismir/SakaueOIO12": {
+    "@key": "conf/ismir/SakaueOIO12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Daichi Sakaue",
+      "Takuma Otsuka",
+      "Katsutoshi Itoyama",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Bayesian Nonnegative Harmonic-Temporal Factorization and Its Application to Multipitch Analysis.",
+    "pages": "91-96",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/091-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SakaueOIO12"
+  },
+  "conf/ismir/MullerJ12": {
+    "@key": "conf/ismir/MullerJ12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Meinard M\u00fcller",
+      "Nanzhu Jiang"
+    ],
+    "title": "A Scape Plot Representation for Visualizing Repetitive Structures of Music Recordings.",
+    "pages": "97-102",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/097-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#MullerJ12"
+  },
+  "conf/ismir/WolffSNW12": {
+    "@key": "conf/ismir/WolffSNW12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Daniel Wolff",
+      "Sebastian Stober",
+      "Andreas N\u00fcrnberger",
+      "Tillman Weyde"
+    ],
+    "title": "A Systematic Comparison of Music Similarity Adaptation Approaches.",
+    "pages": "103-108",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/103-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#WolffSNW12"
+  },
+  "conf/ismir/NiMSB12": {
+    "@key": "conf/ismir/NiMSB12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Yizhao Ni",
+      "Matt McVicar",
+      "Ra\u00fal Santos-Rodriguez",
+      "Tijl De Bie"
+    ],
+    "title": "Using Hyper-genre Training to Explore Genre Information for Automatic Chord Estimation.",
+    "pages": "109-114",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/109-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#NiMSB12"
+  },
+  "conf/ismir/LefevreBF12": {
+    "@key": "conf/ismir/LefevreBF12",
+    "@mdate": "2015-05-06",
+    "author": [
+      "Augustin Lef\u00e8vre",
+      "Francis R. Bach",
+      "C\u00e9dric F\u00e9votte"
+    ],
+    "title": "Semi-supervised NMF with Time-frequency Annotations for Single-channel Source Separation.",
+    "pages": "115-120",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/115-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#LefevreBF12"
+  },
+  "conf/ismir/BurletPHF12": {
+    "@key": "conf/ismir/BurletPHF12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Gregory Burlet",
+      "Alastair Porter",
+      "Andrew Hankinson",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Neon.js: Neume Editor Online.",
+    "pages": "121-126",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/121-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#BurletPHF12"
+  },
+  "conf/ismir/PapadopoulosT12": {
+    "@key": "conf/ismir/PapadopoulosT12",
+    "@mdate": "2015-01-20",
+    "author": [
+      "H\u00e9l\u00e8ne Papadopoulos",
+      "George Tzanetakis"
+    ],
+    "title": "Modeling Chord and Key Structure with Markov Logic.",
+    "pages": "127-132",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": [
+      "http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.294.4044",
+      "http://ismir2012.ismir.net/event/papers/127-ismir-2012.pdf"
+    ],
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#PapadopoulosT12"
+  },
+  "conf/ismir/Meredith12": {
+    "@key": "conf/ismir/Meredith12",
+    "@mdate": "2016-09-26",
+    "author": "David Meredith 0001",
+    "title": "A Geometric Language for Representing Structure in Polyphonic Music.",
+    "pages": "133-138",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/133-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#Meredith12"
+  },
+  "conf/ismir/WulfingR12": {
+    "@key": "conf/ismir/WulfingR12",
+    "@mdate": "2015-04-01",
+    "author": [
+      "Jan W\u00fclfing",
+      "Martin A. Riedmiller"
+    ],
+    "title": "Unsupervised Learning of Local Features for Music Classification.",
+    "pages": "139-144",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/139-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#WulfingR12"
+  },
+  "conf/ismir/GuR12": {
+    "@key": "conf/ismir/GuR12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Yupeng Gu",
+      "Christopher Raphael"
+    ],
+    "title": "Modeling Piano Interpretation Using Switching Kalman Filter.",
+    "pages": "145-150",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/145-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#GuR12"
+  },
+  "conf/ismir/JinR12": {
+    "@key": "conf/ismir/JinR12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Rong Jin",
+      "Christopher Raphael"
+    ],
+    "title": "Interpreting Rhythm in Optical Music Recognition.",
+    "pages": "151-156",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/151-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#JinR12"
+  },
+  "conf/ismir/ZapataHDOG12": {
+    "@key": "conf/ismir/ZapataHDOG12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Jos\u00e9 R. Zapata",
+      "Andre Holzapfel",
+      "Matthew E. P. Davies",
+      "Jo\u00e3o Lobato Oliveira",
+      "Fabien Gouyon"
+    ],
+    "title": "Assigning a Confidence Threshold on Automatic Beat Annotation in Large Datasets.",
+    "pages": "157-162",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/157-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#ZapataHDOG12"
+  },
+  "conf/ismir/MauchD12": {
+    "@key": "conf/ismir/MauchD12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Matthias Mauch",
+      "Simon Dixon"
+    ],
+    "title": "A Corpus-based Study of Rhythm Patterns.",
+    "pages": "163-168",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/163-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#MauchD12"
+  },
+  "conf/ismir/HockmanDF12": {
+    "@key": "conf/ismir/HockmanDF12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Jason Hockman",
+      "Matthew E. P. Davies",
+      "Ichiro Fujinaga"
+    ],
+    "title": "One in the Jungle: Downbeat Detection in Hardcore, Jungle, and Drum and Bass.",
+    "pages": "169-174",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/169-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#HockmanDF12"
+  },
+  "conf/ismir/FlexerSS12": {
+    "@key": "conf/ismir/FlexerSS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Arthur Flexer",
+      "Dominik Schnitzer",
+      "Jan Schlueter"
+    ],
+    "title": "A MIREX Meta-analysis of Hubness in Audio Music Similarity.",
+    "pages": "175-180",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/175-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#FlexerSS12"
+  },
+  "conf/ismir/UrbanoDMS12": {
+    "@key": "conf/ismir/UrbanoDMS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Juli\u00e1n Urbano",
+      "J. Stephen Downie",
+      "Brian McFee",
+      "Markus Schedl"
+    ],
+    "title": "How Significant is Statistically Significant? The case of Audio Music Similarity and Retrieval.",
+    "pages": "181-186",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/181-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#UrbanoDMS12"
+  },
+  "conf/ismir/SalamonPR12": {
+    "@key": "conf/ismir/SalamonPR12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Justin Salamon",
+      "Geoffroy Peeters",
+      "Axel R\u00f6bel"
+    ],
+    "title": "Statistical Characterisation of Melodic Pitch Contours and its Application for Melody Extraction.",
+    "pages": "187-192",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/187-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SalamonPR12"
+  },
+  "conf/ismir/RossPR12": {
+    "@key": "conf/ismir/RossPR12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Joe Cheri Ross",
+      "Vinutha T. P.",
+      "Preeti Rao"
+    ],
+    "title": "Detecting Melodic Motifs from Audio for Hindustani Classical Music.",
+    "pages": "193-198",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/193-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#RossPR12"
+  },
+  "conf/ismir/KoduriSS12": {
+    "@key": "conf/ismir/KoduriSS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Gopala K. Koduri",
+      "Joan Serr\u00e0",
+      "Xavier Serra"
+    ],
+    "title": "Characterization of Intonation in Carnatic Music by Parametrizing Pitch Histograms.",
+    "pages": "199-204",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/199-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#KoduriSS12"
+  },
+  "conf/ismir/Boulanger-LewandowskiBV12": {
+    "@key": "conf/ismir/Boulanger-LewandowskiBV12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Nicolas Boulanger-Lewandowski",
+      "Yoshua Bengio",
+      "Pascal Vincent"
+    ],
+    "title": "Discriminative Non-negative Matrix Factorization for Multiple Pitch Estimation.",
+    "pages": "205-210",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/205-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#Boulanger-LewandowskiBV12"
+  },
+  "conf/ismir/FohlMT12": {
+    "@key": "conf/ismir/FohlMT12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Wolfgang Fohl",
+      "Andreas Meisel",
+      "Ivan Turkalj"
+    ],
+    "title": "A Feature Relevance Study for Guitar Tone Classification.",
+    "pages": "211-216",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/211-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#FohlMT12"
+  },
+  "conf/ismir/HillewaereMC12": {
+    "@key": "conf/ismir/HillewaereMC12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Ruben Hillewaere",
+      "Bernard Manderick",
+      "Darrell Conklin"
+    ],
+    "title": "String Methods for Folk Tune Genre Classification.",
+    "pages": "217-222",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/217-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#HillewaereMC12"
+  },
+  "conf/ismir/Karaosmanoglu12": {
+    "@key": "conf/ismir/Karaosmanoglu12",
+    "@mdate": "2012-10-25",
+    "author": "Mustafa Kemal Karaosmanoglu",
+    "title": "A Turkish Makam Music Symbolic Database for Music Information Retrieval: SymbTr.",
+    "pages": "223-228",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/223-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#Karaosmanoglu12"
+  },
+  "conf/ismir/AnanHBTS12": {
+    "@key": "conf/ismir/AnanHBTS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Yoko Anan",
+      "Kohei Hatano",
+      "Hideo Bannai",
+      "Masayuki Takeda",
+      "Ken Satoh"
+    ],
+    "title": "Polyphonic Music Classification on Symbolic Data Using Dissimilarity Functions.",
+    "pages": "229-234",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/229-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#AnanHBTS12"
+  },
+  "conf/ismir/BimbotDSV12": {
+    "@key": "conf/ismir/BimbotDSV12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Fr\u00e9d\u00e9ric Bimbot",
+      "Emmanuel Deruty",
+      "Gabriel Sargent",
+      "Emmanuel Vincent"
+    ],
+    "title": "Semiotic Structure Labeling of Music Pieces: Concepts, Methods and Annotation Conventions.",
+    "pages": "235-240",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/235-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#BimbotDSV12"
+  },
+  "conf/ismir/Bertin-MahieuxE12": {
+    "@key": "conf/ismir/Bertin-MahieuxE12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Thierry Bertin-Mahieux",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "Large-Scale Cover Song Recognition Using the 2D Fourier Transform Magnitude.",
+    "pages": "241-246",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/241-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#Bertin-MahieuxE12"
+  },
+  "conf/ismir/ChuanC12": {
+    "@key": "conf/ismir/ChuanC12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Ching-Hua Chuan",
+      "Elaine Chew"
+    ],
+    "title": "Creating Ground Truth for Audio Key Finding: When the Title Key May Not Be the Key.",
+    "pages": "247-252",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/247-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#ChuanC12"
+  },
+  "conf/ismir/LeeW12": {
+    "@key": "conf/ismir/LeeW12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Jin Ha Lee",
+      "Nichole Maiman Waterman"
+    ],
+    "title": "Understanding User Requirements for Music Information Services.",
+    "pages": "253-258",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/253-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#LeeW12"
+  },
+  "conf/ismir/CunninghamBD12": {
+    "@key": "conf/ismir/CunninghamBD12",
+    "@mdate": "2017-12-03",
+    "author": [
+      "Sally Jo Cunningham",
+      "David Bainbridge 0001",
+      "J. Stephen Downie"
+    ],
+    "title": "The Impact of MIREX on Scholarly Research (2005 - 2010).",
+    "pages": "259-264",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/259-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#CunninghamBD12"
+  },
+  "conf/ismir/CabredoLIN12": {
+    "@key": "conf/ismir/CabredoLIN12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Rafael Cabredo",
+      "Roberto S. Legaspi",
+      "Paul Salvador Inventado",
+      "Masayuki Numao"
+    ],
+    "title": "An Emotion Model for Music Using Brain Waves.",
+    "pages": "265-270",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/265-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#CabredoLIN12"
+  },
+  "conf/ismir/PanagakisK12": {
+    "@key": "conf/ismir/PanagakisK12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Yannis Panagakis",
+      "Constantine Kotropoulos"
+    ],
+    "title": "Music Structure Analysis by Ridge Regression of Beat-synchronous Audio Features.",
+    "pages": "271-276",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/271-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#PanagakisK12"
+  },
+  "conf/ismir/JoderS12": {
+    "@key": "conf/ismir/JoderS12",
+    "@mdate": "2015-06-17",
+    "author": [
+      "Cyril Joder",
+      "Bj\u00f6rn W. Schuller"
+    ],
+    "title": "Score-Informed Leading Voice Separation from Monaural Audio.",
+    "pages": "277-282",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/277-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#JoderS12"
+  },
+  "conf/ismir/SiorosHG12": {
+    "@key": "conf/ismir/SiorosHG12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "George Sioros",
+      "Andre Holzapfel",
+      "Carlos Guedes"
+    ],
+    "title": "On Measuring Syncopation to Drive an Interactive Music System.",
+    "pages": "283-288",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/283-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SiorosHG12"
+  },
+  "conf/ismir/SalamonU12": {
+    "@key": "conf/ismir/SalamonU12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Justin Salamon",
+      "Juli\u00e1n Urbano"
+    ],
+    "title": "Current Challenges in the Evaluation of Predominant Melody Extraction Algorithms.",
+    "pages": "289-294",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/289-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SalamonU12"
+  },
+  "conf/ismir/HaasMW12": {
+    "@key": "conf/ismir/HaasMW12",
+    "@mdate": "2015-11-04",
+    "author": [
+      "W. Bas de Haas",
+      "Jos\u00e9 Pedro Magalh\u00e3es",
+      "Frans Wiering"
+    ],
+    "title": "Improving Audio Chord Transcription by Exploiting Harmonic and Metric Knowledge.",
+    "pages": "295-300",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/295-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#HaasMW12"
+  },
+  "conf/ismir/GkiokasKC12": {
+    "@key": "conf/ismir/GkiokasKC12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Aggelos Gkiokas",
+      "Vassilios Katsouros",
+      "George Carayannis"
+    ],
+    "title": "Reducing Tempo Octave Errors by Periodicity Vector Coding And SVM Learning.",
+    "pages": "301-306",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/301-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#GkiokasKC12"
+  },
+  "conf/ismir/KameokaONTS12": {
+    "@key": "conf/ismir/KameokaONTS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Hirokazu Kameoka",
+      "Kazuki Ochiai",
+      "Masahiro Nakano",
+      "Masato Tsuchiya",
+      "Shigeki Sagayama"
+    ],
+    "title": "Context-free 2D Tree Structure Model of Musical Notes for Bayesian Modeling of Polyphonic Spectrograms.",
+    "pages": "307-312",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/307-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#KameokaONTS12"
+  },
+  "conf/ismir/NietoHB12": {
+    "@key": "conf/ismir/NietoHB12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Oriol Nieto",
+      "Eric J. Humphrey",
+      "Juan Pablo Bello"
+    ],
+    "title": "Compressing Music Recordings into Audio Summaries.",
+    "pages": "313-318",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/313-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#NietoHB12"
+  },
+  "conf/ismir/BayEBSD12": {
+    "@key": "conf/ismir/BayEBSD12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Mert Bay",
+      "Andreas F. Ehmann",
+      "James W. Beauchamp",
+      "Paris Smaragdis",
+      "J. Stephen Downie"
+    ],
+    "title": "Second Fiddle is Important Too: Pitch Tracking Individual Voices in Polyphonic Music.",
+    "pages": "319-324",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/319-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#BayEBSD12"
+  },
+  "conf/ismir/SchmidtSK12": {
+    "@key": "conf/ismir/SchmidtSK12",
+    "@mdate": "2012-10-26",
+    "author": [
+      "Erik M. Schmidt",
+      "Jeffrey J. Scott",
+      "Youngmoo E. Kim"
+    ],
+    "title": "Feature Learning in Dynamic Environments: Modeling the Acoustic Structure of Musical Emotion.",
+    "pages": "325-330",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/325-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SchmidtSK12"
+  },
+  "conf/ismir/HuK12": {
+    "@key": "conf/ismir/HuK12",
+    "@mdate": "2018-08-16",
+    "author": [
+      "Xiao Hu 0001",
+      "Noriko Kando"
+    ],
+    "title": "User-centered Measures vs. System Effectiveness in Finding Similar Songs.",
+    "pages": "331-336",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/331-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#HuK12"
+  },
+  "conf/ismir/MayerR12": {
+    "@key": "conf/ismir/MayerR12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Rudolf Mayer",
+      "Andreas Rauber"
+    ],
+    "title": "Towards Time-resilient MIR Processes.",
+    "pages": "337-342",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/337-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#MayerR12"
+  },
+  "conf/ismir/McFeeL12": {
+    "@key": "conf/ismir/McFeeL12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Brian McFee",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Hypergraph Models of Playlist Dialects.",
+    "pages": "343-348",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/343-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#McFeeL12"
+  },
+  "conf/ismir/MooreCJT12": {
+    "@key": "conf/ismir/MooreCJT12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Joshua L. Moore",
+      "Shuo Chen",
+      "Thorsten Joachims",
+      "Douglas Turnbull"
+    ],
+    "title": "Learning to Embed Songs and Tags for Playlist Prediction.",
+    "pages": "349-354",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/349-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#MooreCJT12"
+  },
+  "conf/ismir/SordoSKS12": {
+    "@key": "conf/ismir/SordoSKS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Mohamed Sordo",
+      "Joan Serr\u00e0",
+      "Gopala K. Koduri",
+      "Xavier Serra"
+    ],
+    "title": "Extracting Semantic Information from an Online Carnatic Music Forum.",
+    "pages": "355-360",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/355-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SordoSKS12"
+  },
+  "conf/ismir/MacraeD12": {
+    "@key": "conf/ismir/MacraeD12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Robert Macrae",
+      "Simon Dixon"
+    ],
+    "title": "Ranking Lyrics for Online Search.",
+    "pages": "361-366",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/361-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#MacraeD12"
+  },
+  "conf/ismir/WoelferL12": {
+    "@key": "conf/ismir/WoelferL12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Jill Palzkill Woelfer",
+      "Jin Ha Lee"
+    ],
+    "title": "The Role Of Music in the Lives of Homeless Young People: A Preliminary Report.",
+    "pages": "367-372",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/367-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#WoelferL12"
+  },
+  "conf/ismir/KamalzadehBM12": {
+    "@key": "conf/ismir/KamalzadehBM12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Mohsen Kamalzadeh",
+      "Dominikus Baur",
+      "Torsten M\u00f6ller"
+    ],
+    "title": "A Survey on Music Listening and Management Behaviours.",
+    "pages": "373-378",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/373-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#KamalzadehBM12"
+  },
+  "conf/ismir/BenetosDGKK12": {
+    "@key": "conf/ismir/BenetosDGKK12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Emmanouil Benetos",
+      "Simon Dixon",
+      "Dimitrios Giannoulis",
+      "Holger Kirchhoff",
+      "Anssi Klapuri"
+    ],
+    "title": "Automatic Music Transcription: Breaking the Glass Ceiling.",
+    "pages": "379-384",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/379-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#BenetosDGKK12"
+  },
+  "conf/ismir/SchedlF12": {
+    "@key": "conf/ismir/SchedlF12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Markus Schedl",
+      "Arthur Flexer"
+    ],
+    "title": "Putting the User in the Center of Music Information Retrieval.",
+    "pages": "385-390",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/385-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SchedlF12"
+  },
+  "conf/ismir/LeeC12": {
+    "@key": "conf/ismir/LeeC12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Jin Ha Lee",
+      "Sally Jo Cunningham"
+    ],
+    "title": "The Impact (or Non-impact) of User Studies in Music Information Retrieval.",
+    "pages": "391-396",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/391-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#LeeC12"
+  },
+  "conf/ismir/AucouturierB12": {
+    "@key": "conf/ismir/AucouturierB12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Jean-Julien Aucouturier",
+      "Emmanuel Bigand"
+    ],
+    "title": "Mel Cepstrum &amp; Ann Ova: The Difficult Dialog Between MIR and Music Cognition.",
+    "pages": "397-402",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/397-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#AucouturierB12"
+  },
+  "conf/ismir/HumphreyBL12": {
+    "@key": "conf/ismir/HumphreyBL12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Eric J. Humphrey",
+      "Juan Pablo Bello",
+      "Yann LeCun"
+    ],
+    "title": "Moving Beyond Feature Design: Deep Architectures and Automatic Feature Learning in Music Informatics.",
+    "pages": "403-408",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/403-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#HumphreyBL12"
+  },
+  "conf/ismir/PageFRCD12": {
+    "@key": "conf/ismir/PageFRCD12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Kevin R. Page",
+      "Benjamin Fields",
+      "David De Roure",
+      "Tim Crawford",
+      "J. Stephen Downie"
+    ],
+    "title": "Reuse, Remix, Repeat: the Workflows of MIR.",
+    "pages": "409-414",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/409-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#PageFRCD12"
+  },
+  "conf/ismir/KirchhoffDK12": {
+    "@key": "conf/ismir/KirchhoffDK12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Holger Kirchhoff",
+      "Simon Dixon",
+      "Anssi Klapuri"
+    ],
+    "title": "Multi-Template Shift-Variant Non-Negative Matrix Deconvolution for Semi-Automatic Music Transcription.",
+    "pages": "415-420",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/415-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#KirchhoffDK12"
+  },
+  "conf/ismir/PikrakisGODMEGS12": {
+    "@key": "conf/ismir/PikrakisGODMEGS12",
+    "@mdate": "2018-03-29",
+    "author": [
+      "Aggelos Pikrakis",
+      "Francisco G\u00f3mez 0001",
+      "Sergio Oramas",
+      "Jos\u00e9 Miguel D\u00edaz-B\u00e1\u00f1ez",
+      "Joaqu\u00edn Mora",
+      "Francisco Escobar-Borrego",
+      "Emilia G\u00f3mez",
+      "Justin Salamon"
+    ],
+    "title": "Tracking Melodic Patterns in Flamenco Singing by Analyzing Polyphonic Music Recordings.",
+    "pages": "421-426",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/421-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#PikrakisGODMEGS12"
+  },
+  "conf/ismir/MullerPD12": {
+    "@key": "conf/ismir/MullerPD12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Meinard M\u00fcller",
+      "Thomas Pr\u00e4tzlich",
+      "Jonathan Driedger"
+    ],
+    "title": "A Cross-version Approach for Stabilizing Tempo-based Novelty Detection.",
+    "pages": "427-432",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/427-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#MullerPD12"
+  },
+  "conf/ismir/ArztBW12": {
+    "@key": "conf/ismir/ArztBW12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Andreas Arzt",
+      "Sebastian B\u00f6ck",
+      "Gerhard Widmer"
+    ],
+    "title": "Fast Identification of Piece and Score Position via Symbolic Fingerprinting.",
+    "pages": "433-438",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/433-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#ArztBW12"
+  },
+  "conf/ismir/PeetersCCTBVBRC12": {
+    "@key": "conf/ismir/PeetersCCTBVBRC12",
+    "@mdate": "2012-11-02",
+    "author": [
+      "Geoffroy Peeters",
+      "Fr\u00e9d\u00e9ric Cornu",
+      "Christophe Charbuillet",
+      "Damien Tardieu",
+      "Juan Jos\u00e9 Burred",
+      "Marie Vian",
+      "Val\u00e9rie Botherel",
+      "Jean-Bernard Rault",
+      "Jean-Philippe Cabanal"
+    ],
+    "title": "A Multimedia Search and Navigation Prototype, Including Music and Video-clips.",
+    "pages": "439-444",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/439-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#PeetersCCTBVBRC12"
+  },
+  "conf/ismir/ChenSSC12": {
+    "@key": "conf/ismir/ChenSSC12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Ruofeng Chen",
+      "Weibin Shen",
+      "Ajay Srinivasamurthy",
+      "Parag Chordia"
+    ],
+    "title": "Chord Recognition Using Duration-explicit Hidden Markov Models.",
+    "pages": "445-450",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/445-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#ChenSSC12"
+  },
+  "conf/ismir/BohakM12": {
+    "@key": "conf/ismir/BohakM12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Ciril Bohak",
+      "Matija Marolt"
+    ],
+    "title": "Finding Repeating Stanzas in Folk Songs.",
+    "pages": "451-456",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/451-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#BohakM12"
+  },
+  "conf/ismir/GiraudGL12": {
+    "@key": "conf/ismir/GiraudGL12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Mathieu Giraud",
+      "Richard Groult",
+      "Florence Lev\u00e9"
+    ],
+    "title": "Detecting Episodes with Harmonic Sequences for Fugue Analysis.",
+    "pages": "457-462",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/457-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#GiraudGL12"
+  },
+  "conf/ismir/OHaraSLT12": {
+    "@key": "conf/ismir/OHaraSLT12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Tom O'Hara",
+      "Nico Sch\u00fcler",
+      "Yijuan Lu",
+      "Dan Tamir"
+    ],
+    "title": "Inferring Chord Sequence Meanings via Lyrics: Process and Evaluation.",
+    "pages": "463-468",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/463-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#OHaraSLT12"
+  },
+  "conf/ismir/RauberSM12": {
+    "@key": "conf/ismir/RauberSM12",
+    "@mdate": "2013-05-23",
+    "author": [
+      "Alexander Schindler",
+      "Rudolf Mayer",
+      "Andreas Rauber"
+    ],
+    "title": "Facilitating Comprehensive Benchmarking Experiments on the Million Song Dataset.",
+    "pages": "469-474",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/469-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#RauberSM12"
+  },
+  "conf/ismir/Robertson12": {
+    "@key": "conf/ismir/Robertson12",
+    "@mdate": "2012-10-25",
+    "author": "Andrew Robertson",
+    "title": "Decoding Tempo and Timing Variations in Music Recordings from Beat Annotations.",
+    "pages": "475-480",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/475-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#Robertson12"
+  },
+  "conf/ismir/KostaMP12": {
+    "@key": "conf/ismir/KostaMP12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Katerina Kosta",
+      "Marco Marchini",
+      "Hendrik Purwins"
+    ],
+    "title": "Unsupervised Chord-Sequence Generation from an Audio Example.",
+    "pages": "481-486",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/481-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#KostaMP12"
+  },
+  "conf/ismir/TerrellFSSD12": {
+    "@key": "conf/ismir/TerrellFSSD12",
+    "@mdate": "2014-09-17",
+    "author": [
+      "Michael Terrell",
+      "Gy\u00f6rgy Fazekas",
+      "Andrew Simpson",
+      "Jordan B. L. Smith",
+      "Simon Dixon"
+    ],
+    "title": "Listening Level Changes Music Similarity.",
+    "pages": "487-492",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/487-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#TerrellFSSD12"
+  },
+  "conf/ismir/JureLRCSI12": {
+    "@key": "conf/ismir/JureLRCSI12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Luis Jure",
+      "Ernesto L\u00f3pez",
+      "Mart\u00edn Rocamora",
+      "Pablo Cancela",
+      "Haldo Sponton",
+      "Ignacio Irigaray"
+    ],
+    "title": "Pitch Content Visualization Tools for Music Performance Analysis.",
+    "pages": "493-498",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/493-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#JureLRCSI12"
+  },
+  "conf/ismir/SalamonGS12": {
+    "@key": "conf/ismir/SalamonGS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Justin Salamon",
+      "Sankalp Gulati",
+      "Xavier Serra"
+    ],
+    "title": "A Multipitch Approach to Tonic Identification in Indian Classical Music.",
+    "pages": "499-504",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/499-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SalamonGS12"
+  },
+  "conf/ismir/PuginKRHH12": {
+    "@key": "conf/ismir/PuginKRHH12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Laurent Pugin",
+      "Johannes Kepper",
+      "Perry Roland",
+      "Maja Hartwig",
+      "Andrew Hankinson"
+    ],
+    "title": "Separating Presentation and Content in MEI.",
+    "pages": "505-510",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/505-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#PuginKRHH12"
+  },
+  "conf/ismir/DevaneyMF12": {
+    "@key": "conf/ismir/DevaneyMF12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Johanna Devaney",
+      "Michael I. Mandel",
+      "Ichiro Fujinaga"
+    ],
+    "title": "A Study of Intonation in Three-Part Singing using the Automatic Music Performance Analysis and Comparison Toolkit (AMPACT).",
+    "pages": "511-516",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/511-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#DevaneyMF12"
+  },
+  "conf/ismir/Rosao0M12": {
+    "@key": "conf/ismir/Rosao0M12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Carlos Ros\u00e3o",
+      "Ricardo Ribeiro 0001",
+      "David Martins de Matos"
+    ],
+    "title": "Influence of Peak Selection Methods on Onset Detection.",
+    "pages": "517-522",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/517-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#Rosao0M12"
+  },
+  "conf/ismir/SongDP12": {
+    "@key": "conf/ismir/SongDP12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Yading Song",
+      "Simon Dixon",
+      "Marcus Pearce"
+    ],
+    "title": "Evaluation of Musical Features for Emotion Classification.",
+    "pages": "523-528",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/523-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SongDP12"
+  },
+  "conf/ismir/MartinBHF12": {
+    "@key": "conf/ismir/MartinBHF12",
+    "@mdate": "2016-07-06",
+    "author": [
+      "Benjamin Martin 0001",
+      "Daniel G. Brown 0001",
+      "Pierre Hanna",
+      "Pascal Ferraro"
+    ],
+    "title": "BLAST for Audio Sequences Alignment: A Fast Scalable Cover Identification Tool.",
+    "pages": "529-534",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/529-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#MartinBHF12"
+  },
+  "conf/ismir/HuL12": {
+    "@key": "conf/ismir/HuL12",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "Jin Ha Lee"
+    ],
+    "title": "A Cross-cultural Study of Music Mood Perception between American and Chinese Listeners.",
+    "pages": "535-540",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/535-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#HuL12"
+  },
+  "conf/ismir/MechtleySC12": {
+    "@key": "conf/ismir/MechtleySC12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Brandon Mechtley",
+      "Andreas Spanias",
+      "Perry Cook"
+    ],
+    "title": "Shortest Path Techniques for Annotation and Retrieval of Environmental Sounds.",
+    "pages": "541-546",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/541-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#MechtleySC12"
+  },
+  "conf/ismir/CovielloVCL12": {
+    "@key": "conf/ismir/CovielloVCL12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Emanuele Coviello",
+      "Yonatan Vaizman",
+      "Antoni B. Chan",
+      "Gert R. G. Lanckriet"
+    ],
+    "title": "Multivariate Autoregressive Mixture Models for Music Auto-Tagging.",
+    "pages": "547-552",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/547-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#CovielloVCL12"
+  },
+  "conf/ismir/HamelBE12": {
+    "@key": "conf/ismir/HamelBE12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Philippe Hamel",
+      "Yoshua Bengio",
+      "Douglas Eck"
+    ],
+    "title": "Building Musically-relevant Audio Features through Multiple Timescale Representations.",
+    "pages": "553-558",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/553-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#HamelBE12"
+  },
+  "conf/ismir/BoschJFH12": {
+    "@key": "conf/ismir/BoschJFH12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Juan J. Bosch",
+      "Jordi Janer",
+      "Ferdinand Fuhrmann",
+      "Perfecto Herrera"
+    ],
+    "title": "A Comparison of Sound Segregation Techniques for Predominant Instrument Recognition in Musical Audio Signals.",
+    "pages": "559-564",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/559-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#BoschJFH12"
+  },
+  "conf/ismir/NamHSS12": {
+    "@key": "conf/ismir/NamHSS12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Juhan Nam",
+      "Jorge Herrera",
+      "Malcolm Slaney",
+      "Julius O. Smith"
+    ],
+    "title": "Learning Sparse Feature Representations for Music Annotation and Retrieval.",
+    "pages": "565-570",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/565-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#NamHSS12"
+  },
+  "conf/ismir/SebastienRSC12": {
+    "@key": "conf/ismir/SebastienRSC12",
+    "@mdate": "2014-09-15",
+    "author": [
+      "V\u00e9ronique S\u00e9bastien",
+      "Henri Ralambondrainy",
+      "Olivier S\u00e9bastien",
+      "No\u00ebl Conruyt"
+    ],
+    "title": "Score Analyzer: Automatically Determining Scores Difficulty Level for Instrumental e-Learning.",
+    "pages": "571-576",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/571-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#SebastienRSC12"
+  },
+  "conf/ismir/HankinsonBVPTLCF12": {
+    "@key": "conf/ismir/HankinsonBVPTLCF12",
+    "@mdate": "2017-08-08",
+    "author": [
+      "Andrew Hankinson",
+      "John Ashley Burgoyne",
+      "Gabriel Vigliensoni",
+      "Alastair Porter",
+      "Jessica Thompson 0001",
+      "Wendy Liu",
+      "Remi Chiu",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Digital Document Image Retrieval Using Optical Music Recognition.",
+    "pages": "577-582",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/577-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#HankinsonBVPTLCF12"
+  },
+  "conf/ismir/RafiiP12": {
+    "@key": "conf/ismir/RafiiP12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Zafar Rafii",
+      "Bryan Pardo"
+    ],
+    "title": "Music/Voice Separation Using the Similarity Matrix.",
+    "pages": "583-588",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/583-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#RafiiP12"
+  },
+  "conf/ismir/ProutskovaRWC12": {
+    "@key": "conf/ismir/ProutskovaRWC12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Polina Proutskova",
+      "Christophe Rhodes",
+      "Geraint A. Wiggins",
+      "Tim Crawford"
+    ],
+    "title": "Breathy or Resonant - A Controlled and Curated Dataset for Phonation Mode Detection in Singing.",
+    "pages": "589-594",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/589-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#ProutskovaRWC12"
+  },
+  "conf/ismir/LagrangeOV12": {
+    "@key": "conf/ismir/LagrangeOV12",
+    "@mdate": "2012-10-25",
+    "author": [
+      "Mathieu Lagrange",
+      "Alexey Ozerov",
+      "Emmanuel Vincent"
+    ],
+    "title": "Robust Singer Identification in Polyphonic Music using Melody Enhancement and Uncertainty-based Learning.",
+    "pages": "595-600",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/595-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#LagrangeOV12"
+  },
+  "conf/ismir/GomezCSBCM12": {
+    "@key": "conf/ismir/GomezCSBCM12",
+    "@mdate": "2017-05-06",
+    "author": [
+      "Emilia G\u00f3mez",
+      "Francisco J. Ca\u00f1adas-Quesada",
+      "Justin Salamon",
+      "Jordi Bonada",
+      "Pedro Vera-Candeas",
+      "Pablo Caba\u00f1as Molero"
+    ],
+    "title": "Predominant Fundamental Frequency Estimation vs Singing Voice Separation for the Automatic Transcription of Accompanied Flamenco Singing.",
+    "pages": "601-606",
+    "year": "2012",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2012.ismir.net/event/papers/601-ismir-2012.pdf",
+    "crossref": "conf/ismir/2012",
+    "url": "db/conf/ismir/ismir2012.html#GomezCSBCM12"
+  },
+  "conf/ismir/DielemanS13": {
+    "@key": "conf/ismir/DielemanS13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Sander Dieleman",
+      "Benjamin Schrauwen"
+    ],
+    "title": "Multiscale Approaches To Music Audio Feature Learning.",
+    "pages": "3-8",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/69_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#DielemanS13"
+  },
+  "conf/ismir/HamelDYG13": {
+    "@key": "conf/ismir/HamelDYG13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Philippe Hamel",
+      "Matthew E. P. Davies",
+      "Kazuyoshi Yoshii",
+      "Masataka Goto"
+    ],
+    "title": "Transfer Learning In Mir: Sharing Learned Latent Representations For Music Audio Classification And Similarity.",
+    "pages": "9-14",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/76_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#HamelDYG13"
+  },
+  "conf/ismir/CherlaWGP13": {
+    "@key": "conf/ismir/CherlaWGP13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Srikanth Cherla",
+      "Tillman Weyde",
+      "Artur S. d'Avila Garcez",
+      "Marcus Pearce"
+    ],
+    "title": "A Distributed Model For Multiple-Viewpoint Melodic Prediction.",
+    "pages": "15-20",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/135_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#CherlaWGP13"
+  },
+  "conf/ismir/SchmidtK13": {
+    "@key": "conf/ismir/SchmidtK13",
+    "@mdate": "2016-09-28",
+    "author": [
+      "Erik M. Schmidt",
+      "Youngmoo Kim"
+    ],
+    "title": "Learning Rhythm And Melody Features With Deep Belief Networks.",
+    "pages": "21-26",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/193_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SchmidtK13"
+  },
+  "conf/ismir/AgarwalKR13": {
+    "@key": "conf/ismir/AgarwalKR13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Parul Agarwal",
+      "Harish Karnick",
+      "Bhiksha Raj"
+    ],
+    "title": "A Comparative Study Of Indian And Western Music Forms.",
+    "pages": "29-34",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/27_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#AgarwalKR13"
+  },
+  "conf/ismir/DigheKR13": {
+    "@key": "conf/ismir/DigheKR13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Pranay Dighe",
+      "Harish Karnick",
+      "Bhiksha Raj"
+    ],
+    "title": "Swara Histogram Based Structural Analysis And Identification Of Indian Classical Ragas.",
+    "pages": "35-40",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/43_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#DigheKR13"
+  },
+  "conf/ismir/RafiiGSM13": {
+    "@key": "conf/ismir/RafiiGSM13",
+    "@mdate": "2015-10-30",
+    "author": [
+      "Zafar Rafii",
+      "Fran\u00e7ois G. Germain",
+      "Dennis L. Sun",
+      "Gautham J. Mysore"
+    ],
+    "title": "Combining Modeling Of Singing Voice And Background Music For Automatic Separation Of Musical Mixtures.",
+    "pages": "41-46",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/63_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#RafiiGSM13"
+  },
+  "conf/ismir/LaaksonenL13": {
+    "@key": "conf/ismir/LaaksonenL13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Antti Laaksonen",
+      "Kjell Lemstr\u00f6m"
+    ],
+    "title": "On Finding Symbolic Themes Directly From Audio Files Using Dynamic Programming.",
+    "pages": "47-52",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/66_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#LaaksonenL13"
+  },
+  "conf/ismir/LehnerSW13": {
+    "@key": "conf/ismir/LehnerSW13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Bernhard Lehner",
+      "Reinhard Sonnleitner",
+      "Gerhard Widmer"
+    ],
+    "title": "Towards Light-Weight, Real-Time-Capable Singing Voice Detection.",
+    "pages": "53-58",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/89_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#LehnerSW13"
+  },
+  "conf/ismir/ChoudhuryBB13": {
+    "@key": "conf/ismir/ChoudhuryBB13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Monojit Choudhury",
+      "Ranjita Bhagwan",
+      "Kalika Bali"
+    ],
+    "title": "The Use Of Melodic Scales In Bollywood Music: An Empirical Study.",
+    "pages": "59-64",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/103_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#ChoudhuryBB13"
+  },
+  "conf/ismir/YakarSLBS13": {
+    "@key": "conf/ismir/YakarSLBS13",
+    "@mdate": "2016-11-26",
+    "author": [
+      "Tal Ben Yakar",
+      "Roee Litman",
+      "Pablo Sprechmann",
+      "Alexander M. Bronstein",
+      "Guillermo Sapiro"
+    ],
+    "title": "Bilevel Sparse Models for Polyphonic Music Transcription.",
+    "pages": "65-70",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/110_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#YakarSLBS13"
+  },
+  "conf/ismir/McKay13": {
+    "@key": "conf/ismir/McKay13",
+    "@mdate": "2013-12-05",
+    "author": "Cory McKay",
+    "title": "JProductionCritic: An Educational Tool for Detecting Technical Errors in Audio Mixes.",
+    "pages": "71-76",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/112_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#McKay13"
+  },
+  "conf/ismir/OrioP13": {
+    "@key": "conf/ismir/OrioP13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Nicola Orio",
+      "Roberto Piva"
+    ],
+    "title": "Combining Timbric and Rhythmic Features for Semantic Music Tagging.",
+    "pages": "77-82",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/129_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#OrioP13"
+  },
+  "conf/ismir/MauchE13": {
+    "@key": "conf/ismir/MauchE13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Matthias Mauch",
+      "Sebastian Ewert"
+    ],
+    "title": "The Audio Degradation Toolbox and Its Application to Robustness Evaluation.",
+    "pages": "83-88",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/145_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#MauchE13"
+  },
+  "conf/ismir/SongDPH13": {
+    "@key": "conf/ismir/SongDPH13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Yading Song",
+      "Simon Dixon",
+      "Marcus Pearce",
+      "Andrea R. Halpern"
+    ],
+    "title": "Do Online Social Tags Predict Perceived or Induced Emotional Responses to Music?",
+    "pages": "89-94",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/170_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SongDPH13"
+  },
+  "conf/ismir/SilvaPBE13": {
+    "@key": "conf/ismir/SilvaPBE13",
+    "@mdate": "2014-04-20",
+    "author": [
+      "Diego Furtado Silva",
+      "H\u00e9l\u00e8ne Papadopoulos",
+      "Gustavo Enrique De Almeida Prado Alves Batista",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "A Video Compression-Based Approach to Measure Music Structural Similarity.",
+    "pages": "95-100",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/174_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SilvaPBE13"
+  },
+  "conf/ismir/PorterSS13": {
+    "@key": "conf/ismir/PorterSS13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Alastair Porter",
+      "Mohamed Sordo",
+      "Xavier Serra"
+    ],
+    "title": "Dunya: A System to Browse Audio Music Collections Exploiting Cultural Context.",
+    "pages": "101-106",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/179_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#PorterSS13"
+  },
+  "conf/ismir/BalenBWV13": {
+    "@key": "conf/ismir/BalenBWV13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Jan Van Balen",
+      "John Ashley Burgoyne",
+      "Frans Wiering",
+      "Remco C. Veltkamp"
+    ],
+    "title": "An Analysis of Chorus Features in Popular Song.",
+    "pages": "107-112",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/180_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BalenBWV13"
+  },
+  "conf/ismir/KuuskankareS13": {
+    "@key": "conf/ismir/KuuskankareS13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Mika Kuuskankare",
+      "Craig Sapp"
+    ],
+    "title": "Visual Humdrum-Library for PWGL.",
+    "pages": "113-118",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/184_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#KuuskankareS13"
+  },
+  "conf/ismir/BryanMW13": {
+    "@key": "conf/ismir/BryanMW13",
+    "@mdate": "2018-01-25",
+    "author": [
+      "Nicholas J. Bryan",
+      "Gautham J. Mysore",
+      "Ge Wang 0002"
+    ],
+    "title": "Source Separation of Polyphonic Music with Interactive User-Feedback on a Piano Roll Display.",
+    "pages": "119-124",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/188_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BryanMW13"
+  },
+  "conf/ismir/VigliensoniBF13": {
+    "@key": "conf/ismir/VigliensoniBF13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Gabriel Vigliensoni",
+      "Gregory Burlet",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Optical Measure Recognition in Common Music Notation.",
+    "pages": "125-130",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/207_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#VigliensoniBF13"
+  },
+  "conf/ismir/VigliensoniBF13a": {
+    "@key": "conf/ismir/VigliensoniBF13a",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Gabriel Vigliensoni",
+      "John Ashley Burgoyne",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Musicbrainz for The World: The Chilean Experience.",
+    "pages": "131-136",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/212_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#VigliensoniBF13a"
+  },
+  "conf/ismir/CunninghamL13": {
+    "@key": "conf/ismir/CunninghamL13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Sally Jo Cunningham",
+      "Jin Ha Lee"
+    ],
+    "title": "Influences of ISMIR and MIREX Research on Technology Patents.",
+    "pages": "137-142",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/226_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#CunninghamL13"
+  },
+  "conf/ismir/ProckupSSK13": {
+    "@key": "conf/ismir/ProckupSSK13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Matthew Prockup",
+      "Erik M. Schmidt",
+      "Jeffrey J. Scott",
+      "Youngmoo E. Kim"
+    ],
+    "title": "Toward Understanding Expressive Percussion Through Content Based Analysis.",
+    "pages": "143-148",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/242_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#ProckupSSK13"
+  },
+  "conf/ismir/HumphreyNB13": {
+    "@key": "conf/ismir/HumphreyNB13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Eric J. Humphrey",
+      "Oriol Nieto",
+      "Juan Pablo Bello"
+    ],
+    "title": "Data Driven and Discriminative Projections for Large-Scale Cover Song Identification.",
+    "pages": "149-154",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/246_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#HumphreyNB13"
+  },
+  "conf/ismir/Wu13": {
+    "@key": "conf/ismir/Wu13",
+    "@mdate": "2013-12-05",
+    "author": "Dekai Wu",
+    "title": "Simultaneous Unsupervised Learning of Flamenco Metrical Structure, Hypermetrical Structure, and Multipart Structural Relations.",
+    "pages": "155-160",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/259_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#Wu13"
+  },
+  "conf/ismir/VolkH13": {
+    "@key": "conf/ismir/VolkH13",
+    "@mdate": "2015-11-04",
+    "author": [
+      "Anja Volk",
+      "W. Bas de Haas"
+    ],
+    "title": "A Corpus-Based Study on Ragtime Syncopation.",
+    "pages": "163-168",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/10_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#VolkH13"
+  },
+  "conf/ismir/PanteliP13": {
+    "@key": "conf/ismir/PanteliP13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Maria Panteli",
+      "Hendrik Purwins"
+    ],
+    "title": "A Computational Comparison of Theory And Practice of Scale Intonation in Byzantine Chant.",
+    "pages": "169-174",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/98_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#PanteliP13"
+  },
+  "conf/ismir/SenturkGS13": {
+    "@key": "conf/ismir/SenturkGS13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Sertan Sent\u00fcrk",
+      "Sankalp Gulati",
+      "Xavier Serra"
+    ],
+    "title": "Score Informed Tonic Identification for Makam Music of Turkey.",
+    "pages": "175-180",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/185_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SenturkGS13"
+  },
+  "conf/ismir/BountouridisVB13": {
+    "@key": "conf/ismir/BountouridisVB13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Dimitrios Bountouridis",
+      "Remco C. Veltkamp",
+      "Jan Van Balen"
+    ],
+    "title": "Placing Music Artists and Songs in Time Using Editorial Metadata and Web Mining Techniques.",
+    "pages": "183-188",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/37_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BountouridisVB13"
+  },
+  "conf/ismir/HaugerSKT13": {
+    "@key": "conf/ismir/HaugerSKT13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "David Hauger",
+      "Markus Schedl",
+      "Andrej Kosir",
+      "Marko Tkalcic"
+    ],
+    "title": "The Million Musical Tweet Dataset - What We Can Learn From Microblogs.",
+    "pages": "189-194",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/85_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#HaugerSKT13"
+  },
+  "conf/ismir/ArjannikovSZ13": {
+    "@key": "conf/ismir/ArjannikovSZ13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Tom Arjannikov",
+      "Chris Sanden",
+      "John Z. Zhang"
+    ],
+    "title": "Verifying Music Tag Annotation Via Association Analysis.",
+    "pages": "195-200",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/198_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#ArjannikovSZ13"
+  },
+  "conf/ismir/SaariEFBLS13": {
+    "@key": "conf/ismir/SaariEFBLS13",
+    "@mdate": "2013-12-06",
+    "author": [
+      "Pasi Saari",
+      "Tuomas Eerola",
+      "Gy\u00f6rgy Fazekas",
+      "Mathieu Barthet",
+      "Olivier Lartillot",
+      "Mark B. Sandler"
+    ],
+    "title": "The Role of Audio and Tags in Music Mood Prediction: A Study Using Semantic Layer Projection.",
+    "pages": "201-206",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/225_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SaariEFBLS13"
+  },
+  "conf/ismir/GrohganzCJM13": {
+    "@key": "conf/ismir/GrohganzCJM13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Harald Grohganz",
+      "Michael Clausen",
+      "Nanzhu Jiang",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Converting Path Structures Into Block Structures Using Eigenvalue Decompositions of Self-Similarity Matrices.",
+    "pages": "209-214",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/23_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#GrohganzCJM13"
+  },
+  "conf/ismir/WilmeringFS13": {
+    "@key": "conf/ismir/WilmeringFS13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Thomas Wilmering",
+      "Gy\u00f6rgy Fazekas",
+      "Mark B. Sandler"
+    ],
+    "title": "The Audio Effects Ontology.",
+    "pages": "215-220",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/41_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#WilmeringFS13"
+  },
+  "conf/ismir/LinCY13": {
+    "@key": "conf/ismir/LinCY13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Yi Lin",
+      "Xiaoou Chen",
+      "Deshun Yang"
+    ],
+    "title": "Exploration of Music Emotion Recognition Based on MIDI.",
+    "pages": "221-226",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/45_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#LinCY13"
+  },
+  "conf/ismir/KrebsBW13": {
+    "@key": "conf/ismir/KrebsBW13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Florian Krebs",
+      "Sebastian B\u00f6ck",
+      "Gerhard Widmer"
+    ],
+    "title": "Rhythmic Pattern Modeling for Beat and Downbeat Tracking in Musical Audio.",
+    "pages": "227-232",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/51_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#KrebsBW13"
+  },
+  "conf/ismir/KhadkevichO13": {
+    "@key": "conf/ismir/KhadkevichO13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Maksim Khadkevich",
+      "Maurizio Omologo"
+    ],
+    "title": "Large-Scale Cover Song Identification Using Chord Profiles.",
+    "pages": "233-238",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/67_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#KhadkevichO13"
+  },
+  "conf/ismir/MiryalaBBC13": {
+    "@key": "conf/ismir/MiryalaBBC13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Sai Sumanth Miryala",
+      "Kalika Bali",
+      "Ranjita Bhagwan",
+      "Monojit Choudhury"
+    ],
+    "title": "Automatically Identifying Vocal Expressions for Music Transcription.",
+    "pages": "239-244",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/97_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#MiryalaBBC13"
+  },
+  "conf/ismir/BurgoyneBBH13": {
+    "@key": "conf/ismir/BurgoyneBBH13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "John Ashley Burgoyne",
+      "Dimitrios Bountouridis",
+      "Jan Van Balen",
+      "Henkjan Honing"
+    ],
+    "title": "Hooked: A Game For Discovering What Makes Music Catchy.",
+    "pages": "245-250",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/101_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BurgoyneBBH13"
+  },
+  "conf/ismir/RanjaniS13": {
+    "@key": "conf/ismir/RanjaniS13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "H. G. Ranjani",
+      "T. V. Sreenivas"
+    ],
+    "title": "Hierarchical Classification of Carnatic Music Forms.",
+    "pages": "251-256",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/104_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#RanjaniS13"
+  },
+  "conf/ismir/KaiserP13": {
+    "@key": "conf/ismir/KaiserP13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Florian Kaiser",
+      "Geoffroy Peeters"
+    ],
+    "title": "A Simple Fusion Method of State And Sequence Segmentation for Music Structure Discovery.",
+    "pages": "257-262",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/106_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#KaiserP13"
+  },
+  "conf/ismir/BonninJ13": {
+    "@key": "conf/ismir/BonninJ13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Geoffray Bonnin",
+      "Dietmar Jannach"
+    ],
+    "title": "Evaluating The Quality of Generated Playlists Based on Hand-Crafted Samples.",
+    "pages": "263-268",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/114_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BonninJ13"
+  },
+  "conf/ismir/BenetosW13": {
+    "@key": "conf/ismir/BenetosW13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Emmanouil Benetos",
+      "Tillman Weyde"
+    ],
+    "title": "Explicit Duration Hidden Markov Models for Multiple-Instrument Polyphonic Music Transcription.",
+    "pages": "269-274",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/117_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BenetosW13"
+  },
+  "conf/ismir/PachetSM13": {
+    "@key": "conf/ismir/PachetSM13",
+    "@mdate": "2014-05-30",
+    "author": [
+      "Fran\u00e7ois Pachet",
+      "Jeff Suzda",
+      "Dani Mart\u00ednez"
+    ],
+    "title": "A Comprehensive Online Database of Machine-Readable Lead-Sheets for Jazz Standards.",
+    "pages": "275-280",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/149_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#PachetSM13"
+  },
+  "conf/ismir/GrantET13": {
+    "@key": "conf/ismir/GrantET13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Maurice Grant",
+      "Adeesha Ekanayake",
+      "Douglas Turnbull"
+    ],
+    "title": "MeUse: Recommending Internet Radio Stations.",
+    "pages": "281-286",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/150_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#GrantET13"
+  },
+  "conf/ismir/DupontR13": {
+    "@key": "conf/ismir/DupontR13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "St\u00e9phane Dupont",
+      "Thierry Ravet"
+    ],
+    "title": "Improved Audio Classification Using a Novel Non-Linear Dimensionality Reduction Ensemble Approach.",
+    "pages": "287-292",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/154_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#DupontR13"
+  },
+  "conf/ismir/VeraCH13": {
+    "@key": "conf/ismir/VeraCH13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Bogdan Vera",
+      "Elaine Chew",
+      "Patrick G. T. Healey"
+    ],
+    "title": "A Study of Ensemble Synchronisation Under Restricted Line of Sight.",
+    "pages": "293-298",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/171_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#VeraCH13"
+  },
+  "conf/ismir/SarroffC13": {
+    "@key": "conf/ismir/SarroffC13",
+    "@mdate": "2015-12-01",
+    "author": [
+      "Andy M. Sarroff",
+      "Michael A. Casey"
+    ],
+    "title": "Groove Kernels as Rhythmic-Acoustic Motif Descriptors.",
+    "pages": "299-304",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/181_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SarroffC13"
+  },
+  "conf/ismir/ScottK13": {
+    "@key": "conf/ismir/ScottK13",
+    "@mdate": "2014-11-03",
+    "author": [
+      "Jeffrey J. Scott",
+      "Youngmoo E. Kim"
+    ],
+    "title": "Instrument Identification Informed Multi-Track Mixing.",
+    "pages": "305-310",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/200_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#ScottK13"
+  },
+  "conf/ismir/Gartner13": {
+    "@key": "conf/ismir/Gartner13",
+    "@mdate": "2013-12-05",
+    "author": "Daniel G\u00e4rtner",
+    "title": "Tempo Detection of Urban Music Using Tatum Grid Non Negative Matrix Factorization.",
+    "pages": "311-316",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/218_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#Gartner13"
+  },
+  "conf/ismir/KostaSFS13": {
+    "@key": "conf/ismir/KostaSFS13",
+    "@mdate": "2013-12-06",
+    "author": [
+      "Katerina Kosta",
+      "Yading Song",
+      "Gy\u00f6rgy Fazekas",
+      "Mark B. Sandler"
+    ],
+    "title": "A Study of Cultural Dependence of Perceived Mood in Greek Music.",
+    "pages": "317-322",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/222_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#KostaSFS13"
+  },
+  "conf/ismir/HuLO13": {
+    "@key": "conf/ismir/HuLO13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Yajie Hu",
+      "Dingding Li",
+      "Mitsunori Ogihara"
+    ],
+    "title": "Evaluation on Feature Importance for Favorite Song Detection.",
+    "pages": "323-328",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/231_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#HuLO13"
+  },
+  "conf/ismir/KaneshiroKHOBS13": {
+    "@key": "conf/ismir/KaneshiroKHOBS13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Blair Kaneshiro",
+      "Hyung-Suk Kim",
+      "Jorge Herrera",
+      "Jieun Oh",
+      "Jonathan Berger",
+      "Malcolm Slaney"
+    ],
+    "title": "QBT-Extended: An Annotated Dataset of Melodically Contoured Tapped Queries.",
+    "pages": "329-334",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/238_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#KaneshiroKHOBS13"
+  },
+  "conf/ismir/Boulanger-LewandowskiBV13": {
+    "@key": "conf/ismir/Boulanger-LewandowskiBV13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Nicolas Boulanger-Lewandowski",
+      "Yoshua Bengio",
+      "Pascal Vincent"
+    ],
+    "title": "Audio Chord Recognition with Recurrent Neural Networks.",
+    "pages": "335-340",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/243_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#Boulanger-LewandowskiBV13"
+  },
+  "conf/ismir/MoreiraRP13": {
+    "@key": "conf/ismir/MoreiraRP13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Julian Moreira",
+      "Pierre Roy",
+      "Fran\u00e7ois Pachet"
+    ],
+    "title": "Virtualband: Interacting with Stylistically Consistent Agents.",
+    "pages": "341-346",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/277_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#MoreiraRP13"
+  },
+  "conf/ismir/SuY13": {
+    "@key": "conf/ismir/SuY13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Li Su",
+      "Yi-Hsuan Yang"
+    ],
+    "title": "Sparse Modeling for Artist Identification: Exploiting Phase Information and Vocal Separation.",
+    "pages": "349-354",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/54_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SuY13"
+  },
+  "conf/ismir/BenetosH13": {
+    "@key": "conf/ismir/BenetosH13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Emmanouil Benetos",
+      "Andre Holzapfel"
+    ],
+    "title": "Automatic Transcription of Turkish Makam Music.",
+    "pages": "355-360",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/119_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BenetosH13"
+  },
+  "conf/ismir/BockW13": {
+    "@key": "conf/ismir/BockW13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Sebastian B\u00f6ck",
+      "Gerhard Widmer"
+    ],
+    "title": "Local Group Delay Based Vibrato and Tremolo Suppression for Onset Detection.",
+    "pages": "361-366",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/175_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BockW13"
+  },
+  "conf/ismir/YoshiiTMG13": {
+    "@key": "conf/ismir/YoshiiTMG13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Kazuyoshi Yoshii",
+      "Ryota Tomioka",
+      "Daichi Mochihashi",
+      "Masataka Goto"
+    ],
+    "title": "Beyond NMF: Time-Domain Audio Source Separation without Phase Reconstruction.",
+    "pages": "369-374",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/32_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#YoshiiTMG13"
+  },
+  "conf/ismir/LiangHE13": {
+    "@key": "conf/ismir/LiangHE13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Dawen Liang",
+      "Matthew D. Hoffman",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "Beta Process Sparse Nonnegative Matrix Factorization for Music.",
+    "pages": "375-380",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/229_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#LiangHE13"
+  },
+  "conf/ismir/AroraB13": {
+    "@key": "conf/ismir/AroraB13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Vipul Arora",
+      "Laxmidhar Behera"
+    ],
+    "title": "Semi-Supervised Polyphonic Source Identification using PLCA Based Graph Clustering.",
+    "pages": "381-386",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/265_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#AroraB13"
+  },
+  "conf/ismir/SchoefflerSBEH13": {
+    "@key": "conf/ismir/SchoefflerSBEH13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Michael Schoeffler",
+      "Fabian-Robert St\u00f6ter",
+      "Harald Bayerlein",
+      "Bernd Edler",
+      "J\u00fcrgen Herre"
+    ],
+    "title": "An Experiment about Estimating the Number of Instruments in Polyphonic Music: A Comparison Between Internet and Laboratory Results.",
+    "pages": "389-394",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/59_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SchoefflerSBEH13"
+  },
+  "conf/ismir/CartwrightP13": {
+    "@key": "conf/ismir/CartwrightP13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Mark Brozier Cartwright",
+      "Bryan Pardo"
+    ],
+    "title": "Social-EQ: Crowdsourcing an Equalization Descriptor Map.",
+    "pages": "395-400",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/173_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#CartwrightP13"
+  },
+  "conf/ismir/MooreCTJ13": {
+    "@key": "conf/ismir/MooreCTJ13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Joshua L. Moore",
+      "Shuo Chen",
+      "Douglas Turnbull",
+      "Thorsten Joachims"
+    ],
+    "title": "Taste Over Time: The Temporal Dynamics of User Preferences.",
+    "pages": "401-406",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/220_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#MooreCTJ13"
+  },
+  "conf/ismir/RamosAM13": {
+    "@key": "conf/ismir/RamosAM13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Andryw Marques Ramos",
+      "Nazareno Andrade",
+      "Leandro Balby Marinho"
+    ],
+    "title": "Exploring the Relation Between Novelty Aspects and Preferences in Music Listening.",
+    "pages": "407-412",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/257_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#RamosAM13"
+  },
+  "conf/ismir/WuWLH13": {
+    "@key": "conf/ismir/WuWLH13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Bin Wu",
+      "Simon Wun",
+      "Chung Lee",
+      "Andrew Horner"
+    ],
+    "title": "Spectral Correlates in Emotion Labeling of Sustained Musical Instrument Tones.",
+    "pages": "415-420",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/7_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#WuWLH13"
+  },
+  "conf/ismir/BarthetMBFS13": {
+    "@key": "conf/ismir/BarthetMBFS13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Mathieu Barthet",
+      "David Marston",
+      "Chris Baume",
+      "Gy\u00f6rgy Fazekas",
+      "Mark B. Sandler"
+    ],
+    "title": "Design and Evaluation of Semantic Mood Models for Music Recommendation using Editorial Tags.",
+    "pages": "421-426",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/14_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BarthetMBFS13"
+  },
+  "conf/ismir/Yang13": {
+    "@key": "conf/ismir/Yang13",
+    "@mdate": "2013-12-05",
+    "author": "Yi-Hsuan Yang",
+    "title": "Low-Rank Representation of Both Singing Voice and Music Accompaniment Via Learned Dictionaries.",
+    "pages": "427-432",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/17_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#Yang13"
+  },
+  "conf/ismir/StoberLGN13": {
+    "@key": "conf/ismir/StoberLGN13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Sebastian Stober",
+      "Thomas Low",
+      "Tatiana Gossen",
+      "Andreas N\u00fcrnberger"
+    ],
+    "title": "Incremental Visualization of Growing Music Collections.",
+    "pages": "433-438",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/40_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#StoberLGN13"
+  },
+  "conf/ismir/PuginC13": {
+    "@key": "conf/ismir/PuginC13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Laurent Pugin",
+      "Tim Crawford"
+    ],
+    "title": "Evaluating OMR on the Early Music Online Collection.",
+    "pages": "439-444",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/65_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#PuginC13"
+  },
+  "conf/ismir/GaoDC13": {
+    "@key": "conf/ismir/GaoDC13",
+    "@mdate": "2017-10-19",
+    "author": [
+      "Boyang Gao",
+      "Emmanuel Dellandr\u00e9a",
+      "Liming Chen 0002"
+    ],
+    "title": "Sparse Music Decomposition onto a MIDI Dictionary Driven by Statistical Music Knowledge.",
+    "pages": "445-450",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/71_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#GaoDC13"
+  },
+  "conf/ismir/SebastienSC13": {
+    "@key": "conf/ismir/SebastienSC13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "V\u00e9ronique S\u00e9bastien",
+      "Didier S\u00e9bastien",
+      "No\u00ebl Conruyt"
+    ],
+    "title": "Annotating Works for Music Education: Propositions for a Musical Forms and Structures Ontology and a Musical Performance Ontology.",
+    "pages": "451-456",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/83_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SebastienSC13"
+  },
+  "conf/ismir/FukayamaYG13": {
+    "@key": "conf/ismir/FukayamaYG13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Satoru Fukayama",
+      "Kazuyoshi Yoshii",
+      "Masataka Goto"
+    ],
+    "title": "Chord-Sequence-Factory: A Chord Arrangement System Modifying Factorized Chord Sequence Probabilities.",
+    "pages": "457-462",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/84_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#FukayamaYG13"
+  },
+  "conf/ismir/LiuLW13": {
+    "@key": "conf/ismir/LiuLW13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "I-Ting Liu",
+      "Yin-Tzu Lin",
+      "Ja-Ling Wu"
+    ],
+    "title": "Music Cut and Paste: A Personalized Musical Medley Generating System.",
+    "pages": "463-468",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/92_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#LiuLW13"
+  },
+  "conf/ismir/SmithC13": {
+    "@key": "conf/ismir/SmithC13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Jordan B. L. Smith",
+      "Elaine Chew"
+    ],
+    "title": "A Meta-Analysis of the MIREX Structural Segmentation Task.",
+    "pages": "469-474",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/144_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SmithC13"
+  },
+  "conf/ismir/ChengDM13": {
+    "@key": "conf/ismir/ChengDM13",
+    "@mdate": "2014-11-10",
+    "author": [
+      "Tian Cheng 0001",
+      "Simon Dixon",
+      "Matthias Mauch"
+    ],
+    "title": "A Deterministic Annealing EM Algorithm for Automatic Music Transcription.",
+    "pages": "475-480",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/155_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#ChengDM13"
+  },
+  "conf/ismir/ElowssonFMP13": {
+    "@key": "conf/ismir/ElowssonFMP13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Anders Elowsson",
+      "Anders Friberg",
+      "Guy Madison",
+      "Johan Paulin"
+    ],
+    "title": "Modelling the Speed of Music using Features from Harmonic/Percussive Separated Audio.",
+    "pages": "481-486",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/165_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#ElowssonFMP13"
+  },
+  "conf/ismir/SaralaM13": {
+    "@key": "conf/ismir/SaralaM13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Padi Sarala",
+      "Hema A. Murthy"
+    ],
+    "title": "Inter and Intra Item Segmentation of Continuous Audio Recordings of Carnatic Music for Archival.",
+    "pages": "487-492",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/167_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#SaralaM13"
+  },
+  "conf/ismir/BogdanovWGGHMRSZS13": {
+    "@key": "conf/ismir/BogdanovWGGHMRSZS13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Dmitry Bogdanov",
+      "Nicolas Wack",
+      "Emilia G\u00f3mez",
+      "Sankalp Gulati",
+      "Perfecto Herrera",
+      "Oscar Mayor",
+      "Gerard Roma",
+      "Justin Salamon",
+      "Jos\u00e9 R. Zapata",
+      "Xavier Serra"
+    ],
+    "title": "Essentia: An Audio Analysis Library for Music Information Retrieval.",
+    "pages": "493-498",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/177_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BogdanovWGGHMRSZS13"
+  },
+  "conf/ismir/IshwarDBM13": {
+    "@key": "conf/ismir/IshwarDBM13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Vignesh Ishwar",
+      "Shrey Dutta",
+      "Ashwin Bellur",
+      "Hema A. Murthy"
+    ],
+    "title": "Motif Spotting in an Alapana in Carnatic Music.",
+    "pages": "499-504",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/205_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#IshwarDBM13"
+  },
+  "conf/ismir/KellT13": {
+    "@key": "conf/ismir/KellT13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Thor Kell",
+      "George Tzanetakis"
+    ],
+    "title": "Empirical Analysis of Track Selection and Ordering in Electronic Dance Music using Audio Feature Extraction.",
+    "pages": "505-510",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/210_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#KellT13"
+  },
+  "conf/ismir/Koerich13": {
+    "@key": "conf/ismir/Koerich13",
+    "@mdate": "2013-12-05",
+    "author": "Alessandro L. Koerich",
+    "title": "Improving the Reliability of Music Genre Classification using Rejection and Verification.",
+    "pages": "511-516",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/214_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#Koerich13"
+  },
+  "conf/ismir/BurletF13": {
+    "@key": "conf/ismir/BurletF13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Gregory Burlet",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Robotaba Guitar Tablature Transcription Framework.",
+    "pages": "517-522",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/217_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#BurletF13"
+  },
+  "conf/ismir/Polfreman13": {
+    "@key": "conf/ismir/Polfreman13",
+    "@mdate": "2013-12-05",
+    "author": "Richard Polfreman",
+    "title": "Comparing Onset Detection &amp; Perceptual Attack Time.",
+    "pages": "523-528",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/224_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#Polfreman13"
+  },
+  "conf/ismir/LeeCHD13": {
+    "@key": "conf/ismir/LeeCHD13",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Jin Ha Lee",
+      "Kahyun Choi",
+      "Xiao Hu 0001",
+      "J. Stephen Downie"
+    ],
+    "title": "K-Pop Genres: A Cross-Cultural Exploration.",
+    "pages": "529-534",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/233_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#LeeCHD13"
+  },
+  "conf/ismir/ScheerenPKL13": {
+    "@key": "conf/ismir/ScheerenPKL13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Felipe Mendon\u00e7a Scheeren",
+      "Marcelo Soares Pimenta",
+      "Dami\u00e1n Keller",
+      "Victor Lazzarini"
+    ],
+    "title": "Coupling Social Network Services and Support for Online Communities in Codes Environment.",
+    "pages": "535-540",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/234_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#ScheerenPKL13"
+  },
+  "conf/ismir/CaiEDLW13": {
+    "@key": "conf/ismir/CaiEDLW13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Zhouhong Cai",
+      "Robert J. Ellis",
+      "Zhiyan Duan",
+      "Hong Lu",
+      "Ye Wang"
+    ],
+    "title": "Basic Evaluation of Auditory Temporal Stability (Beats): A Novel Rationale and Implementation.",
+    "pages": "541-546",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/249_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#CaiEDLW13"
+  },
+  "conf/ismir/CollinsAFW13": {
+    "@key": "conf/ismir/CollinsAFW13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Tom Collins",
+      "Andreas Arzt",
+      "Sebastian Flossmann",
+      "Gerhard Widmer"
+    ],
+    "title": "SIARCT-CFP: Improving Precision and the Discovery of Inexact Musical Patterns in Point-Set Representations.",
+    "pages": "549-554",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/161_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#CollinsAFW13"
+  },
+  "conf/ismir/ValkWB13": {
+    "@key": "conf/ismir/ValkWB13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Reinier de Valk",
+      "Tillman Weyde",
+      "Emmanouil Benetos"
+    ],
+    "title": "A Machine Learning Approach to Voice Separation in Lute Tablature.",
+    "pages": "555-560",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/221_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#ValkWB13"
+  },
+  "conf/ismir/ThomasPEM13": {
+    "@key": "conf/ismir/ThomasPEM13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Nicolas Gonzalez Thomas",
+      "Philippe Pasquier",
+      "Arne Eigenfeldt",
+      "James B. Maxwell"
+    ],
+    "title": "A Methodology for the Comparison of Melodic Generation Models Using Meta-Melo.",
+    "pages": "561-566",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/228_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#ThomasPEM13"
+  },
+  "conf/ismir/FenetGR13": {
+    "@key": "conf/ismir/FenetGR13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "S\u00e9bastien Fenet",
+      "Yves Grenier",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "An Extended Audio Fingerprint Method with Capabilities for Similar Music Detection.",
+    "pages": "569-574",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/46_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#FenetGR13"
+  },
+  "conf/ismir/DaviesHYG13": {
+    "@key": "conf/ismir/DaviesHYG13",
+    "@mdate": "2013-12-06",
+    "author": [
+      "Matthew E. P. Davies",
+      "Philippe Hamel",
+      "Kazuyoshi Yoshii",
+      "Masataka Goto"
+    ],
+    "title": "AutoMashUpper: An Automatic Multi-Song Mashup System.",
+    "pages": "575-580",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/77_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#DaviesHYG13"
+  },
+  "conf/ismir/Schluter13": {
+    "@key": "conf/ismir/Schluter13",
+    "@mdate": "2013-12-05",
+    "author": "Jan Schl\u00fcter",
+    "title": "Learning Binary Codes For Efficient Large-Scale Music Similarity Search.",
+    "pages": "581-586",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/189_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#Schluter13"
+  },
+  "conf/ismir/PratzlichM13": {
+    "@key": "conf/ismir/PratzlichM13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Thomas Pr\u00e4tzlich",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Freisch\u00fctz Digital: A Case Study for Reference-Based Audio Segmentation for Operas.",
+    "pages": "589-594",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/82_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#PratzlichM13"
+  },
+  "conf/ismir/JiangM13": {
+    "@key": "conf/ismir/JiangM13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Nanzhu Jiang",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Automated Methods for Analyzing Music Recordings in Sonata Form.",
+    "pages": "595-600",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/90_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#JiangM13"
+  },
+  "conf/ismir/PauwelsKP13": {
+    "@key": "conf/ismir/PauwelsKP13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Johan Pauwels",
+      "Florian Kaiser",
+      "Geoffroy Peeters"
+    ],
+    "title": "Combining Harmony-Based and Novelty-Based Approaches for Structural Segmentation.",
+    "pages": "601-606",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/138_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#PauwelsKP13"
+  },
+  "conf/ismir/GrachtenGAW13": {
+    "@key": "conf/ismir/GrachtenGAW13",
+    "@mdate": "2013-12-05",
+    "author": [
+      "Maarten Grachten",
+      "Martin Gasser",
+      "Andreas Arzt",
+      "Gerhard Widmer"
+    ],
+    "title": "Automatic Alignment of Music Performances with Structural Differences.",
+    "pages": "607-612",
+    "year": "2013",
+    "booktitle": "ISMIR",
+    "ee": "http://www.ppgia.pucpr.br/ismir2013/wp-content/uploads/2013/09/158_Paper.pdf",
+    "crossref": "conf/ismir/2013",
+    "url": "db/conf/ismir/ismir2013.html#GrachtenGAW13"
+  },
+  "conf/ismir/SinghiB14": {
+    "@key": "conf/ismir/SinghiB14",
+    "@mdate": "2015-02-12",
+    "author": [
+      "Abhishek Singhi",
+      "Daniel G. Brown 0001"
+    ],
+    "title": "On Cultural, Textual and Experiential Aspects of Music Mood.",
+    "pages": "3-8",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T002_113_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SinghiB14"
+  },
+  "conf/ismir/SuYY14": {
+    "@key": "conf/ismir/SuYY14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Li Su",
+      "Li-Fan Yu",
+      "Yi-Hsuan Yang"
+    ],
+    "title": "Sparse Cepstral, Phase Codes for Guitar Playing Technique Classification.",
+    "pages": "9-14",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T003_213_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SuYY14"
+  },
+  "conf/ismir/KokuerJAA14": {
+    "@key": "conf/ismir/KokuerJAA14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "M\u00fcnevver K\u00f6k\u00fcer",
+      "Peter Jancovic",
+      "Islah Ali-MacLachlan",
+      "Cham Athwal"
+    ],
+    "title": "Automated Detection of Single- and Multi-Note Ornaments in Irish Traditional Flute Playing.",
+    "pages": "15-20",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T004_203_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#KokuerJAA14"
+  },
+  "conf/ismir/SturmC14": {
+    "@key": "conf/ismir/SturmC14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Bob L. Sturm",
+      "Nick Collins"
+    ],
+    "title": "The Kiki-Bouba Challenge: Algorithmic Composition for Content-based MIR Research and Development.",
+    "pages": "21-26",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T005_176_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SturmC14"
+  },
+  "conf/ismir/OordDS14": {
+    "@key": "conf/ismir/OordDS14",
+    "@mdate": "2016-07-12",
+    "author": [
+      "A\u00e4ron van den Oord",
+      "Sander Dieleman",
+      "Benjamin Schrauwen"
+    ],
+    "title": "Transfer Learning by Supervised Pre-training for Audio-based Music Classification.",
+    "pages": "29-34",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T007_118_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#OordDS14"
+  },
+  "conf/ismir/GrohganzCM14": {
+    "@key": "conf/ismir/GrohganzCM14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Harald Grohganz",
+      "Michael Clausen",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Estimating Musical Time Information from Performed MIDI Files.",
+    "pages": "35-40",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T008_121_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#GrohganzCM14"
+  },
+  "conf/ismir/BarbanchoTTDB14": {
+    "@key": "conf/ismir/BarbanchoTTDB14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Isabel Barbancho",
+      "George Tzanetakis",
+      "Lorenzo J. Tard\u00f3n",
+      "Peter F. Driessen",
+      "Ana M. Barbancho"
+    ],
+    "title": "Estimation of the Direction of Strokes and Arpeggios.",
+    "pages": "41-46",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T009_130_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#BarbanchoTTDB14"
+  },
+  "conf/ismir/HerwaardenGH14": {
+    "@key": "conf/ismir/HerwaardenGH14",
+    "@mdate": "2015-11-04",
+    "author": [
+      "Sam van Herwaarden",
+      "Maarten Grachten",
+      "W. Bas de Haas"
+    ],
+    "title": "Predicting Expressive Dynamics in Piano Performances using Neural Networks.",
+    "pages": "47-52",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T010_132_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#HerwaardenGH14"
+  },
+  "conf/ismir/SigtiaBCWGD14": {
+    "@key": "conf/ismir/SigtiaBCWGD14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Siddharth Sigtia",
+      "Emmanouil Benetos",
+      "Srikanth Cherla",
+      "Tillman Weyde",
+      "Artur S. d'Avila Garcez",
+      "Simon Dixon"
+    ],
+    "title": "An RNN-based Music Language Model for Improving Automatic Music Transcription.",
+    "pages": "53-58",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T011_142_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SigtiaBCWGD14"
+  },
+  "conf/ismir/GiraudLMRT14": {
+    "@key": "conf/ismir/GiraudLMRT14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Mathieu Giraud",
+      "Florence Lev\u00e9",
+      "Florent Mercier",
+      "Marc Rigaudi\u00e8re",
+      "Donatien Thorez"
+    ],
+    "title": "Towards Modeling Texture in Symbolic Data.",
+    "pages": "59-64",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T012_143_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#GiraudLMRT14"
+  },
+  "conf/ismir/KroherGGGB14": {
+    "@key": "conf/ismir/KroherGGGB14",
+    "@mdate": "2018-03-29",
+    "author": [
+      "Nadine Kroher",
+      "Emilia G\u00f3mez",
+      "Catherine Guastavino",
+      "Francisco G\u00f3mez 0001",
+      "Jordi Bonada"
+    ],
+    "title": "Computational Models for Perceived Melodic Similarity in A Cappella Flamenco Singing.",
+    "pages": "65-70",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T013_148_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#KroherGGGB14"
+  },
+  "conf/ismir/AntilaC14": {
+    "@key": "conf/ismir/AntilaC14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Christopher Antila",
+      "Julie Cumming"
+    ],
+    "title": "The VIS Framework: Analyzing Counterpoint in Large Datasets.",
+    "pages": "71-76",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T014_162_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#AntilaC14"
+  },
+  "conf/ismir/HanL14": {
+    "@key": "conf/ismir/HanL14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Yoonchang Han",
+      "Kyogu Lee"
+    ],
+    "title": "Hierarchical Approach to Detect Common Mistakes of Beginner Flute Players.",
+    "pages": "77-82",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T015_165_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#HanL14"
+  },
+  "conf/ismir/WangED14": {
+    "@key": "conf/ismir/WangED14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Siying Wang",
+      "Sebastian Ewert",
+      "Simon Dixon"
+    ],
+    "title": "Robust Joint Alignment of Multiple Versions of a Piece of Music.",
+    "pages": "83-88",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T016_174_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#WangED14"
+  },
+  "conf/ismir/SturmBLE14": {
+    "@key": "conf/ismir/SturmBLE14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Bob L. Sturm",
+      "Rolf Bardeli",
+      "Thibault Langlois",
+      "Valentin Emiya"
+    ],
+    "title": "Formalizing the Problem of Music Description.",
+    "pages": "89-94",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T017_180_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SturmBLE14"
+  },
+  "conf/ismir/ArjannikovZ14": {
+    "@key": "conf/ismir/ArjannikovZ14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Tom Arjannikov",
+      "John Z. Zhang"
+    ],
+    "title": "An Association-based Approach to Genre Classification in Music.",
+    "pages": "95-100",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T018_186_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#ArjannikovZ14"
+  },
+  "conf/ismir/CherlaWG14": {
+    "@key": "conf/ismir/CherlaWG14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Srikanth Cherla",
+      "Tillman Weyde",
+      "Artur S. d'Avila Garcez"
+    ],
+    "title": "Multiple Viewpiont Melodic Prediction with Fixed-Context Neural Networks.",
+    "pages": "101-106",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T019_187_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#CherlaWG14"
+  },
+  "conf/ismir/PuginZR14": {
+    "@key": "conf/ismir/PuginZR14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Laurent Pugin",
+      "Rodolfo Zitellini",
+      "Perry Roland"
+    ],
+    "title": "Verovio: A library for Engraving MEI Music Notation into SVG.",
+    "pages": "107-112",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T020_221_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#PuginZR14"
+  },
+  "conf/ismir/SilvaRRB14": {
+    "@key": "conf/ismir/SilvaRRB14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Diego Furtado Silva",
+      "Rafael Geraldeli Rossi",
+      "Solange Oliveira Rezende",
+      "Gustavo Enrique De Almeida Prado Alves Batista"
+    ],
+    "title": "Music Classification by Transductive Learning Using Bipartite Heterogeneous Networks.",
+    "pages": "113-118",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T021_263_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SilvaRRB14"
+  },
+  "conf/ismir/Laaksonen14": {
+    "@key": "conf/ismir/Laaksonen14",
+    "@mdate": "2014-12-19",
+    "author": "Antti Laaksonen",
+    "title": "Automatic Melody Transcription based on Chord Transcription.",
+    "pages": "119-124",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T022_277_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#Laaksonen14"
+  },
+  "conf/ismir/MironCJ14": {
+    "@key": "conf/ismir/MironCJ14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Marius Miron",
+      "Julio Jos\u00e9 Carabias-Orti",
+      "Jordi Janer"
+    ],
+    "title": "Audio-to-score Alignment at the Note Level for Orchestral Recordings.",
+    "pages": "125-130",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T023_281_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#MironCJ14"
+  },
+  "conf/ismir/PesekLM14": {
+    "@key": "conf/ismir/PesekLM14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Matevz Pesek",
+      "Ales Leonardis",
+      "Matija Marolt"
+    ],
+    "title": "A Compositional Hierarchical Model for Music Information Retrieval.",
+    "pages": "131-136",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T024_286_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#PesekLM14"
+  },
+  "conf/ismir/ManLKR14": {
+    "@key": "conf/ismir/ManLKR14",
+    "@mdate": "2017-07-26",
+    "author": [
+      "Brecht De Man",
+      "Brett Leonard",
+      "Richard L. King",
+      "Joshua D. Reiss"
+    ],
+    "title": "An Analysis and Evaluation of Audio Features for Multitrack Music Mixtures.",
+    "pages": "137-142",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T025_293_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#ManLKR14"
+  },
+  "conf/ismir/YadatiLLH14": {
+    "@key": "conf/ismir/YadatiLLH14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Karthik Yadati",
+      "Martha Larson",
+      "Cynthia C. S. Liem",
+      "Alan Hanjalic"
+    ],
+    "title": "Detecting Drops in Electronic Dance Music: Content based approaches to a socially significant music event.",
+    "pages": "143-148",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T026_297_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#YadatiLLH14"
+  },
+  "conf/ismir/Glazyrin14": {
+    "@key": "conf/ismir/Glazyrin14",
+    "@mdate": "2014-12-19",
+    "author": "Nikolay Glazyrin",
+    "title": "Towards Automatic Content-Based Separation of DJ Mixes into Single Tracks.",
+    "pages": "149-154",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T027_311_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#Glazyrin14"
+  },
+  "conf/ismir/BittnerSTMCB14": {
+    "@key": "conf/ismir/BittnerSTMCB14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Rachel M. Bittner",
+      "Justin Salamon",
+      "Mike Tierney",
+      "Matthias Mauch",
+      "Chris Cannam",
+      "Juan Pablo Bello"
+    ],
+    "title": "MedleyDB: A Multitrack Dataset for Annotation-Intensive MIR Research.",
+    "pages": "155-160",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T028_322_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#BittnerSTMCB14"
+  },
+  "conf/ismir/TangB14": {
+    "@key": "conf/ismir/TangB14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Zheng Tang",
+      "Dawn A. A. Black"
+    ],
+    "title": "Melody Extraction from Polyphonic Audio of Western Opera: A Method based on Detection of the Singer's Formant.",
+    "pages": "161-166",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T029_329_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#TangB14"
+  },
+  "conf/ismir/LiangPE14": {
+    "@key": "conf/ismir/LiangPE14",
+    "@mdate": "2016-12-02",
+    "author": [
+      "Dawen Liang",
+      "John William Paisley",
+      "Dan Ellis"
+    ],
+    "title": "Codebook-based Scalable Music Tagging with Poisson Matrix Factorization.",
+    "pages": "167-172",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T030_363_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#LiangPE14"
+  },
+  "conf/ismir/BenetosBWR14": {
+    "@key": "conf/ismir/BenetosBWR14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Emmanouil Benetos",
+      "Roland Badeau",
+      "Tillman Weyde",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "Template Adaptation for Improving Automatic Music Transcription.",
+    "pages": "175-180",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T032_235_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#BenetosBWR14"
+  },
+  "conf/ismir/DuanT14": {
+    "@key": "conf/ismir/DuanT14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Zhiyao Duan",
+      "David Temperley"
+    ],
+    "title": "Note-level Music Transcription by Maximum Likelihood Sampling.",
+    "pages": "181-186",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T033_333_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#DuanT14"
+  },
+  "conf/ismir/ThompsonDM14": {
+    "@key": "conf/ismir/ThompsonDM14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Lucas Thompson",
+      "Simon Dixon",
+      "Matthias Mauch"
+    ],
+    "title": "Drum Transcription via Classification of Bar-Level Rhythmic Patterns.",
+    "pages": "187-192",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T034_302_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#ThompsonDM14"
+  },
+  "conf/ismir/ChaconLG14": {
+    "@key": "conf/ismir/ChaconLG14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Carlos Eduardo Cancino Chac\u00f3n",
+      "Stefan Lattner",
+      "Maarten Grachten"
+    ],
+    "title": "Developing Tonal Perception through Unsupervised Learning.",
+    "pages": "195-200",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T036_230_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#ChaconLG14"
+  },
+  "conf/ismir/BazzicaLH14": {
+    "@key": "conf/ismir/BazzicaLH14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Alessio Bazzica",
+      "Cynthia C. S. Liem",
+      "Alan Hanjalic"
+    ],
+    "title": "Exploiting Instrument-wise Playing/Non-Playing Labels for Score Synchronization of Symphonic Music.",
+    "pages": "201-206",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T037_182_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#BazzicaLH14"
+  },
+  "conf/ismir/Rodriguez-LopezVB14": {
+    "@key": "conf/ismir/Rodriguez-LopezVB14",
+    "@mdate": "2014-12-20",
+    "author": [
+      "Marcelo Enrique Rodr\u00edguez-L\u00f3pez",
+      "Anja Volk",
+      "Dimitrios Bountouridis"
+    ],
+    "title": "Multi-Strategy Segmentation of Melodies.",
+    "pages": "207-212",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T038_294_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#Rodriguez-LopezVB14"
+  },
+  "conf/ismir/Kirlin14": {
+    "@key": "conf/ismir/Kirlin14",
+    "@mdate": "2014-12-19",
+    "author": "Phillip B. Kirlin",
+    "title": "A Data Set for Computational Studies of Schenkerian Analysis.",
+    "pages": "213-218",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T039_344_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#Kirlin14"
+  },
+  "conf/ismir/MartorellG14": {
+    "@key": "conf/ismir/MartorellG14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Agust\u00edn Martorell",
+      "Emilia G\u00f3mez"
+    ],
+    "title": "Systematic Multi-scale Set-class Analysis.",
+    "pages": "219-224",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T040_305_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#MartorellG14"
+  },
+  "conf/ismir/MasudaYGM14": {
+    "@key": "conf/ismir/MasudaYGM14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Taro Masuda",
+      "Kazuyoshi Yoshii",
+      "Masataka Goto",
+      "Shigeo Morishima"
+    ],
+    "title": "Spotting a Query Phrase from Polyphonic Music Audio Signals Based on Semi-supervised Nonnegative Matrix Factorization.",
+    "pages": "227-232",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T042_131_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#MasudaYGM14"
+  },
+  "conf/ismir/MaezawaIYO14": {
+    "@key": "conf/ismir/MaezawaIYO14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Akira Maezawa",
+      "Katsutoshi Itoyama",
+      "Kazuyoshi Yoshii",
+      "Hiroshi G. Okuno"
+    ],
+    "title": "Bayesian Audio Alignment based on a Unified Model of Music Composition and Performance.",
+    "pages": "233-238",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T043_173_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#MaezawaIYO14"
+  },
+  "conf/ismir/WangYYW14": {
+    "@key": "conf/ismir/WangYYW14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Ju-Chiang Wang",
+      "Ming-Chi Yen",
+      "Yi-Hsuan Yang",
+      "Hsin-Min Wang"
+    ],
+    "title": "Automatic Set List Identification and Song Segmentation for Full-Length Concert Videos.",
+    "pages": "239-244",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T044_211_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#WangYYW14"
+  },
+  "conf/ismir/Flexer14": {
+    "@key": "conf/ismir/Flexer14",
+    "@mdate": "2014-12-19",
+    "author": "Arthur Flexer",
+    "title": "On Inter-rater Agreement in Audio Music Similarity.",
+    "pages": "245-250",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T045_256_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#Flexer14"
+  },
+  "conf/ismir/WuHL14": {
+    "@key": "conf/ismir/WuHL14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Bin Wu",
+      "Andrew Horner",
+      "Chung Lee"
+    ],
+    "title": "Emotional Predisposition of Musical Instrument Timbres with Static Spectra.",
+    "pages": "253-258",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T047_109_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#WuHL14"
+  },
+  "conf/ismir/SixL14": {
+    "@key": "conf/ismir/SixL14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Joren Six",
+      "Marc Leman"
+    ],
+    "title": "Panako - A Scalable Acoustic Fingerprinting System Handling Time-Scale and Pitch Modification.",
+    "pages": "259-264",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T048_122_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SixL14"
+  },
+  "conf/ismir/NietoFJB14": {
+    "@key": "conf/ismir/NietoFJB14",
+    "@mdate": "2016-02-17",
+    "author": [
+      "Oriol Nieto",
+      "Morwaread M. Farbood",
+      "Tristan Jehan",
+      "Juan Pablo Bello"
+    ],
+    "title": "Perceptual Analysis of the F-Measure to Evaluate Section Boundaries in Music.",
+    "pages": "265-270",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T049_124_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#NietoFJB14"
+  },
+  "conf/ismir/Kruspe14": {
+    "@key": "conf/ismir/Kruspe14",
+    "@mdate": "2014-12-19",
+    "author": "Anna M. Kruspe",
+    "title": "Keyword Spotting in A-capella Singing.",
+    "pages": "271-276",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T050_126_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#Kruspe14"
+  },
+  "conf/ismir/MolinaTBB14": {
+    "@key": "conf/ismir/MolinaTBB14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Emilio Molina",
+      "Lorenzo J. Tard\u00f3n",
+      "Isabel Barbancho",
+      "Ana M. Barbancho"
+    ],
+    "title": "The Importance of F0 Tracking in Query-by-singing-humming.",
+    "pages": "277-282",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T051_147_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#MolinaTBB14"
+  },
+  "conf/ismir/VenkataramaniNRV14": {
+    "@key": "conf/ismir/VenkataramaniNRV14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Shrikant Venkataramani",
+      "Nagesh Nayak",
+      "Preeti Rao",
+      "Rajbabu Velmurugan"
+    ],
+    "title": "Vocal Separation using Singer-Vowel Priors Obtained from Polyphonic Audio.",
+    "pages": "283-288",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T052_177_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#VenkataramaniNRV14"
+  },
+  "conf/ismir/ChenJL14": {
+    "@key": "conf/ismir/ChenJL14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Chun-Ta Chen",
+      "Jyh-Shing Roger Jang",
+      "Chun-Hung Lu"
+    ],
+    "title": "Improving Query by Tapping via Tempo Alignment.",
+    "pages": "289-294",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T053_181_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#ChenJL14"
+  },
+  "conf/ismir/FourerRHR14": {
+    "@key": "conf/ismir/FourerRHR14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Dominique Fourer",
+      "Jean-Luc Rouas",
+      "Pierre Hanna",
+      "Matthias Robine"
+    ],
+    "title": "Automatic Instrument Classification of Ethnomusicological Audio Recordings.",
+    "pages": "295-300",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T054_206_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#FourerRHR14"
+  },
+  "conf/ismir/SidorovJM14": {
+    "@key": "conf/ismir/SidorovJM14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Kirill A. Sidorov",
+      "Andrew Jones",
+      "A. David Marshall"
+    ],
+    "title": "Music Analysis as a Smallest Grammar Problem.",
+    "pages": "301-306",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T055_226_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SidorovJM14"
+  },
+  "conf/ismir/PratzlichM14": {
+    "@key": "conf/ismir/PratzlichM14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Thomas Pr\u00e4tzlich",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Frame-Level Audio Segmentation for Abridged Musical Works.",
+    "pages": "307-312",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T056_231_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#PratzlichM14"
+  },
+  "conf/ismir/RepettoS14": {
+    "@key": "conf/ismir/RepettoS14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Rafael Caro Repetto",
+      "Xavier Serra"
+    ],
+    "title": "Creating a Corpus of Jingju (Beijing Opera) Music and Possibilities for Melodic Analysis.",
+    "pages": "313-318",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T057_237_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#RepettoS14"
+  },
+  "conf/ismir/MadsenJL14": {
+    "@key": "conf/ismir/MadsenJL14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Jens Madsen",
+      "Bj\u00f8rn Sand Jensen",
+      "Jan Larsen"
+    ],
+    "title": "Modeling Temporal Structure in Music for Emotion Prediction using Pairwise Comparisons.",
+    "pages": "319-324",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T058_254_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#MadsenJL14"
+  },
+  "conf/ismir/HamanakaHT14": {
+    "@key": "conf/ismir/HamanakaHT14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Masatoshi Hamanaka",
+      "Keiji Hirata",
+      "Satoshi Tojo"
+    ],
+    "title": "Musical Structural Analysis Database Based on GTTM.",
+    "pages": "325-330",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T059_257_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#HamanakaHT14"
+  },
+  "conf/ismir/CaetanoW14": {
+    "@key": "conf/ismir/CaetanoW14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Marcelo F. Caetano",
+      "Frans Wiering"
+    ],
+    "title": "Theoretical Framework of A Computational Model of Auditory Memory for Music Emotion Recognition.",
+    "pages": "331-336",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T060_258_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#CaetanoW14"
+  },
+  "conf/ismir/PeetersB14": {
+    "@key": "conf/ismir/PeetersB14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Geoffroy Peeters",
+      "Victor Bisot"
+    ],
+    "title": "Improving Music Structure Segmentation using lag-priors.",
+    "pages": "337-342",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T061_288_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#PeetersB14"
+  },
+  "conf/ismir/ZhangRS14": {
+    "@key": "conf/ismir/ZhangRS14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Shuo Zhang",
+      "Rafael Caro Repetto",
+      "Xavier Serra"
+    ],
+    "title": "Study of the Similarity between Linguistic Tones and Melodic Pitch Contours in Beijing Opera Singing.",
+    "pages": "343-348",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T062_292_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#ZhangRS14"
+  },
+  "conf/ismir/FrissonDYRSD14": {
+    "@key": "conf/ismir/FrissonDYRSD14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Christian Frisson",
+      "St\u00e9phane Dupont",
+      "Willy Yvart",
+      "Nicolas Riche",
+      "Xavier Siebert",
+      "Thierry Dutoit"
+    ],
+    "title": "A Proximity Grid Optimization Method to Improve Audio Search for Sound Design.",
+    "pages": "349-354",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T063_299_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#FrissonDYRSD14"
+  },
+  "conf/ismir/PesekGPSGSPM14": {
+    "@key": "conf/ismir/PesekGPSGSPM14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Matevz Pesek",
+      "Primoz Godec",
+      "Mojca Poredos",
+      "Gregor Strle",
+      "Joze Guna",
+      "Emilija Stojmenova",
+      "Matevz Pogacnik",
+      "Matija Marolt"
+    ],
+    "title": "Introducing a Dataset of Emotional and Color Responses to Music.",
+    "pages": "355-360",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T064_307_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#PesekGPSGSPM14"
+  },
+  "conf/ismir/Lartillot14": {
+    "@key": "conf/ismir/Lartillot14",
+    "@mdate": "2014-12-19",
+    "author": "Olivier Lartillot",
+    "title": "In-depth Motivic Analysis based on Multiparametric Closed Pattern and Cyclic Sequence Mining.",
+    "pages": "361-366",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T065_308_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#Lartillot14"
+  },
+  "conf/ismir/RaffelMHSNLE14": {
+    "@key": "conf/ismir/RaffelMHSNLE14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Colin Raffel",
+      "Brian McFee",
+      "Eric J. Humphrey",
+      "Justin Salamon",
+      "Oriol Nieto",
+      "Dawen Liang",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "MIR_EVAL: A Transparent Implementation of Common MIR Metrics.",
+    "pages": "367-372",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T066_320_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#RaffelMHSNLE14"
+  },
+  "conf/ismir/AljanakiWV14": {
+    "@key": "conf/ismir/AljanakiWV14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Anna Aljanaki",
+      "Frans Wiering",
+      "Remco C. Veltkamp"
+    ],
+    "title": "Computational Modeling of Induced Emotion Using GEMS.",
+    "pages": "373-378",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T067_325_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#AljanakiWV14"
+  },
+  "conf/ismir/BalenBWV14": {
+    "@key": "conf/ismir/BalenBWV14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Jan Van Balen",
+      "Dimitrios Bountouridis",
+      "Frans Wiering",
+      "Remco C. Veltkamp"
+    ],
+    "title": "Cognition-inspired Descriptors for Scalable Cover Song Retrieval.",
+    "pages": "379-384",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T068_337_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#BalenBWV14"
+  },
+  "conf/ismir/HuLCD14": {
+    "@key": "conf/ismir/HuLCD14",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "Jin Ha Lee",
+      "Kahyun Choi",
+      "J. Stephen Downie"
+    ],
+    "title": "A Cross-Cultural Study on the Mood of K-POP Songs.",
+    "pages": "385-390",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T069_341_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#HuLCD14"
+  },
+  "conf/ismir/KranenburgK14": {
+    "@key": "conf/ismir/KranenburgK14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Peter van Kranenburg",
+      "Folgert Karsdorp"
+    ],
+    "title": "Cadence Detection in Western Traditional Stanzaic Songs using Melodic and Textual Features.",
+    "pages": "391-396",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T070_347_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#KranenburgK14"
+  },
+  "conf/ismir/DuttaM14": {
+    "@key": "conf/ismir/DuttaM14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Shrey Dutta",
+      "Hema A. Murthy"
+    ],
+    "title": "Discovering Typical Motifs of a Raga from One-Liners of Songs in Carnatic Music.",
+    "pages": "397-402",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T071_380_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#DuttaM14"
+  },
+  "conf/ismir/McFeeE14": {
+    "@key": "conf/ismir/McFeeE14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Brian McFee",
+      "Dan Ellis"
+    ],
+    "title": "Analyzing Song Structure with Spectral Clustering.",
+    "pages": "405-410",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T073_319_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#McFeeE14"
+  },
+  "conf/ismir/NietoF14": {
+    "@key": "conf/ismir/NietoF14",
+    "@mdate": "2016-02-17",
+    "author": [
+      "Oriol Nieto",
+      "Morwaread M. Farbood"
+    ],
+    "title": "Identifying Polyphonic Musical Patterns From Audio Recordings Using Music Segmentation Techniques.",
+    "pages": "411-416",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T074_150_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#NietoF14"
+  },
+  "conf/ismir/UllrichSG14": {
+    "@key": "conf/ismir/UllrichSG14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Karen Ullrich",
+      "Jan Schl\u00fcter",
+      "Thomas Grill"
+    ],
+    "title": "Boundary Detection in Music Structure Analysis using Convolutional Neural Networks.",
+    "pages": "417-422",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T075_271_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#UllrichSG14"
+  },
+  "conf/ismir/HolzapfelKS14": {
+    "@key": "conf/ismir/HolzapfelKS14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Andre Holzapfel",
+      "Florian Krebs",
+      "Ajay Srinivasamurthy"
+    ],
+    "title": "Tracking the \"Odd\": Meter Inference in a Culturally Diverse Music Corpus.",
+    "pages": "425-430",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T077_265_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#HolzapfelKS14"
+  },
+  "conf/ismir/SrinivasamurthyRHS14": {
+    "@key": "conf/ismir/SrinivasamurthyRHS14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Ajay Srinivasamurthy",
+      "Rafael Caro Repetto",
+      "Sundar Harshavardhan",
+      "Xavier Serra"
+    ],
+    "title": "Transcription and Recognition of Syllable based Percussion Patterns: The Case of Beijing Opera.",
+    "pages": "431-436",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T078_134_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SrinivasamurthyRHS14"
+  },
+  "conf/ismir/MooreJT14": {
+    "@key": "conf/ismir/MooreJT14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Joshua L. Moore",
+      "Thorsten Joachims",
+      "Douglas Turnbull"
+    ],
+    "title": "Taste Space Versus the World: an Embedding Analysis of Listening Habits and Geography.",
+    "pages": "439-444",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T080_188_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#MooreJT14"
+  },
+  "conf/ismir/XingWW14": {
+    "@key": "conf/ismir/XingWW14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Zhe Xing",
+      "Xinxi Wang",
+      "Ye Wang"
+    ],
+    "title": "Enhancing Collaborative Filtering Music Recommendation by Balancing Exploration and Exploitation.",
+    "pages": "445-450",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T081_140_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#XingWW14"
+  },
+  "conf/ismir/Laplante14": {
+    "@key": "conf/ismir/Laplante14",
+    "@mdate": "2014-12-19",
+    "author": "Audrey Laplante",
+    "title": "Improving Music Recommender Systems: What Can We Learn from Research on Music Tastes?",
+    "pages": "451-456",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T082_339_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#Laplante14"
+  },
+  "conf/ismir/CunninghamNBA14": {
+    "@key": "conf/ismir/CunninghamNBA14",
+    "@mdate": "2017-12-03",
+    "author": [
+      "Sally Jo Cunningham",
+      "David M. Nichols",
+      "David Bainbridge 0001",
+      "Hassan Ali"
+    ],
+    "title": "Social Music in Cars.",
+    "pages": "457-462",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T083_184_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#CunninghamNBA14"
+  },
+  "conf/ismir/MorchidDL14": {
+    "@key": "conf/ismir/MorchidDL14",
+    "@mdate": "2015-04-09",
+    "author": [
+      "Mohamed Morchid",
+      "Richard Dufour",
+      "Georges Linar\u00e8s"
+    ],
+    "title": "A Combined Thematic and Acoustic Approach for a Music Recommendation Service in TV Commercials.",
+    "pages": "465-470",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T086_151_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#MorchidDL14"
+  },
+  "conf/ismir/SinghiB14a": {
+    "@key": "conf/ismir/SinghiB14a",
+    "@mdate": "2015-02-12",
+    "author": [
+      "Abhishek Singhi",
+      "Daniel G. Brown 0001"
+    ],
+    "title": "Are Poetry and Lyrics All That Different?",
+    "pages": "471-476",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T085_107_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SinghiB14a"
+  },
+  "conf/ismir/HuangKHS14": {
+    "@key": "conf/ismir/HuangKHS14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Po-Sen Huang",
+      "Minje Kim",
+      "Mark Hasegawa-Johnson",
+      "Paris Smaragdis"
+    ],
+    "title": "Singing-Voice Separation from Monaural Recordings using Deep Recurrent Neural Networks.",
+    "pages": "477-482",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T087_154_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#HuangKHS14"
+  },
+  "conf/ismir/FarrahiSVHT14": {
+    "@key": "conf/ismir/FarrahiSVHT14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Katayoun Farrahi",
+      "Markus Schedl",
+      "Andreu Vall",
+      "David Hauger",
+      "Marko Tkalcic"
+    ],
+    "title": "Impact of Listening Behavior on Music Recommendation.",
+    "pages": "483-488",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T088_192_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#FarrahiSVHT14"
+  },
+  "conf/ismir/VeraC14": {
+    "@key": "conf/ismir/VeraC14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Bogdan Vera",
+      "Elaine Chew"
+    ],
+    "title": "Towards Seamless Network Music Performance: Predicting an Ensemble's Expressive Decisions for Distributed Performance.",
+    "pages": "489-494",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T089_194_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#VeraC14"
+  },
+  "conf/ismir/HsuWLMS14": {
+    "@key": "conf/ismir/HsuWLMS14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Ling-Chi Hsu",
+      "Yu-Lin Wang",
+      "Yi-Ju Lin",
+      "Cheryl D. Metcalf",
+      "Alvin W. Y. Su"
+    ],
+    "title": "Detection of Motor Changes in Violin Playing by EMG Signals.",
+    "pages": "495-500",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T090_227_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#HsuWLMS14"
+  },
+  "conf/ismir/LamL14": {
+    "@key": "conf/ismir/LamL14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Wang-Kong Lam",
+      "Tan Lee"
+    ],
+    "title": "Automatic Key Partition Based on Tonal Organization Information of Classical Music.",
+    "pages": "501-506",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T091_236_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#LamL14"
+  },
+  "conf/ismir/YangHC14": {
+    "@key": "conf/ismir/YangHC14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Po-Kai Yang",
+      "Chung-Chien Hsu",
+      "Jen-Tzung Chien"
+    ],
+    "title": "Bayesian Singing-Voice Separation.",
+    "pages": "507-512",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T092_241_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#YangHC14"
+  },
+  "conf/ismir/KorzeniowskiBW14": {
+    "@key": "conf/ismir/KorzeniowskiBW14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Filip Korzeniowski",
+      "Sebastian B\u00f6ck",
+      "Gerhard Widmer"
+    ],
+    "title": "Probabilistic Extraction of Beat Positions from a Beat Activation Function.",
+    "pages": "513-518",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T093_242_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#KorzeniowskiBW14"
+  },
+  "conf/ismir/JunRH14": {
+    "@key": "conf/ismir/JunRH14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Sanghoon Jun",
+      "Seungmin Rho",
+      "Eenjun Hwang"
+    ],
+    "title": "Geographical Region Mapping Scheme Based on Musical Preferences.",
+    "pages": "519-524",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T094_244_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#JunRH14"
+  },
+  "conf/ismir/BurgoyneHP14": {
+    "@key": "conf/ismir/BurgoyneHP14",
+    "@mdate": "2015-11-04",
+    "author": [
+      "John Ashley Burgoyne",
+      "W. Bas de Haas",
+      "Johan Pauwels"
+    ],
+    "title": "On Comparative Statistics for Labelling Tasks: What can We Learn from MIREX ACE 2013?",
+    "pages": "525-530",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T095_250_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#BurgoyneHP14"
+  },
+  "conf/ismir/NakamuraOS14": {
+    "@key": "conf/ismir/NakamuraOS14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Eita Nakamura",
+      "Nobutaka Ono",
+      "Shigeki Sagayama"
+    ],
+    "title": "Merged-Output HMM for Piano Fingering of Both Hands.",
+    "pages": "531-536",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T096_251_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#NakamuraOS14"
+  },
+  "conf/ismir/PanteliBH14": {
+    "@key": "conf/ismir/PanteliBH14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Maria Panteli",
+      "Niels Bogaards",
+      "Aline K. Honingh"
+    ],
+    "title": "Modeling Rhythm Similarity for Electronic Dance Music.",
+    "pages": "537-542",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T097_268_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#PanteliBH14"
+  },
+  "conf/ismir/Przyjaciel-ZablockiHSGTL14": {
+    "@key": "conf/ismir/Przyjaciel-ZablockiHSGTL14",
+    "@mdate": "2017-12-31",
+    "author": [
+      "Martin Przyjaciel-Zablocki",
+      "Thomas Hornung 0001",
+      "Alexander Sch\u00e4tzle",
+      "Sven Gau\u00df",
+      "Io Taxidou",
+      "Georg Lausen"
+    ],
+    "title": "MuSe: A Music Recommendation Management System.",
+    "pages": "543-548",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T098_270_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#Przyjaciel-ZablockiHSGTL14"
+  },
+  "conf/ismir/ArztWS14": {
+    "@key": "conf/ismir/ArztWS14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Andreas Arzt",
+      "Gerhard Widmer",
+      "Reinhard Sonnleitner"
+    ],
+    "title": "Tempo- and Transposition-invariant Identification of Piece and Score Position.",
+    "pages": "549-554",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T099_276_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#ArztWS14"
+  },
+  "conf/ismir/WuJL14": {
+    "@key": "conf/ismir/WuJL14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Ming-Ju Wu",
+      "Jyh-Shing Roger Jang",
+      "Chun-Hung Lu"
+    ],
+    "title": "Gender Identification and Age Estimation of Users Based on Music Metadata.",
+    "pages": "555-560",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T100_278_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#WuJL14"
+  },
+  "conf/ismir/BolandM14": {
+    "@key": "conf/ismir/BolandM14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Daniel Boland",
+      "Roderick Murray-Smith"
+    ],
+    "title": "Information-Theoretic Measures of Music Listening Behaviour.",
+    "pages": "561-566",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T101_296_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#BolandM14"
+  },
+  "conf/ismir/MolinaBTB14": {
+    "@key": "conf/ismir/MolinaBTB14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Emilio Molina",
+      "Ana M. Barbancho",
+      "Lorenzo J. Tard\u00f3n",
+      "Isabel Barbancho"
+    ],
+    "title": "Evaluation Framework for Automatic Singing Transcription.",
+    "pages": "567-572",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T102_298_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#MolinaBTB14"
+  },
+  "conf/ismir/UrbanoBHGS14": {
+    "@key": "conf/ismir/UrbanoBHGS14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Juli\u00e1n Urbano",
+      "Dmitry Bogdanov",
+      "Perfecto Herrera",
+      "Emilia G\u00f3mez",
+      "Xavier Serra"
+    ],
+    "title": "What is the Effect of Audio Quality on the Robustness of MFCCs and Chroma Features?",
+    "pages": "573-578",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T103_326_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#UrbanoBHGS14"
+  },
+  "conf/ismir/HuLW14": {
+    "@key": "conf/ismir/HuLW14",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "Jin Ha Lee",
+      "Leanne Ka Yan Wong"
+    ],
+    "title": "Music Information Behaviors and System Preferences of University Students in Hong Kong.",
+    "pages": "579-584",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T104_346_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#HuLW14"
+  },
+  "conf/ismir/SasakiYNGM14": {
+    "@key": "conf/ismir/SasakiYNGM14",
+    "@mdate": "2014-12-20",
+    "author": [
+      "Shoto Sasaki",
+      "Kazuyoshi Yoshii",
+      "Tomoyasu Nakano",
+      "Masataka Goto",
+      "Shigeo Morishima"
+    ],
+    "title": "LyricsRadar: A Lyrics Retrieval System Based on Latent Topics of Lyrics.",
+    "pages": "585-590",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T105_352_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SasakiYNGM14"
+  },
+  "conf/ismir/HumphreySNFBB14": {
+    "@key": "conf/ismir/HumphreySNFBB14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Eric J. Humphrey",
+      "Justin Salamon",
+      "Oriol Nieto",
+      "Jon Forsyth",
+      "Rachel M. Bittner",
+      "Juan Pablo Bello"
+    ],
+    "title": "JAMS: A JSON Annotated Music Specification for Reproducible MIR Research.",
+    "pages": "591-596",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T106_355_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#HumphreySNFBB14"
+  },
+  "conf/ismir/SaurelRD14": {
+    "@key": "conf/ismir/SaurelRD14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Pierre Saurel",
+      "Francis Rousseaux",
+      "Marc Danger"
+    ],
+    "title": "On The Changing Regulations of Privacy and Personal Information in MIR.",
+    "pages": "597-602",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T107_356_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#SaurelRD14"
+  },
+  "conf/ismir/BockKW14": {
+    "@key": "conf/ismir/BockKW14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Sebastian B\u00f6ck",
+      "Florian Krebs",
+      "Gerhard Widmer"
+    ],
+    "title": "A Multi-model Approach to Beat Tracking Considering Heterogeneous Music Styles.",
+    "pages": "603-608",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T108_367_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#BockKW14"
+  },
+  "conf/ismir/DriedgerMD14": {
+    "@key": "conf/ismir/DriedgerMD14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Jonathan Driedger",
+      "Meinard M\u00fcller",
+      "Sascha Disch"
+    ],
+    "title": "Extending Harmonic-Percussive Separation of Audio Signals.",
+    "pages": "611-616",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T110_127_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#DriedgerMD14"
+  },
+  "conf/ismir/YenLC14": {
+    "@key": "conf/ismir/YenLC14",
+    "@mdate": "2016-01-04",
+    "author": [
+      "Frederick Z. Yen",
+      "Yin-Jyun Luo",
+      "Tai-Shih Chi"
+    ],
+    "title": "Singing Voice Separation Using Spectro-Temporal Modulation Features.",
+    "pages": "617-622",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T111_217_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#YenLC14"
+  },
+  "conf/ismir/NakamuraSTK14": {
+    "@key": "conf/ismir/NakamuraSTK14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Tomohiko Nakamura",
+      "Kotaro Shikata",
+      "Norihiro Takamune",
+      "Hirokazu Kameoka"
+    ],
+    "title": "Harmonic-Temporal Factor Decomposition Incorporating Music Prior Information for Informed Monaural Source Separation.",
+    "pages": "623-628",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T112_135_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#NakamuraSTK14"
+  },
+  "conf/ismir/TianFBS14": {
+    "@key": "conf/ismir/TianFBS14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Mi Tian",
+      "Gy\u00f6rgy Fazekas",
+      "Dawn A. A. Black",
+      "Mark B. Sandler"
+    ],
+    "title": "Design And Evaluation of Onset Detectors using Different Fusion Policies.",
+    "pages": "631-636",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T114_229_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#TianFBS14"
+  },
+  "conf/ismir/DaviesB14": {
+    "@key": "conf/ismir/DaviesB14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Matthew E. P. Davies",
+      "Sebastian B\u00f6ck"
+    ],
+    "title": "Evaluating the Evaluation Measures for Beat Tracking.",
+    "pages": "637-642",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T115_238_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#DaviesB14"
+  },
+  "conf/ismir/ChurchC14": {
+    "@key": "conf/ismir/ChurchC14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Maura Church",
+      "Michael Scott Cuthbert"
+    ],
+    "title": "Improving Rhythmic Transcriptions via Probability Models Applied Post-OMR.",
+    "pages": "643-648",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T116_357_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#ChurchC14"
+  },
+  "conf/ismir/StoberCG14": {
+    "@key": "conf/ismir/StoberCG14",
+    "@mdate": "2014-12-19",
+    "author": [
+      "Sebastian Stober",
+      "Daniel J. Cameron",
+      "Jessica A. Grahn"
+    ],
+    "title": "Classifying EEG Recordings of Rhythm Perception.",
+    "pages": "649-654",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T117_317_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#StoberCG14"
+  },
+  "conf/ismir/DownieHLCCH14": {
+    "@key": "conf/ismir/DownieHLCCH14",
+    "@mdate": "2018-05-28",
+    "author": [
+      "J. Stephen Downie",
+      "Xiao Hu 0001",
+      "Jin Ha Lee",
+      "Kahyun Choi",
+      "Sally Jo Cunningham",
+      "Yun Hao"
+    ],
+    "title": "Ten Years of MIREX (Music Information Retrieval Evaluation eXchange): Reflections, Challenges and Opportunities.",
+    "pages": "657-662",
+    "year": "2014",
+    "booktitle": "ISMIR",
+    "ee": "http://www.terasoft.com.tw/conf/ismir2014/proceedings/T119_342_Paper.pdf",
+    "crossref": "conf/ismir/2014",
+    "url": "db/conf/ismir/ismir2014.html#DownieHLCCH14"
+  },
+  "conf/ismir/RingwaltD15": {
+    "@key": "conf/ismir/RingwaltD15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Dan Ringwalt",
+      "Roger B. Dannenberg"
+    ],
+    "title": "Image Quality Estimation for Multi-Score OMR.",
+    "pages": "17-23",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/37_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#RingwaltD15"
+  },
+  "conf/ismir/WolffMW15": {
+    "@key": "conf/ismir/WolffMW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Daniel Wolff",
+      "Andrew MacFarlane 0001",
+      "Tillman Weyde"
+    ],
+    "title": "Comparative Music Similarity Modelling Using Transfer Learning Across User Groups.",
+    "pages": "24-30",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/151_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#WolffMW15"
+  },
+  "conf/ismir/ProckupEGSCK15": {
+    "@key": "conf/ismir/ProckupEGSCK15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Matthew Prockup",
+      "Andreas F. Ehmann",
+      "Fabien Gouyon",
+      "Erik M. Schmidt",
+      "\u00d2scar Celma",
+      "Youngmoo E. Kim"
+    ],
+    "title": "Modeling Genre with the Music Genome Project: Comparing Human-Labeled Attributes and Audio Features.",
+    "pages": "31-37",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/276_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#ProckupEGSCK15"
+  },
+  "conf/ismir/TralieB15": {
+    "@key": "conf/ismir/TralieB15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Christopher J. Tralie",
+      "Paul Bendich"
+    ],
+    "title": "Cover Song Identification with Timbral Shape Sequences.",
+    "pages": "38-44",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/277_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#TralieB15"
+  },
+  "conf/ismir/WeissS15": {
+    "@key": "conf/ismir/WeissS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Christof Wei\u00df",
+      "Maximilian Schaab"
+    ],
+    "title": "On the Impact of Key Detection Performance for Identifying Classical Music Styles.",
+    "pages": "45-51",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/44_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#WeissS15"
+  },
+  "conf/ismir/ZhouL15": {
+    "@key": "conf/ismir/ZhouL15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Xinquan Zhou",
+      "Alexander Lerch"
+    ],
+    "title": "Chord Detection Using Deep Learning.",
+    "pages": "52-58",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/96_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#ZhouL15"
+  },
+  "conf/ismir/SummersP15": {
+    "@key": "conf/ismir/SummersP15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Cameron Summers",
+      "Phillip Popp"
+    ],
+    "title": "Temporal Music Context Identification with User Listening Data.",
+    "pages": "59-64",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/195_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#SummersP15"
+  },
+  "conf/ismir/VallSKS15": {
+    "@key": "conf/ismir/VallSKS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Andreu Vall",
+      "Marcin Skowron",
+      "Peter Knees",
+      "Markus Schedl"
+    ],
+    "title": "Improving Music Recommendations with a Weighted Factorization of the Tagging Activity.",
+    "pages": "65-71",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/129_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#VallSKS15"
+  },
+  "conf/ismir/KrebsBW15": {
+    "@key": "conf/ismir/KrebsBW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Florian Krebs",
+      "Sebastian B\u00f6ck",
+      "Gerhard Widmer"
+    ],
+    "title": "An Efficient State-Space Model for Joint Tempo and Meter Tracking.",
+    "pages": "72-78",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/239_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#KrebsBW15"
+  },
+  "conf/ismir/HuangCBBG15": {
+    "@key": "conf/ismir/HuangCBBG15",
+    "@mdate": "2016-04-26",
+    "author": [
+      "Yu-Hui Huang",
+      "Xuanli Chen",
+      "Serafina Beck",
+      "David Burn",
+      "Luc J. Van Gool"
+    ],
+    "title": "Automatic Handwritten Mensural Notation Interpreter: From Manuscript to MIDI Performance.",
+    "pages": "79-85",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/191_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#HuangCBBG15"
+  },
+  "conf/ismir/YoshiiIG15": {
+    "@key": "conf/ismir/YoshiiIG15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Kazuyoshi Yoshii",
+      "Katsutoshi Itoyama",
+      "Masataka Goto"
+    ],
+    "title": "Infinite Superimposed Discrete All-Pole Modeling for Multipitch Analysis of Wavelet Spectrograms.",
+    "pages": "86-92",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/161_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#YoshiiIG15"
+  },
+  "conf/ismir/RiskMHC15": {
+    "@key": "conf/ismir/RiskMHC15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Laura Risk",
+      "Lillio Mok",
+      "Andrew Hankinson",
+      "Julie Cumming"
+    ],
+    "title": "Melodic Similarity in Traditional French-Canadian Instrumental Dance Tunes.",
+    "pages": "93-99",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/183_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#RiskMHC15"
+  },
+  "conf/ismir/OramasSAS15": {
+    "@key": "conf/ismir/OramasSAS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Sergio Oramas",
+      "Mohamed Sordo",
+      "Luis Espinosa Anke",
+      "Xavier Serra"
+    ],
+    "title": "A Semantic-Based Approach for Artist Similarity.",
+    "pages": "100-106",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/305_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#OramasSAS15"
+  },
+  "conf/ismir/ZhangRS15": {
+    "@key": "conf/ismir/ZhangRS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Shuo Zhang",
+      "Rafael Caro Repetto",
+      "Xavier Serra"
+    ],
+    "title": "Predicting Pairwise Pitch Contour Relations Based on Linguistic Tone Information in Beijing Opera Singing.",
+    "pages": "107-113",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/282_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#ZhangRS15"
+  },
+  "conf/ismir/PercivalFG15": {
+    "@key": "conf/ismir/PercivalFG15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Graham Percival",
+      "Satoru Fukayama",
+      "Masataka Goto"
+    ],
+    "title": "Song2Quartet: A System for Generating String Quartet Cover Songs from Polyphonic Audio of Popular Music.",
+    "pages": "114-120",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/141_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#PercivalFG15"
+  },
+  "conf/ismir/SchluterG15": {
+    "@key": "conf/ismir/SchluterG15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Jan Schl\u00fcter",
+      "Thomas Grill"
+    ],
+    "title": "Exploring Data Augmentation for Improved Singing Voice Detection with Neural Networks.",
+    "pages": "121-126",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/264_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#SchluterG15"
+  },
+  "conf/ismir/SigtiaBD15": {
+    "@key": "conf/ismir/SigtiaBD15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Siddharth Sigtia",
+      "Nicolas Boulanger-Lewandowski",
+      "Simon Dixon"
+    ],
+    "title": "Audio Chord Recognition with a Hybrid Recurrent Neural Network.",
+    "pages": "127-133",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/227_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#SigtiaBD15"
+  },
+  "conf/ismir/VadBWMS15": {
+    "@key": "conf/ismir/VadBWMS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Beatrix Vad",
+      "Daniel Boland",
+      "John Williamson",
+      "Roderick Murray-Smith",
+      "Peter Berg Steffensen"
+    ],
+    "title": "Design and Evaluation of a Probabilistic Music Projection Interface.",
+    "pages": "134-140",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/254_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#VadBWMS15"
+  },
+  "conf/ismir/ZacharakisKC15": {
+    "@key": "conf/ismir/ZacharakisKC15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Asterios I. Zacharakis",
+      "Maximos A. Kaliakatsos-Papakostas",
+      "Emilios Cambouropoulos"
+    ],
+    "title": "Conceptual Blending in Music Cadences: A Formal Model and Subjective Evaluation.",
+    "pages": "141-147",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/166_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#ZacharakisKC15"
+  },
+  "conf/ismir/ParkL15": {
+    "@key": "conf/ismir/ParkL15",
+    "@mdate": "2017-02-02",
+    "author": [
+      "Jeongsoo Park 0001",
+      "Kyogu Lee"
+    ],
+    "title": "Harmonic-Percussive Source Separation Using Harmonicity and Sparsity Constraints.",
+    "pages": "148-154",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/219_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#ParkL15"
+  },
+  "conf/ismir/SzetoW15": {
+    "@key": "conf/ismir/SzetoW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Wai Man Szeto",
+      "Kin Hong Wong"
+    ],
+    "title": "A Hierarchical Bayesian Framework for Score-Informed Source Separation of Piano Music Signals.",
+    "pages": "155-161",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/316_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#SzetoW15"
+  },
+  "conf/ismir/SavageA15": {
+    "@key": "conf/ismir/SavageA15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Patrick E. Savage",
+      "Quentin D. Atkinson"
+    ],
+    "title": "Automatic Tune Family Identification by Musical Sequence Alignment.",
+    "pages": "162-168",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/76_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#SavageA15"
+  },
+  "conf/ismir/VatolkinRW15": {
+    "@key": "conf/ismir/VatolkinRW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Igor Vatolkin",
+      "G\u00fcnter Rudolph",
+      "Claus Weihs"
+    ],
+    "title": "Evaluation of Album Effect for Feature Selection in Music Genre Recognition.",
+    "pages": "169-175",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/202_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#VatolkinRW15"
+  },
+  "conf/ismir/WangHD15": {
+    "@key": "conf/ismir/WangHD15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Cheng-i Wang",
+      "Jennifer Hsu",
+      "Shlomo Dubnov"
+    ],
+    "title": "Music Pattern Discovery with Variable Markov Oracle: A Unified Approach to Symbolic and Audio Representations.",
+    "pages": "176-182",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/78_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#WangHD15"
+  },
+  "conf/ismir/SchrammNJ15": {
+    "@key": "conf/ismir/SchrammNJ15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Rodrigo Schramm",
+      "Helena de Souza Nunes",
+      "Cl\u00e1udio Rosito Jung"
+    ],
+    "title": "Automatic Solf\u00e8ge Assessment.",
+    "pages": "183-189",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/75_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#SchrammNJ15"
+  },
+  "conf/ismir/VieiraA15": {
+    "@key": "conf/ismir/VieiraA15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Felipe Vieira",
+      "Nazareno Andrade"
+    ],
+    "title": "Evaluating Conflict Management Mechanisms for Online Social Jukeboxes.",
+    "pages": "190-196",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/212_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#VieiraA15"
+  },
+  "conf/ismir/Srinivasamurthy15": {
+    "@key": "conf/ismir/Srinivasamurthy15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Ajay Srinivasamurthy",
+      "Andre Holzapfel",
+      "Ali Taylan Cemgil",
+      "Xavier Serra"
+    ],
+    "title": "Particle Filters for Efficient Meter Tracking with Dynamic Bayesian Networks.",
+    "pages": "197-203",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/97_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#Srinivasamurthy15"
+  },
+  "conf/ismir/SordoOW15": {
+    "@key": "conf/ismir/SordoOW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Mohamed Sordo",
+      "Mitsunori Ogihara",
+      "Stefan Wuchty"
+    ],
+    "title": "Analysis of the Evolution of Research Groups and Topics in the ISMIR Conference.",
+    "pages": "204-210",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/301_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#SordoOW15"
+  },
+  "conf/ismir/PageNRWLDR15": {
+    "@key": "conf/ismir/PageNRWLDR15",
+    "@mdate": "2018-05-11",
+    "author": [
+      "Kevin R. Page",
+      "Terhi Nurmikko-Fuller",
+      "Carolin Rindfleisch",
+      "David M. Weigl",
+      "Richard Lewis 0001",
+      "Laurence Dreyfus",
+      "David De Roure"
+    ],
+    "title": "A Toolkit for Live Annotation of Opera Performance: Experiences Capturing Wagner's Ring Cycle.",
+    "pages": "211-217",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/311_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#PageNRWLDR15"
+  },
+  "conf/ismir/Rodriguez-Lopez15": {
+    "@key": "conf/ismir/Rodriguez-Lopez15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Marcelo E. Rodr\u00edguez-L\u00f3pez",
+      "Anja Volk"
+    ],
+    "title": "Selective Acquisition Techniques for Enculturation-Based Melodic Phrase Segmentation.",
+    "pages": "218-224",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/319_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#Rodriguez-Lopez15"
+  },
+  "conf/ismir/BalenBBMV15": {
+    "@key": "conf/ismir/BalenBBMV15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Jan Van Balen",
+      "John Ashley Burgoyne",
+      "Dimitrios Bountouridis",
+      "Daniel M\u00fcllensiefen",
+      "Remco C. Veltkamp"
+    ],
+    "title": "Corpus Analysis Tools for Computational Hook Discovery.",
+    "pages": "227-233",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/148_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#BalenBBMV15"
+  },
+  "conf/ismir/RaffelE15": {
+    "@key": "conf/ismir/RaffelE15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Colin Raffel",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "Large-Scale Content-Based Matching of MIDI and Audio Files.",
+    "pages": "234-240",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/114_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#RaffelE15"
+  },
+  "conf/ismir/Schreiber15": {
+    "@key": "conf/ismir/Schreiber15",
+    "@mdate": "2015-11-05",
+    "author": "Hendrik Schreiber",
+    "title": "Improving Genre Annotations for the Million Song Dataset.",
+    "pages": "241-247",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/102_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#Schreiber15"
+  },
+  "conf/ismir/McFeeHB15": {
+    "@key": "conf/ismir/McFeeHB15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Brian McFee",
+      "Eric J. Humphrey",
+      "Juan Pablo Bello"
+    ],
+    "title": "A Software Framework for Musical Data Augmentation.",
+    "pages": "248-254",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/228_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#McFeeHB15"
+  },
+  "conf/ismir/WuL15": {
+    "@key": "conf/ismir/WuL15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Chih-Wei Wu",
+      "Alexander Lerch"
+    ],
+    "title": "Drum Transcription Using Partially Fixed Non-Negative Matrix Factorization with Template Adaptation.",
+    "pages": "257-263",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/199_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#WuL15"
+  },
+  "conf/ismir/NunesRJB15": {
+    "@key": "conf/ismir/NunesRJB15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Leonardo O. Nunes",
+      "Mart\u00edn Rocamora",
+      "Luis Jure",
+      "Luiz W. P. Biscainho"
+    ],
+    "title": "Beat and Downbeat Tracking Based on Rhythmic Patterns Applied to the Uruguayan Candombe Drumming.",
+    "pages": "264-270",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/95_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#NunesRJB15"
+  },
+  "conf/ismir/DittmarPM15": {
+    "@key": "conf/ismir/DittmarPM15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Christian Dittmar",
+      "Martin Pfleiderer",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Automated Estimation of Ride Cymbal Swing Ratios in Jazz Recordings.",
+    "pages": "271-277",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/143_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#DittmarPM15"
+  },
+  "conf/ismir/LiangSYL15": {
+    "@key": "conf/ismir/LiangSYL15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Che-Yuan Liang",
+      "Li Su",
+      "Yi-Hsuan Yang",
+      "Hsin-Ming Lin"
+    ],
+    "title": "Musical Offset Detection of Pitched Instruments: The Case of Violin.",
+    "pages": "281-287",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/118_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LiangSYL15"
+  },
+  "conf/ismir/ManarisS15": {
+    "@key": "conf/ismir/ManarisS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Bill Z. Manaris",
+      "Seth Stoudenmier"
+    ],
+    "title": "Specter: Combining Music Information Retrieval with Sound Spatialization.",
+    "pages": "288-294",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/270_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#ManarisS15"
+  },
+  "conf/ismir/LiangZE15": {
+    "@key": "conf/ismir/LiangZE15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Dawen Liang",
+      "Minshu Zhan",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "Content-Aware Collaborative Music Recommendation Using Pre-trained Neural Networks.",
+    "pages": "295-301",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/290_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LiangZE15"
+  },
+  "conf/ismir/LiemH15": {
+    "@key": "conf/ismir/LiemH15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Cynthia C. S. Liem",
+      "Alan Hanjalic"
+    ],
+    "title": "Comparative Analysis of Orchestral Performance Recordings: An Image-Based Approach.",
+    "pages": "302-308",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/108_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LiemH15"
+  },
+  "conf/ismir/LehnerW15": {
+    "@key": "conf/ismir/LehnerW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Bernhard Lehner",
+      "Gerhard Widmer"
+    ],
+    "title": "Monaural Blind Source Separation in the Context of Vocal Detection.",
+    "pages": "309-315",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/160_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LehnerW15"
+  },
+  "conf/ismir/LuoSYC15": {
+    "@key": "conf/ismir/LuoSYC15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Yin-Jyun Luo",
+      "Li Su",
+      "Yi-Hsuan Yang",
+      "Tai-Shih Chi"
+    ],
+    "title": "Detection of Common Mistakes in Novice Violin Playing.",
+    "pages": "316-322",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/197_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LuoSYC15"
+  },
+  "conf/ismir/MakrisKC15": {
+    "@key": "conf/ismir/MakrisKC15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Dimos Makris",
+      "Maximos A. Kaliakatsos-Papakostas",
+      "Emilios Cambouropoulos"
+    ],
+    "title": "Probabilistic Modular Bass Voice Leading in Melodic Harmonisation.",
+    "pages": "323-329",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/189_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#MakrisKC15"
+  },
+  "conf/ismir/KhlifS15": {
+    "@key": "conf/ismir/KhlifS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Anis Khlif",
+      "Vidhyasaharan Sethu"
+    ],
+    "title": "An Iterative Multi Range Non-Negative Matrix Factorization Algorithm for Polyphonic Music Transcription.",
+    "pages": "330-335",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/90_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#KhlifS15"
+  },
+  "conf/ismir/Kruspe15": {
+    "@key": "conf/ismir/Kruspe15",
+    "@mdate": "2015-11-05",
+    "author": "Anna M. Kruspe",
+    "title": "Training Phoneme Models for Singing with \"Songified\" Speech Data.",
+    "pages": "336-342",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/34_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#Kruspe15"
+  },
+  "conf/ismir/JinR15": {
+    "@key": "conf/ismir/JinR15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Rong Jin",
+      "Christopher Raphael"
+    ],
+    "title": "Graph-Based Rhythm Interpretation.",
+    "pages": "343-349",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/226_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#JinR15"
+  },
+  "conf/ismir/DriedgerPM15": {
+    "@key": "conf/ismir/DriedgerPM15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Jonathan Driedger",
+      "Thomas Pr\u00e4tzlich",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Let it Bee - Towards NMF-Inspired Audio Mosaicing.",
+    "pages": "350-356",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/13_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#DriedgerPM15"
+  },
+  "conf/ismir/ArztW15": {
+    "@key": "conf/ismir/ArztW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Andreas Arzt",
+      "Gerhard Widmer"
+    ],
+    "title": "Real-Time Music Tracking Using Multiple Performances as a Reference.",
+    "pages": "357-363",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/150_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#ArztW15"
+  },
+  "conf/ismir/KneesFHVBHG15": {
+    "@key": "conf/ismir/KneesFHVBHG15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Peter Knees",
+      "\u00c1ngel Faraldo",
+      "Perfecto Herrera",
+      "Richard Vogl",
+      "Sebastian B\u00f6ck",
+      "Florian H\u00f6rschl\u00e4ger",
+      "Mickael Le Goff"
+    ],
+    "title": "Two Data Sets for Tempo Estimation and Key Detection in Electronic Dance Music Annotated from User Corrections.",
+    "pages": "364-370",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/246_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#KneesFHVBHG15"
+  },
+  "conf/ismir/KuribayashiAY15": {
+    "@key": "conf/ismir/KuribayashiAY15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Taku Kuribayashi",
+      "Yasuhito Asano",
+      "Masatoshi Yoshikawa"
+    ],
+    "title": "Towards Support for Understanding Classical Music: Alignment of Content Descriptions on the Web.",
+    "pages": "371-377",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/287_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#KuribayashiAY15"
+  },
+  "conf/ismir/OramasGGM15": {
+    "@key": "conf/ismir/OramasGGM15",
+    "@mdate": "2018-03-29",
+    "author": [
+      "Sergio Oramas",
+      "Francisco G\u00f3mez 0001",
+      "Emilia G\u00f3mez",
+      "Joaqu\u00edn Mora"
+    ],
+    "title": "FlaBase: Towards the Creation of a Flamenco Music Knowledge Base.",
+    "pages": "378-384",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/304_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#OramasGGM15"
+  },
+  "conf/ismir/GuptaSKMS15": {
+    "@key": "conf/ismir/GuptaSKMS15",
+    "@mdate": "2017-09-12",
+    "author": [
+      "Swapnil Gupta",
+      "Ajay Srinivasamurthy",
+      "Manoj Kumar P. A.",
+      "Hema A. Murthy",
+      "Xavier Serra"
+    ],
+    "title": "Discovery of Syllabic Percussion Patterns in Tabla Solo Recordings.",
+    "pages": "385-391",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/86_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#GuptaSKMS15"
+  },
+  "conf/ismir/NakamuraCCOS15": {
+    "@key": "conf/ismir/NakamuraCCOS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Eita Nakamura",
+      "Philippe Cuvillier",
+      "Arshia Cont",
+      "Nobutaka Ono",
+      "Shigeki Sagayama"
+    ],
+    "title": "Autoregressive Hidden Semi-Markov Model of Symbolic Music Performance for Score Following.",
+    "pages": "392-398",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/15_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#NakamuraCCOS15"
+  },
+  "conf/ismir/LeeLYLW15": {
+    "@key": "conf/ismir/LeeLYLW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Chuan-Lung Lee",
+      "Yin-Tzu Lin",
+      "Zun-Ren Yao",
+      "Feng-Yi Lee",
+      "Ja-Ling Wu"
+    ],
+    "title": "Automatic Mashup Creation by Considering both Vertical and Horizontal Mashabilities.",
+    "pages": "399-405",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/302_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LeeLYLW15"
+  },
+  "conf/ismir/McFeeNB15": {
+    "@key": "conf/ismir/McFeeNB15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Brian McFee",
+      "Oriol Nieto",
+      "Juan Pablo Bello"
+    ],
+    "title": "Hierarchical Evaluation of Segment Boundary Detection.",
+    "pages": "406-412",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/174_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#McFeeNB15"
+  },
+  "conf/ismir/OtsukaK15": {
+    "@key": "conf/ismir/OtsukaK15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Masaki Otsuka",
+      "Tetsuro Kitahara"
+    ],
+    "title": "Improving MIDI Guitar's Accuracy with NMF and Neural Net.",
+    "pages": "413-419",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/56_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#OtsukaK15"
+  },
+  "conf/ismir/DaiMD15": {
+    "@key": "conf/ismir/DaiMD15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Jiajie Dai",
+      "Matthias Mauch",
+      "Simon Dixon"
+    ],
+    "title": "Analysis of Intonation Trajectories in Solo Singing.",
+    "pages": "420-426",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/233_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#DaiMD15"
+  },
+  "conf/ismir/Kaliakatsos-Papakostas15": {
+    "@key": "conf/ismir/Kaliakatsos-Papakostas15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Maximos A. Kaliakatsos-Papakostas",
+      "Asterios I. Zacharakis",
+      "Costas Tsougras",
+      "Emilios Cambouropoulos"
+    ],
+    "title": "Evaluating the General Chord Type Representation in Tonal Music and Organising GCT Chord Labels in Functional Chord Categories.",
+    "pages": "427-433",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/158_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#Kaliakatsos-Papakostas15"
+  },
+  "conf/ismir/LykartsisWL15": {
+    "@key": "conf/ismir/LykartsisWL15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Athanasios Lykartsis",
+      "Chih-Wei Wu",
+      "Alexander Lerch"
+    ],
+    "title": "Beat Histogram Features from NMF-Based Novelty Functions for Music Classification.",
+    "pages": "434-440",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/300_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LykartsisWL15"
+  },
+  "conf/ismir/SilvaSB15": {
+    "@key": "conf/ismir/SilvaSB15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Diego Furtado Silva",
+      "Vin\u00edcius M. A. de Souza",
+      "Gustavo E. A. P. A. Batista"
+    ],
+    "title": "Music Shapelets for Fast Cover Song Recognition.",
+    "pages": "441-447",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/164_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#SilvaSB15"
+  },
+  "conf/ismir/MironCJ15": {
+    "@key": "conf/ismir/MironCJ15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Marius Miron",
+      "Julio Jos\u00e9 Carabias-Orti",
+      "Jordi Janer"
+    ],
+    "title": "Improving Score-Informed Source Separation for Classical Music through Note Refinement.",
+    "pages": "448-454",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/99_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#MironCJ15"
+  },
+  "conf/ismir/InskipW15": {
+    "@key": "conf/ismir/InskipW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Charles Inskip",
+      "Frans Wiering"
+    ],
+    "title": "In Their Own Words: Using Text Analysis to Identify Musicologists' Attitudes towards Technology.",
+    "pages": "455-461",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/171_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#InskipW15"
+  },
+  "conf/ismir/OsmalskyjFDE15": {
+    "@key": "conf/ismir/OsmalskyjFDE15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Julien Osmalskyj",
+      "Peter Foster",
+      "Simon Dixon",
+      "Jean-Jacques Embrechts"
+    ],
+    "title": "Combining Features for Cover Song Identification.",
+    "pages": "462-468",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/198_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#OsmalskyjFDE15"
+  },
+  "conf/ismir/LiD15": {
+    "@key": "conf/ismir/LiD15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Bochen Li",
+      "Zhiyao Duan"
+    ],
+    "title": "Score Following for Piano Performances with Sustain-Pedal Effects.",
+    "pages": "469-475",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/285_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LiD15"
+  },
+  "conf/ismir/LeeP15": {
+    "@key": "conf/ismir/LeeP15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Jin Ha Lee",
+      "Rachel Price"
+    ],
+    "title": "Understanding Users of Commercial Music Services through Personas: Design Implications.",
+    "pages": "476-482",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/12_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LeeP15"
+  },
+  "conf/ismir/KoopsVH15": {
+    "@key": "conf/ismir/KoopsVH15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Hendrik Vincent Koops",
+      "Anja Volk",
+      "W. Bas de Haas"
+    ],
+    "title": "Corpus-Based Rhythmic Pattern Analysis of Ragtime Syncopation.",
+    "pages": "483-489",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/241_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#KoopsVH15"
+  },
+  "conf/ismir/Guiomard-KaganG15": {
+    "@key": "conf/ismir/Guiomard-KaganG15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Nicolas Guiomard-Kagan",
+      "Mathieu Giraud",
+      "Richard Groult",
+      "Florence Lev\u00e9"
+    ],
+    "title": "Comparing Voice and Stream Segmentation Algorithms.",
+    "pages": "493-499",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/180_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#Guiomard-KaganG15"
+  },
+  "conf/ismir/BittnerSEB15": {
+    "@key": "conf/ismir/BittnerSEB15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Rachel M. Bittner",
+      "Justin Salamon",
+      "Slim Essid",
+      "Juan Pablo Bello"
+    ],
+    "title": "Melody Extraction by Contour Classification.",
+    "pages": "500-506",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/247_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#BittnerSEB15"
+  },
+  "conf/ismir/RepettoGKS15": {
+    "@key": "conf/ismir/RepettoGKS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Rafael Caro Repetto",
+      "Rong Gong",
+      "Nadine Kroher",
+      "Xavier Serra"
+    ],
+    "title": "Comparison of the Singing Style of Two Jingju Schools.",
+    "pages": "507-513",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/257_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#RepettoGKS15"
+  },
+  "conf/ismir/PadillaMMN15": {
+    "@key": "conf/ismir/PadillaMMN15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Victor Padilla",
+      "Alex McLean",
+      "Alan Marsden",
+      "Kia Ng"
+    ],
+    "title": "Improving Optical Music Recognition by Combining Outputs from Multiple Sources.",
+    "pages": "517-523",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/187_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#PadillaMMN15"
+  },
+  "conf/ismir/SutcliffeCFRHL15": {
+    "@key": "conf/ismir/SutcliffeCFRHL15",
+    "@mdate": "2018-05-11",
+    "author": [
+      "Richard F. E. Sutcliffe",
+      "Tim Crawford",
+      "Chris Fox",
+      "Deane L. Root",
+      "Eduard H. Hovy",
+      "Richard Lewis 0001"
+    ],
+    "title": "Relating Natural Language Text to Musical Passages.",
+    "pages": "524-530",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/263_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#SutcliffeCFRHL15"
+  },
+  "conf/ismir/GrillS15": {
+    "@key": "conf/ismir/GrillS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Thomas Grill",
+      "Jan Schl\u00fcter"
+    ],
+    "title": "Music Boundary Detection Using Neural Networks on Combined Features and Two-Level Annotations.",
+    "pages": "531-537",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/134_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#GrillS15"
+  },
+  "conf/ismir/KaneshiroD15": {
+    "@key": "conf/ismir/KaneshiroD15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Blair Kaneshiro",
+      "Jacek P. Dmochowski"
+    ],
+    "title": "Neuroimaging Methods for Music Information Retrieval: Current Findings and Future Prospects.",
+    "pages": "538-544",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/250_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#KaneshiroD15"
+  },
+  "conf/ismir/Flexer15": {
+    "@key": "conf/ismir/Flexer15",
+    "@mdate": "2015-11-05",
+    "author": "Arthur Flexer",
+    "title": "Improving Visualization of High-Dimensional Music Similarity Spaces.",
+    "pages": "547-553",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/35_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#Flexer15"
+  },
+  "conf/ismir/Eghbal-zadehLSW15": {
+    "@key": "conf/ismir/Eghbal-zadehLSW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Hamid Eghbal-zadeh",
+      "Bernhard Lehner",
+      "Markus Schedl",
+      "Gerhard Widmer"
+    ],
+    "title": "I-Vectors for Timbre-Based Music Similarity and Music Artist Classification.",
+    "pages": "554-560",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/128_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#Eghbal-zadehLSW15"
+  },
+  "conf/ismir/FreedmanKT15": {
+    "@key": "conf/ismir/FreedmanKT15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Dylan Freedman",
+      "Eddie Kohler",
+      "Hans Tutschku"
+    ],
+    "title": "Correlating Extracted and Ground-Truth Harmonic Data in Music Retrieval Tasks.",
+    "pages": "561-567",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/271_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#FreedmanKT15"
+  },
+  "conf/ismir/GasserAGGW15": {
+    "@key": "conf/ismir/GasserAGGW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Martin Gasser",
+      "Andreas Arzt",
+      "Thassilo Gadermaier",
+      "Maarten Grachten",
+      "Gerhard Widmer"
+    ],
+    "title": "Classical Music on the Web - User Interfaces and Data Representations.",
+    "pages": "571-577",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/123_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#GasserAGGW15"
+  },
+  "conf/ismir/FuXDW15": {
+    "@key": "conf/ismir/FuXDW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Mutian Fu",
+      "Guangyu Xia",
+      "Roger B. Dannenberg",
+      "Larry A. Wasserman"
+    ],
+    "title": "A Statistical View on the Expressive Timing of Piano Rolled Chords.",
+    "pages": "578-583",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/73_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#FuXDW15"
+  },
+  "conf/ismir/CherlaTWG15": {
+    "@key": "conf/ismir/CherlaTWG15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Srikanth Cherla",
+      "Son N. Tran",
+      "Tillman Weyde",
+      "Artur S. d'Avila Garcez"
+    ],
+    "title": "Hybrid Long- and Short-Term Models of Folk Melodies.",
+    "pages": "584-590",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/140_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#CherlaTWG15"
+  },
+  "conf/ismir/GanguliRPKR15": {
+    "@key": "conf/ismir/GanguliRPKR15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Kaustuv Kanti Ganguli",
+      "Abhinav Rastogi",
+      "Vedhas Pandit",
+      "Prithvi Kantan",
+      "Preeti Rao"
+    ],
+    "title": "Efficient Melodic Query Based Audio Search for Hindustani Vocal Compositions.",
+    "pages": "591-597",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/170_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#GanguliRPKR15"
+  },
+  "conf/ismir/ChenDXZZ15": {
+    "@key": "conf/ismir/ChenDXZZ15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Ning Chen",
+      "J. Stephen Downie",
+      "Haidong Xiao",
+      "Yu Zhu",
+      "Jie Zhu"
+    ],
+    "title": "Modified Perceptual Linear Prediction Liftered Cepstrum (MPLPLC) Model for Pop Cover Song Recognition.",
+    "pages": "598-604",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/28_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#ChenDXZZ15"
+  },
+  "conf/ismir/DuttaPM15": {
+    "@key": "conf/ismir/DuttaPM15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Shrey Dutta",
+      "Krishnaraj Sekhar PV",
+      "Hema A. Murthy"
+    ],
+    "title": "Raga Verification in Carnatic Music Using Longest Common Segment Set.",
+    "pages": "605-611",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/172_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#DuttaPM15"
+  },
+  "conf/ismir/JiangR15": {
+    "@key": "conf/ismir/JiangR15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Yucong Jiang",
+      "Christopher Raphael"
+    ],
+    "title": "Instrument Identification in Optical Music Recognition.",
+    "pages": "612-617",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/193_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#JiangR15"
+  },
+  "conf/ismir/DittmarLPMW15": {
+    "@key": "conf/ismir/DittmarLPMW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Christian Dittmar",
+      "Bernhard Lehner",
+      "Thomas Pr\u00e4tzlich",
+      "Meinard M\u00fcller",
+      "Gerhard Widmer"
+    ],
+    "title": "Cross-Version Singing Voice Detection in Classical Opera Recordings.",
+    "pages": "618-624",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/201_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#DittmarLPMW15"
+  },
+  "conf/ismir/BockKW15": {
+    "@key": "conf/ismir/BockKW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Sebastian B\u00f6ck",
+      "Florian Krebs",
+      "Gerhard Widmer"
+    ],
+    "title": "Accurate Tempo Estimation Based on Recurrent Neural Networks and Resonating Comb Filters.",
+    "pages": "625-631",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/196_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#BockKW15"
+  },
+  "conf/ismir/DuvalBJCD15": {
+    "@key": "conf/ismir/DuvalBJCD15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Erik Duval",
+      "Marnix van Berchum",
+      "Anja Jentzsch",
+      "Gonzalo Alberto Parra Chico",
+      "Andreas Drakos"
+    ],
+    "title": "Musicology of Early Music with Europeana Tools and Services.",
+    "pages": "632-638",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/232_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#DuvalBJCD15"
+  },
+  "conf/ismir/ChoLK15": {
+    "@key": "conf/ismir/ChoLK15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Hye-Seung Cho",
+      "Jun-Yong Lee",
+      "Hyoung-Gook Kim"
+    ],
+    "title": "Singing Voice Separation from Monaural Music Based on Kernel Back-Fitting Using Beta-Order Spectral Amplitude Estimation.",
+    "pages": "639-644",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/55_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#ChoLK15"
+  },
+  "conf/ismir/SiglerWH15": {
+    "@key": "conf/ismir/SiglerWH15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Andie Sigler",
+      "Jon Wild",
+      "Eliot Handelman"
+    ],
+    "title": "Schematizing the Treatment of Dissonance in 16th-Century Counterpoint.",
+    "pages": "645-651",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/153_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#SiglerWH15"
+  },
+  "conf/ismir/BansalW15": {
+    "@key": "conf/ismir/BansalW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Jotthi Bansal",
+      "Matthew Woolhouse"
+    ],
+    "title": "Predictive Power of Personality on Music-Genre Exclusivity.",
+    "pages": "652-658",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/269_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#BansalW15"
+  },
+  "conf/ismir/JanssenKV15": {
+    "@key": "conf/ismir/JanssenKV15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Berit Janssen",
+      "Peter van Kranenburg",
+      "Anja Volk"
+    ],
+    "title": "A Comparison of Symbolic Similarity Measures for Finding Occurrences of Melodic Segments.",
+    "pages": "659-665",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/124_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#JanssenKV15"
+  },
+  "conf/ismir/Gomez-MarinJH15": {
+    "@key": "conf/ismir/Gomez-MarinJH15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Daniel G\u00f3mez-Mar\u00edn",
+      "Sergi Jord\u00e0",
+      "Perfecto Herrera"
+    ],
+    "title": "PAD and SAD: Two Awareness-Weighted Rhythmic Similarity Distances.",
+    "pages": "666-672",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/185_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#Gomez-MarinJH15"
+  },
+  "conf/ismir/HumphreyB15": {
+    "@key": "conf/ismir/HumphreyB15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Eric J. Humphrey",
+      "Juan Pablo Bello"
+    ],
+    "title": "Four Timely Insights on Automatic Chord Estimation.",
+    "pages": "673-679",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/294_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#HumphreyB15"
+  },
+  "conf/ismir/GulatiSS15": {
+    "@key": "conf/ismir/GulatiSS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Sankalp Gulati",
+      "Joan Serr\u00e0",
+      "Xavier Serra"
+    ],
+    "title": "Improving Melodic Similarity in Indian Art Music Using Culture-Specific Melodic Characteristics.",
+    "pages": "680-686",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/69_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#GulatiSS15"
+  },
+  "conf/ismir/DzhambazovSS15": {
+    "@key": "conf/ismir/DzhambazovSS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Georgi Dzhambazov",
+      "Sertan Sent\u00fcrk",
+      "Xavier Serra"
+    ],
+    "title": "Searching Lyrical Phrases in A-Capella Turkish Makam Recordings.",
+    "pages": "687-693",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/249_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#DzhambazovSS15"
+  },
+  "conf/ismir/EllisXFW15": {
+    "@key": "conf/ismir/EllisXFW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Robert J. Ellis",
+      "Zhe Xing",
+      "Jiakun Fang",
+      "Ye Wang"
+    ],
+    "title": "Quantifying Lexical Novelty in Song Lyrics.",
+    "pages": "694-700",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/116_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#EllisXFW15"
+  },
+  "conf/ismir/BenetosW15": {
+    "@key": "conf/ismir/BenetosW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Emmanouil Benetos",
+      "Tillman Weyde"
+    ],
+    "title": "An Efficient Temporally-Constrained Probabilistic Model for Multiple-Instrument Music Transcription.",
+    "pages": "701-707",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/131_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#BenetosW15"
+  },
+  "conf/ismir/ChenSY15": {
+    "@key": "conf/ismir/ChenSY15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Yuan-Ping Chen",
+      "Li Su",
+      "Yi-Hsuan Yang"
+    ],
+    "title": "Electric Guitar Playing Technique Detection in Real-World Recording Based on F0 Sequence Pattern Recognition.",
+    "pages": "708-714",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/119_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#ChenSY15"
+  },
+  "conf/ismir/KirlinT15": {
+    "@key": "conf/ismir/KirlinT15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Phillip B. Kirlin",
+      "David L. Thomas"
+    ],
+    "title": "Extending a Model of Monophonic Hierarchical Music Analysis to Homophony.",
+    "pages": "715-721",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/216_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#KirlinT15"
+  },
+  "conf/ismir/DerutyP15": {
+    "@key": "conf/ismir/DerutyP15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Emmanuel Deruty",
+      "Fran\u00e7ois Pachet"
+    ],
+    "title": "The MIR Perspective on the Evolution of Dynamics in Mainstream Music.",
+    "pages": "722-727",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/136_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#DerutyP15"
+  },
+  "conf/ismir/DevaneyACN15": {
+    "@key": "conf/ismir/DevaneyACN15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Johanna Devaney",
+      "Claire Arthur",
+      "Nathaniel Condit-Schultz",
+      "Kirsten Nisula"
+    ],
+    "title": "Theme And Variation Encodings with Roman Numerals (TAVERN): A New Data Set for Symbolic Music Analysis.",
+    "pages": "728-734",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/261_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#DevaneyACN15"
+  },
+  "conf/ismir/BarbanchoTBS15": {
+    "@key": "conf/ismir/BarbanchoTBS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Isabel Barbancho",
+      "Lorenzo J. Tard\u00f3n",
+      "Ana M. Barbancho",
+      "Mateu Sbert"
+    ],
+    "title": "Benford's Law for Music Analysis.",
+    "pages": "735-741",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/30_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#BarbanchoTBS15"
+  },
+  "conf/ismir/Carabias-OrtiRV15": {
+    "@key": "conf/ismir/Carabias-OrtiRV15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Julio Jos\u00e9 Carabias-Orti",
+      "Francisco J. Rodr\u00edguez-Serrano",
+      "Pedro Vera-Candeas",
+      "Nicol\u00e1s Ruiz-Reyes",
+      "Francisco J. Ca\u00f1adas-Quesada"
+    ],
+    "title": "An Audio to Score Alignment Framework Using Spectral Factorization and Dynamic Time Warping.",
+    "pages": "742-748",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/94_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#Carabias-OrtiRV15"
+  },
+  "conf/ismir/MatzCA15": {
+    "@key": "conf/ismir/MatzCA15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Daniel Matz",
+      "Estefan\u00eda Cano",
+      "Jakob Abe\u00dfer"
+    ],
+    "title": "New Sonorities for Early Jazz Recordings Using Sound Source Separation and Automatic Mixing Tools.",
+    "pages": "749-755",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/190_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#MatzCA15"
+  },
+  "conf/ismir/JancovicKB15": {
+    "@key": "conf/ismir/JancovicKB15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Peter Jancovic",
+      "M\u00fcnevver K\u00f6k\u00fcer",
+      "Wrena Baptiste"
+    ],
+    "title": "Automatic Transcription of Ornamented Irish Traditional Flute Music Using Hidden Markov Models.",
+    "pages": "756-762",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/106_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#JancovicKB15"
+  },
+  "conf/ismir/StoberSOG15": {
+    "@key": "conf/ismir/StoberSOG15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Sebastian Stober",
+      "Avital Sternin",
+      "Adrian M. Owen",
+      "Jessica A. Grahn"
+    ],
+    "title": "Towards Music Imagery Information Retrieval: Introducing the OpenMIIR Dataset of EEG Recordings from Music Perception and Imagination.",
+    "pages": "763-769",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/224_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#StoberSOG15"
+  },
+  "conf/ismir/AljanakiWV15": {
+    "@key": "conf/ismir/AljanakiWV15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Anna Aljanaki",
+      "Frans Wiering",
+      "Remco C. Veltkamp"
+    ],
+    "title": "Emotion Based Segmentation of Musical Audio.",
+    "pages": "770-776",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/265_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#AljanakiWV15"
+  },
+  "conf/ismir/LeeHCD15": {
+    "@key": "conf/ismir/LeeHCD15",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Jin Ha Lee",
+      "Xiao Hu 0001",
+      "Kahyun Choi",
+      "J. Stephen Downie"
+    ],
+    "title": "MIREX Grand Challenge 2014 User Experience: Qualitative Analysis of User Feedback.",
+    "pages": "779-785",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/51_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LeeHCD15"
+  },
+  "conf/ismir/PorterBKTS15": {
+    "@key": "conf/ismir/PorterBKTS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Alastair Porter",
+      "Dmitry Bogdanov",
+      "Robert Kaye",
+      "Roman Tsukanov",
+      "Xavier Serra"
+    ],
+    "title": "AcousticBrainz: A Community Platform for Gathering Music Information Obtained from Audio.",
+    "pages": "786-792",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/210_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#PorterBKTS15"
+  },
+  "conf/ismir/LiebmanSW15": {
+    "@key": "conf/ismir/LiebmanSW15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Elad Liebman",
+      "Peter Stone",
+      "Corey N. White"
+    ],
+    "title": "How Music Alters Decision Making - Impact of Music Stimuli on Emotional Classification.",
+    "pages": "793-799",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/293_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LiebmanSW15"
+  },
+  "conf/ismir/MelenhorstL15": {
+    "@key": "conf/ismir/MelenhorstL15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Mark S. Melenhorst",
+      "Cynthia C. S. Liem"
+    ],
+    "title": "Put the Concert Attendee in the Spotlight. A User-Centered Design and Development Approach for Classical Concert Applications.",
+    "pages": "800-806",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/67_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#MelenhorstL15"
+  },
+  "conf/ismir/LiSYS15": {
+    "@key": "conf/ismir/LiSYS15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Pei-Ching Li",
+      "Li Su",
+      "Yi-Hsuan Yang",
+      "Alvin W. Y. Su"
+    ],
+    "title": "Analysis of Expressive Musical Terms in Violin Using Score-Informed and Expression-Based Audio Features.",
+    "pages": "809-815",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/179_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#LiSYS15"
+  },
+  "conf/ismir/XiaWDG15": {
+    "@key": "conf/ismir/XiaWDG15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Guangyu Xia",
+      "Yun Wang",
+      "Roger B. Dannenberg",
+      "Geoffrey Gordon"
+    ],
+    "title": "Spectral Learning for Expressive Interactive Ensemble Music Performance.",
+    "pages": "816-822",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/72_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#XiaWDG15"
+  },
+  "conf/ismir/AbesserCFPZ15": {
+    "@key": "conf/ismir/AbesserCFPZ15",
+    "@mdate": "2015-11-05",
+    "author": [
+      "Jakob Abe\u00dfer",
+      "Estefan\u00eda Cano",
+      "Klaus Frieler",
+      "Martin Pfleiderer",
+      "Wolf-Georg Zaddach"
+    ],
+    "title": "Score-Informed Analysis of Intonation and Pitch Modulation in Jazz Solos.",
+    "pages": "823-829",
+    "year": "2015",
+    "booktitle": "ISMIR",
+    "ee": "http://ismir2015.uma.es/articles/135_Paper.pdf",
+    "crossref": "conf/ismir/2015",
+    "url": "db/conf/ismir/ismir2015.html#AbesserCFPZ15"
+  },
+  "conf/ismir/SilvaYBK16": {
+    "@key": "conf/ismir/SilvaYBK16",
+    "@mdate": "2016-09-27",
+    "author": [
+      "Diego Furtado Silva",
+      "Chin-Chia Michael Yeh",
+      "Gustavo E. A. P. A. Batista",
+      "Eamonn J. Keogh"
+    ],
+    "title": "SiMPle: Assessing Music Similarity Using Subsequences Joins.",
+    "pages": "23-29",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/099_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#SilvaYBK16"
+  },
+  "conf/ismir/EwertWMS16": {
+    "@key": "conf/ismir/EwertWMS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Sebastian Ewert",
+      "Siying Wang",
+      "Meinard M\u00fcller",
+      "Mark B. Sandler"
+    ],
+    "title": "Score-Informed Identification of Missing and Extra Notes in Piano Recordings.",
+    "pages": "30-36",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/123_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#EwertWMS16"
+  },
+  "conf/ismir/KorzeniowskiW16": {
+    "@key": "conf/ismir/KorzeniowskiW16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Filip Korzeniowski",
+      "Gerhard Widmer"
+    ],
+    "title": "Feature Learning for Chord Recognition: The Deep Chroma Extractor.",
+    "pages": "37-43",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/178_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#KorzeniowskiW16"
+  },
+  "conf/ismir/Schluter16": {
+    "@key": "conf/ismir/Schluter16",
+    "@mdate": "2016-09-08",
+    "author": "Jan Schl\u00fcter",
+    "title": "Learning to Pinpoint Singing Voice from Weakly Labeled Examples.",
+    "pages": "44-50",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/315_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Schluter16"
+  },
+  "conf/ismir/BeauguitteDK16": {
+    "@key": "conf/ismir/BeauguitteDK16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Pierre Beauguitte",
+      "Bryan Duggan",
+      "John D. Kelleher"
+    ],
+    "title": "A Corpus of Annotated Irish Traditional Dance Music Recordings: Design and Benchmark Evaluations.",
+    "pages": "53-59",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/148_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#BeauguitteDK16"
+  },
+  "conf/ismir/LambertWA16": {
+    "@key": "conf/ismir/LambertWA16",
+    "@mdate": "2018-01-09",
+    "author": [
+      "Andrew John Lambert",
+      "Tillman Weyde",
+      "Newton Armstrong"
+    ],
+    "title": "Adaptive Frequency Neural Networks for Dynamic Pulse and Metre Perception.",
+    "pages": "60-66",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/228_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#LambertWA16"
+  },
+  "conf/ismir/NuanainHJ16": {
+    "@key": "conf/ismir/NuanainHJ16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "C\u00e1rthach \u00d3 Nuan\u00e1in",
+      "Perfecto Herrera",
+      "Sergi Jord\u00e0"
+    ],
+    "title": "An Evaluation Framework and Case Study for Rhythmic Concatenative Synthesis.",
+    "pages": "67-72",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/180_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#NuanainHJ16"
+  },
+  "conf/ismir/AllikFS16": {
+    "@key": "conf/ismir/AllikFS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Alo Allik",
+      "Gy\u00f6rgy Fazekas",
+      "Mark B. Sandler"
+    ],
+    "title": "An Ontology for Audio Features.",
+    "pages": "73-79",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/077_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#AllikFS16"
+  },
+  "conf/ismir/StollerD16": {
+    "@key": "conf/ismir/StollerD16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Daniel Stoller",
+      "Simon Dixon"
+    ],
+    "title": "Analysis and Classification of Phonation Modes In Singing.",
+    "pages": "80-86",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/233_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#StollerD16"
+  },
+  "conf/ismir/DaiD16": {
+    "@key": "conf/ismir/DaiD16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Jiajie Dai",
+      "Simon Dixon"
+    ],
+    "title": "Analysis of Vocal Imitations of Pitch Trajectories.",
+    "pages": "87-93",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/127_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#DaiD16"
+  },
+  "conf/ismir/VigliensoniF16": {
+    "@key": "conf/ismir/VigliensoniF16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Gabriel Vigliensoni",
+      "Ichiro Fujinaga"
+    ],
+    "title": "Automatic Music Recommendation Systems: Do Demographic, Profiling, and Contextual Features Improve Their Performance?.",
+    "pages": "94-100",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/044_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#VigliensoniF16"
+  },
+  "conf/ismir/LuWLL16": {
+    "@key": "conf/ismir/LuWLL16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Yen-Cheng Lu",
+      "Chih-Wei Wu",
+      "Alexander Lerch",
+      "Chang-Tien Lu"
+    ],
+    "title": "Automatic Outlier Detection in Music Genre Datasets.",
+    "pages": "101-107",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/215_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#LuWLL16"
+  },
+  "conf/ismir/YangRC16": {
+    "@key": "conf/ismir/YangRC16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Luwei Yang",
+      "Khalid Z. Rajab",
+      "Elaine Chew"
+    ],
+    "title": "AVA: An Interactive System for Visual and Quantitative Analyses of Vibrato and Portamento Performance Styles.",
+    "pages": "108-114",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/314_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#YangRC16"
+  },
+  "conf/ismir/VelardeWCMG16": {
+    "@key": "conf/ismir/VelardeWCMG16",
+    "@mdate": "2016-09-26",
+    "author": [
+      "Gissel Velarde",
+      "Tillman Weyde",
+      "Carlos Eduardo Cancino Chac\u00f3n",
+      "David Meredith 0001",
+      "Maarten Grachten"
+    ],
+    "title": "Composer Recognition Based on 2D-Filtered Piano-Rolls.",
+    "pages": "115-121",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/063_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#VelardeWCMG16"
+  },
+  "conf/ismir/AndersenK16": {
+    "@key": "conf/ismir/AndersenK16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Kristina Andersen",
+      "Peter Knees"
+    ],
+    "title": "Conversations with Expert Users in Music Retrieval and Research Challenges for Creative MIR.",
+    "pages": "122-128",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/246_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#AndersenK16"
+  },
+  "conf/ismir/KrebsBDW16": {
+    "@key": "conf/ismir/KrebsBDW16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Florian Krebs",
+      "Sebastian B\u00f6ck",
+      "Matthias Dorfer",
+      "Gerhard Widmer"
+    ],
+    "title": "Downbeat Tracking Using Beat Synchronous Features with Recurrent Neural Networks.",
+    "pages": "129-135",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/249_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#KrebsBDW16"
+  },
+  "conf/ismir/OsmalskyjDE16": {
+    "@key": "conf/ismir/OsmalskyjDE16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Julien Osmalskyj",
+      "Marc Van Droogenbroeck",
+      "Jean-Jacques Embrechts"
+    ],
+    "title": "Enhancing Cover Song Identification with Hierarchical Rank Aggregation.",
+    "pages": "136-142",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/064_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#OsmalskyjDE16"
+  },
+  "conf/ismir/TseSWJL16": {
+    "@key": "conf/ismir/TseSWJL16",
+    "@mdate": "2017-02-22",
+    "author": [
+      "Tim Tse",
+      "Justin Salamon",
+      "Alex C. Williams",
+      "Helga Jiang",
+      "Edith Law"
+    ],
+    "title": "Ensemble: A Hybrid Human-Machine System for Generating Melody Scores from Audio.",
+    "pages": "143-149",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/072_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#TseSWJL16"
+  },
+  "conf/ismir/OramasALSS16": {
+    "@key": "conf/ismir/OramasALSS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Sergio Oramas",
+      "Luis Espinosa Anke",
+      "Aonghus Lawlor",
+      "Xavier Serra",
+      "Horacio Saggion"
+    ],
+    "title": "Exploring Customer Reviews for Music Genre Classification and Evolutionary Studies.",
+    "pages": "150-156",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/240_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#OramasALSS16"
+  },
+  "conf/ismir/HajicNPP16": {
+    "@key": "conf/ismir/HajicNPP16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Jan Hajic Jr.",
+      "Jiri Novotn\u00fd",
+      "Pavel Pecina",
+      "Jaroslav Pokorn\u00fd"
+    ],
+    "title": "Further Steps Towards a Standard Testbed for Optical Music Recognition.",
+    "pages": "157-163",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/289_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#HajicNPP16"
+  },
+  "conf/ismir/Guiomard-KaganG16": {
+    "@key": "conf/ismir/Guiomard-KaganG16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Nicolas Guiomard-Kagan",
+      "Mathieu Giraud",
+      "Richard Groult",
+      "Florence Lev\u00e9"
+    ],
+    "title": "Improving Voice Separation by Better Connecting Contigs.",
+    "pages": "164-170",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/129_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Guiomard-KaganG16"
+  },
+  "conf/ismir/TanakaBM16": {
+    "@key": "conf/ismir/TanakaBM16",
+    "@mdate": "2016-09-26",
+    "author": [
+      "Tsubasa Tanaka",
+      "Brian Bemman",
+      "David Meredith 0001"
+    ],
+    "title": "Integer Programming Formulation of the Problem of Generating Milton Babbitt's All-Partition Arrays.",
+    "pages": "171-177",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/034_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#TanakaBM16"
+  },
+  "conf/ismir/KoopsHBV16": {
+    "@key": "conf/ismir/KoopsHBV16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Hendrik Vincent Koops",
+      "W. Bas de Haas",
+      "Dimitrios Bountouridis",
+      "Anja Volk"
+    ],
+    "title": "Integration and Quality Assessment of Heterogeneous Chord Sequences Using Data Fusion.",
+    "pages": "178-184",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/019_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#KoopsHBV16"
+  },
+  "conf/ismir/SonnleitnerAW16": {
+    "@key": "conf/ismir/SonnleitnerAW16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Reinhard Sonnleitner",
+      "Andreas Arzt",
+      "Gerhard Widmer"
+    ],
+    "title": "Landmark-Based Audio Fingerprinting for DJ Mix Monitoring.",
+    "pages": "185-191",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/187_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#SonnleitnerAW16"
+  },
+  "conf/ismir/ValleFADFS16": {
+    "@key": "conf/ismir/ValleFADFS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Rafael Valle",
+      "Daniel J. Fremont",
+      "Ilge Akkaya",
+      "Alexandre Donz\u00e9",
+      "Adrian Freed",
+      "Sanjit A. Seshia"
+    ],
+    "title": "Learning and Visualizing Music Specifications Using Pattern Graphs.",
+    "pages": "192-198",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/280_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#ValleFADFS16"
+  },
+  "conf/ismir/FieldsR16": {
+    "@key": "conf/ismir/FieldsR16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Ben Fields",
+      "Christophe Rhodes"
+    ],
+    "title": "Listen To Me - Don't Listen To Me: What Communities of Critics Tell Us About Music.",
+    "pages": "199-205",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/173_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#FieldsR16"
+  },
+  "conf/ismir/HennequinR16": {
+    "@key": "conf/ismir/HennequinR16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Romain Hennequin",
+      "Fran\u00e7ois Rigaud"
+    ],
+    "title": "Long-Term Reverberation Modeling for Under-Determined Audio Source Separation with Application to Vocal Melody Extraction.",
+    "pages": "206-210",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/196_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#HennequinR16"
+  },
+  "conf/ismir/CreagerSBD16": {
+    "@key": "conf/ismir/CreagerSBD16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Elliot Creager",
+      "Noah D. Stein",
+      "Roland Badeau",
+      "Philippe Depalle"
+    ],
+    "title": "Nonnegative Tensor Factorization with Frequency Modulation Cues for Blind Audio Source Separation.",
+    "pages": "211-217",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/103_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#CreagerSBD16"
+  },
+  "conf/ismir/WuL16": {
+    "@key": "conf/ismir/WuL16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Chih-Wei Wu",
+      "Alexander Lerch"
+    ],
+    "title": "On Drum Playing Technique Detection in Polyphonic Mixtures.",
+    "pages": "218-224",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/268_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#WuL16"
+  },
+  "conf/ismir/LiuR16": {
+    "@key": "conf/ismir/LiuR16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "I-Ting Liu",
+      "Richard Randall"
+    ],
+    "title": "Predicting Missing Music Components with Bidirectional Long Short-Term Memory Neural Networks.",
+    "pages": "225-231",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/097_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#LiuR16"
+  },
+  "conf/ismir/PSGR16": {
+    "@key": "conf/ismir/PSGR16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Vinutha T. P.",
+      "Suryanarayana Sankagiri",
+      "Kaustuv Kanti Ganguli",
+      "Preeti Rao"
+    ],
+    "title": "Structural Segmentation and Visualization of Sitar and Sarod Concert Audio.",
+    "pages": "232-238",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/151_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#PSGR16"
+  },
+  "conf/ismir/DriedgerBEM16": {
+    "@key": "conf/ismir/DriedgerBEM16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Jonathan Driedger",
+      "Stefan Balke",
+      "Sebastian Ewert",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Template-Based Vibrato Analysis in Complex Music Signals.",
+    "pages": "239-245",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/005_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#DriedgerBEM16"
+  },
+  "conf/ismir/BalkeDADM16": {
+    "@key": "conf/ismir/BalkeDADM16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Stefan Balke",
+      "Jonathan Driedger",
+      "Jakob Abe\u00dfer",
+      "Christian Dittmar",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Towards Evaluating Multiple Predominant Melody Annotations in Jazz Recordings.",
+    "pages": "246-252",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/049_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#BalkeDADM16"
+  },
+  "conf/ismir/BockKW16": {
+    "@key": "conf/ismir/BockKW16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Sebastian B\u00f6ck",
+      "Florian Krebs",
+      "Gerhard Widmer"
+    ],
+    "title": "Joint Beat and Downbeat Tracking with Recurrent Neural Networks.",
+    "pages": "255-261",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/186_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#BockKW16"
+  },
+  "conf/ismir/HolzapfelG16": {
+    "@key": "conf/ismir/HolzapfelG16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Andre Holzapfel",
+      "Thomas Grill"
+    ],
+    "title": "Bayesian Meter Tracking on Learned Signal Representations.",
+    "pages": "262-268",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/132_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#HolzapfelG16"
+  },
+  "conf/ismir/FontS16": {
+    "@key": "conf/ismir/FontS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Frederic Font",
+      "Xavier Serra"
+    ],
+    "title": "Tempo Estimation for Music Loops and a Simple Confidence Measure.",
+    "pages": "269-275",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/195_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#FontS16"
+  },
+  "conf/ismir/StoberPM16": {
+    "@key": "conf/ismir/StoberPM16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Sebastian Stober",
+      "Thomas Pr\u00e4tzlich",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Brain Beats: Tempo Extraction from EEG Data.",
+    "pages": "276-282",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/022_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#StoberPM16"
+  },
+  "conf/ismir/McFeeHU16": {
+    "@key": "conf/ismir/McFeeHU16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Brian McFee",
+      "Eric J. Humphrey",
+      "Juli\u00e1n Urbano"
+    ],
+    "title": "A Plan for Sustainable MIR Evaluation.",
+    "pages": "285-291",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/257_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#McFeeHU16"
+  },
+  "conf/ismir/DemetriouLL16": {
+    "@key": "conf/ismir/DemetriouLL16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Andrew Demetriou",
+      "Martha Larson",
+      "Cynthia C. S. Liem"
+    ],
+    "title": "Go with the Flow: When Listeners Use Music as Technology.",
+    "pages": "292-298",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/068_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#DemetriouLL16"
+  },
+  "conf/ismir/LeeKH16": {
+    "@key": "conf/ismir/LeeKH16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Jin Ha Lee",
+      "Yea-Seul Kim",
+      "Chris Hubbles"
+    ],
+    "title": "A Look at the Cloud from Both Sides Now: An Analysis of Cloud Music Service Usage.",
+    "pages": "299-305",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/087_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#LeeKH16"
+  },
+  "conf/ismir/OjimaNIY16": {
+    "@key": "conf/ismir/OjimaNIY16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Yuta Ojima",
+      "Eita Nakamura",
+      "Katsutoshi Itoyama",
+      "Kazuyoshi Yoshii"
+    ],
+    "title": "A Hierarchical Bayesian Model of Chords, Pitches, and Spectrograms for Multipitch Analysis.",
+    "pages": "309-315",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/003_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#OjimaNIY16"
+  },
+  "conf/ismir/BuccoliZFSS16": {
+    "@key": "conf/ismir/BuccoliZFSS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Michele Buccoli",
+      "Massimiliano Zanoni",
+      "Gy\u00f6rgy Fazekas",
+      "Augusto Sarti",
+      "Mark B. Sandler"
+    ],
+    "title": "A Higher-Dimensional Expansion of Affective Norms for English Terms for Music Tagging.",
+    "pages": "316-322",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/253_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#BuccoliZFSS16"
+  },
+  "conf/ismir/ChungLC16": {
+    "@key": "conf/ismir/ChungLC16",
+    "@mdate": "2017-09-20",
+    "author": [
+      "Chia-Hao Chung",
+      "Jing-Kai Lou",
+      "Homer H. Chen"
+    ],
+    "title": "A Latent Representation of Users, Sessions, and Songs for Listening Behavior Analysis.",
+    "pages": "323-329",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/110_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#ChungLC16"
+  },
+  "conf/ismir/BessonGRTT16": {
+    "@key": "conf/ismir/BessonGRTT16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Vincent Besson",
+      "Marco Gurrieri",
+      "Philippe Rigaux",
+      "Alice Tacaille",
+      "Virginie Thion"
+    ],
+    "title": "A Methodology for Quality Assessment in Collaborative Score Libraries.",
+    "pages": "330-336",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/076_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#BessonGRTT16"
+  },
+  "conf/ismir/Kinnaird16": {
+    "@key": "conf/ismir/Kinnaird16",
+    "@mdate": "2016-09-08",
+    "author": "Katherine M. Kinnaird",
+    "title": "Aligned Hierarchies: A Multi-Scale Structure-Based Representation for Music-Based Data Streams.",
+    "pages": "337-343",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/020_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Kinnaird16"
+  },
+  "conf/ismir/Rodriguez-Algarra16": {
+    "@key": "conf/ismir/Rodriguez-Algarra16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Francisco Rodr\u00edguez-Algarra",
+      "Bob L. Sturm",
+      "Hugo Maruri-Aguilar"
+    ],
+    "title": "Analysing Scattering-Based Music Content Analysis Systems: Where's the Music?.",
+    "pages": "344-350",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/146_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Rodriguez-Algarra16"
+  },
+  "conf/ismir/Elowsson16": {
+    "@key": "conf/ismir/Elowsson16",
+    "@mdate": "2016-09-08",
+    "author": "Anders Elowsson",
+    "title": "Beat Tracking with a Cepstroid Invariant Neural Network.",
+    "pages": "351-357",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/252_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Elowsson16"
+  },
+  "conf/ismir/Kruspe16": {
+    "@key": "conf/ismir/Kruspe16",
+    "@mdate": "2016-09-08",
+    "author": "Anna M. Kruspe",
+    "title": "Bootstrapping a System for Phoneme Recognition and Keyword Spotting in Unaccompanied Singing.",
+    "pages": "358-364",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/070_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Kruspe16"
+  },
+  "conf/ismir/ZangerlePHS16": {
+    "@key": "conf/ismir/ZangerlePHS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Eva Zangerle",
+      "Martin Pichl",
+      "Benedikt Hupfauf",
+      "G\u00fcnther Specht"
+    ],
+    "title": "Can Microblogs Predict Music Charts? An Analysis of the Relationship Between #Nowplaying Tweets and Music Charts.",
+    "pages": "365-371",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/039_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#ZangerlePHS16"
+  },
+  "conf/ismir/ScholzRC16": {
+    "@key": "conf/ismir/ScholzRC16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Ricardo Scholz",
+      "Geber Ramalho",
+      "Giordano Cabral"
+    ],
+    "title": "Cross Task Study on MIREX Recent Results: An Index for Evolution Measurement and Some Stagnation Hypotheses.",
+    "pages": "372-378",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/054_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#ScholzRC16"
+  },
+  "conf/ismir/BogdanovPHS16": {
+    "@key": "conf/ismir/BogdanovPHS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Dmitry Bogdanov",
+      "Alastair Porter",
+      "Perfecto Herrera",
+      "Xavier Serra"
+    ],
+    "title": "Cross-Collection Evaluation for Music Classification Tasks.",
+    "pages": "379-385",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/220_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#BogdanovPHS16"
+  },
+  "conf/ismir/DurandE16": {
+    "@key": "conf/ismir/DurandE16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Simon Durand",
+      "Slim Essid"
+    ],
+    "title": "Downbeat Detection with Conditional Random Fields and Deep Learned Features.",
+    "pages": "386-392",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/213_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#DurandE16"
+  },
+  "conf/ismir/SuCY16": {
+    "@key": "conf/ismir/SuCY16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Li Su",
+      "Tsung-Ying Chuang",
+      "Yi-Hsuan Yang"
+    ],
+    "title": "Exploiting Frequency, Periodicity and Harmonicity Using Advanced Time-Frequency Concentration Techniques for Multipitch Estimation of Choir and Symphony.",
+    "pages": "393-399",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/104_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#SuCY16"
+  },
+  "conf/ismir/Schreiber16": {
+    "@key": "conf/ismir/Schreiber16",
+    "@mdate": "2016-09-08",
+    "author": "Hendrik Schreiber",
+    "title": "Genre Ontology Learning: Comparing Curated with Crowd-Sourced Ontologies.",
+    "pages": "400-406",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/074_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Schreiber16"
+  },
+  "conf/ismir/LarochePKR16": {
+    "@key": "conf/ismir/LarochePKR16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Clement Laroche",
+      "H\u00e9l\u00e8ne Papadopoulos",
+      "Matthieu Kowalski",
+      "Ga\u00ebl Richard"
+    ],
+    "title": "Genre Specific Dictionaries for Harmonic/Percussive Source Separation.",
+    "pages": "407-413",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/042_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#LarochePKR16"
+  },
+  "conf/ismir/BandieraPTHOS16": {
+    "@key": "conf/ismir/BandieraPTHOS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Giuseppe Bandiera",
+      "Oriol Romani Picas",
+      "Hiroshi Tokuda",
+      "Wataru Hariya",
+      "Koji Oishi",
+      "Xavier Serra"
+    ],
+    "title": "Good-sounds.org: A Framework to Explore Goodness in Instrumental Sounds.",
+    "pages": "414-419",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/199_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#BandieraPTHOS16"
+  },
+  "conf/ismir/HedgesW16": {
+    "@key": "conf/ismir/HedgesW16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Thomas Hedges",
+      "Geraint A. Wiggins"
+    ],
+    "title": "Improving Predictions of Derived Viewpoints in Multiple Viewpoints Systems.",
+    "pages": "420-426",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/208_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#HedgesW16"
+  },
+  "conf/ismir/TsaiPM16": {
+    "@key": "conf/ismir/TsaiPM16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "T. J. Tsai",
+      "Thomas Pr\u00e4tzlich",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Known Artist Live Song ID: A Hashprint Approach.",
+    "pages": "427-433",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/098_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#TsaiPM16"
+  },
+  "conf/ismir/JeongL16": {
+    "@key": "conf/ismir/JeongL16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Il-Young Jeong",
+      "Kyogu Lee"
+    ],
+    "title": "Learning Temporal Features Using a Deep Neural Network and its Application to Music Genre Classification.",
+    "pages": "434-440",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/159_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#JeongL16"
+  },
+  "conf/ismir/HaasV16": {
+    "@key": "conf/ismir/HaasV16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "W. Bas de Haas",
+      "Anja Volk"
+    ],
+    "title": "Meter Detection in Symbolic Music Using Inner Metric Analysis.",
+    "pages": "441-447",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/033_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#HaasV16"
+  },
+  "conf/ismir/HoriS16": {
+    "@key": "conf/ismir/HoriS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Gen Hori",
+      "Shigeki Sagayama"
+    ],
+    "title": "Minimax Viterbi Algorithm for HMM-Based Guitar Fingering Decision.",
+    "pages": "448-453",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/285_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#HoriS16"
+  },
+  "conf/ismir/CardosoPHGGS16": {
+    "@key": "conf/ismir/CardosoPHGGS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Jo\u00e3o Paulo V. Cardoso",
+      "Luciana Fujii Pontello",
+      "Pedro H. F. Holanda",
+      "Bruno Guilherme",
+      "Olga Goussevskaia",
+      "Ana Paula Couto da Silva"
+    ],
+    "title": "Mixtape: Direction-Based Navigation in Large Media Collections.",
+    "pages": "454-460",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/155_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#CardosoPHGGS16"
+  },
+  "conf/ismir/NishikimiNIY16": {
+    "@key": "conf/ismir/NishikimiNIY16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Ryo Nishikimi",
+      "Eita Nakamura",
+      "Katsutoshi Itoyama",
+      "Kazuyoshi Yoshii"
+    ],
+    "title": "Musical Note Estimation for F0 Trajectories of Singing Voices Based on a Bayesian Semi-Beat-Synchronous HMM.",
+    "pages": "461-467",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/004_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#NishikimiNIY16"
+  },
+  "conf/ismir/PanteliD16": {
+    "@key": "conf/ismir/PanteliD16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Maria Panteli",
+      "Simon Dixon"
+    ],
+    "title": "On the Evaluation of Rhythmic and Melodic Descriptors for Music Similarity.",
+    "pages": "468-474",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/161_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#PanteliD16"
+  },
+  "conf/ismir/KelzDKBAW16": {
+    "@key": "conf/ismir/KelzDKBAW16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Rainer Kelz",
+      "Matthias Dorfer",
+      "Filip Korzeniowski",
+      "Sebastian B\u00f6ck",
+      "Andreas Arzt",
+      "Gerhard Widmer"
+    ],
+    "title": "On the Potential of Simple Framewise Approaches to Piano Transcription.",
+    "pages": "475-481",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/179_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#KelzDKBAW16"
+  },
+  "conf/ismir/GregorioK16": {
+    "@key": "conf/ismir/GregorioK16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Jeff Gregorio",
+      "Youngmoo Kim"
+    ],
+    "title": "Phrase-Level Audio Segmentation of Jazz Improvisations Informed by Symbolic Data.",
+    "pages": "482-487",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/245_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#GregorioK16"
+  },
+  "conf/ismir/Sturm16": {
+    "@key": "conf/ismir/Sturm16",
+    "@mdate": "2016-09-08",
+    "author": "Bob L. Sturm",
+    "title": "Revisiting Priorities: Improving MIR Evaluation Practices.",
+    "pages": "488-494",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/128_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Sturm16"
+  },
+  "conf/ismir/SeetharamanP16": {
+    "@key": "conf/ismir/SeetharamanP16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Prem Seetharaman",
+      "Bryan Pardo"
+    ],
+    "title": "Simultaneous Separation and Segmentation in Layered Music.",
+    "pages": "495-501",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/057_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#SeetharamanP16"
+  },
+  "conf/ismir/Lopez-SerranoDD16": {
+    "@key": "conf/ismir/Lopez-SerranoDD16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Patricio L\u00f3pez-Serrano",
+      "Christian Dittmar",
+      "Jonathan Driedger",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Towards Modeling and Decomposing Loop-Based Electronic Music.",
+    "pages": "502-508",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/065_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Lopez-SerranoDD16"
+  },
+  "conf/ismir/Calvo-ZaragozaR16": {
+    "@key": "conf/ismir/Calvo-ZaragozaR16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Jorge Calvo-Zaragoza",
+      "David Rizo",
+      "Jos\u00e9 Manuel I\u00f1esta Quereda"
+    ],
+    "title": "Two (Note) Heads Are Better Than One: Pen-Based Multimodal Interaction with Music Scores.",
+    "pages": "509-514",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/006_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Calvo-ZaragozaR16"
+  },
+  "conf/ismir/WeissAPKM16": {
+    "@key": "conf/ismir/WeissAPKM16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Christof Wei\u00df",
+      "Vlora Arifi-M\u00fcller",
+      "Thomas Pr\u00e4tzlich",
+      "Rainer Kleinertz",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Analyzing Measure Annotations for Western Classical Music Recordings.",
+    "pages": "517-523",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/079_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#WeissAPKM16"
+  },
+  "conf/ismir/LewisCM16": {
+    "@key": "conf/ismir/LewisCM16",
+    "@mdate": "2017-09-12",
+    "author": [
+      "David Lewis 0001",
+      "Tim Crawford",
+      "Daniel M\u00fcllensiefen"
+    ],
+    "title": "Instrumental Idiom in the 16th Century: Embellishment Patterns in Arrangements of Vocal Music.",
+    "pages": "524-530",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/165_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#LewisCM16"
+  },
+  "conf/ismir/HolzapfelB16": {
+    "@key": "conf/ismir/HolzapfelB16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Andre Holzapfel",
+      "Emmanouil Benetos"
+    ],
+    "title": "The Sousta Corpus: Beat-Informed Automatic Transcription of Traditional Dance Tunes.",
+    "pages": "531-537",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/156_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#HolzapfelB16"
+  },
+  "conf/ismir/PanteliBD16": {
+    "@key": "conf/ismir/PanteliBD16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Maria Panteli",
+      "Emmanouil Benetos",
+      "Simon Dixon"
+    ],
+    "title": "Learning a Feature Space for Similarity in World Music.",
+    "pages": "538-544",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/166_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#PanteliBD16"
+  },
+  "conf/ismir/NietoB16": {
+    "@key": "conf/ismir/NietoB16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Oriol Nieto",
+      "Juan Pablo Bello"
+    ],
+    "title": "Systematic Exploration of Computational Music Structure Research.",
+    "pages": "547-553",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/043_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#NietoB16"
+  },
+  "conf/ismir/SmithG16": {
+    "@key": "conf/ismir/SmithG16",
+    "@mdate": "2017-09-07",
+    "author": [
+      "Jordan B. L. Smith",
+      "Masataka Goto"
+    ],
+    "title": "Using Priors to Improve Estimates of Music Structure.",
+    "pages": "554-560",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/135_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#SmithG16"
+  },
+  "conf/ismir/TianS16": {
+    "@key": "conf/ismir/TianS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Mi Tian",
+      "Mark B. Sandler"
+    ],
+    "title": "Music Structural Segmentation Across Genres with Gammatone Features.",
+    "pages": "561-567",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/032_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#TianS16"
+  },
+  "conf/ismir/BoschBSG16": {
+    "@key": "conf/ismir/BoschBSG16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Juan J. Bosch",
+      "Rachel M. Bittner",
+      "Justin Salamon",
+      "Emilia G\u00f3mez"
+    ],
+    "title": "A Comparison of Melody Extraction Methods Based on Source-Filter Modelling.",
+    "pages": "571-577",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/256_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#BoschBSG16"
+  },
+  "conf/ismir/SchedlEGT16": {
+    "@key": "conf/ismir/SchedlEGT16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Markus Schedl",
+      "Hamid Eghbal-Zadeh",
+      "Emilia G\u00f3mez",
+      "Marko Tkalcic"
+    ],
+    "title": "An Analysis of Agreement in Classical Music Perception and its Relationship to Listener Characteristics.",
+    "pages": "578-583",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/260_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#SchedlEGT16"
+  },
+  "conf/ismir/0001MBD16": {
+    "@key": "conf/ismir/0001MBD16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Tian Cheng 0001",
+      "Matthias Mauch",
+      "Emmanouil Benetos",
+      "Simon Dixon"
+    ],
+    "title": "An Attack/Decay Model for Piano Transcription.",
+    "pages": "584-590",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/085_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#0001MBD16"
+  },
+  "conf/ismir/SouthallSH16": {
+    "@key": "conf/ismir/SouthallSH16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Carl Southall",
+      "Ryan Stables",
+      "Jason Hockman"
+    ],
+    "title": "Automatic Drum Transcription Using Bi-Directional Recurrent Neural Networks.",
+    "pages": "591-597",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/217_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#SouthallSH16"
+  },
+  "conf/ismir/WintersGL16": {
+    "@key": "conf/ismir/WintersGL16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "R. Michael Winters",
+      "Siddharth Gururani",
+      "Alexander Lerch"
+    ],
+    "title": "Automatic Practice Logging: Introduction, Dataset & Preliminary Study.",
+    "pages": "598-604",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/181_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#WintersGL16"
+  },
+  "conf/ismir/GanguliGSR16": {
+    "@key": "conf/ismir/GanguliGSR16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Kaustuv Kanti Ganguli",
+      "Sankalp Gulati",
+      "Xavier Serra",
+      "Preeti Rao"
+    ],
+    "title": "Data-Driven Exploration of Melodic Structure in Hindustani Music.",
+    "pages": "605-611",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/121_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#GanguliGSR16"
+  },
+  "conf/ismir/LostanlenC16": {
+    "@key": "conf/ismir/LostanlenC16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Vincent Lostanlen",
+      "Carmine-Emanuele Cella"
+    ],
+    "title": "Deep Convolutional Networks on the Pitch Spiral For Music Instrument Recognition.",
+    "pages": "612-618",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/093_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#LostanlenC16"
+  },
+  "conf/ismir/Stasiak16": {
+    "@key": "conf/ismir/Stasiak16",
+    "@mdate": "2016-09-08",
+    "author": "Bartlomiej Stasiak",
+    "title": "DTV-Based Melody Cutting for DTW-Based Melody Search and Indexing in QbH Systems.",
+    "pages": "619-625",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/089_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Stasiak16"
+  },
+  "conf/ismir/FullerHKL16": {
+    "@key": "conf/ismir/FullerHKL16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "John Fuller",
+      "Lauren Hubener",
+      "Yea-Seul Kim",
+      "Jin Ha Lee"
+    ],
+    "title": "Elucidating User Behavior in Music Services Through Persona and Gender.",
+    "pages": "626-632",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/205_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#FullerHKL16"
+  },
+  "conf/ismir/AndradeF16": {
+    "@key": "conf/ismir/AndradeF16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Nazareno Andrade",
+      "Flavio Figueiredo"
+    ],
+    "title": "Exploring the Latent Structure of Collaborations in Music Recordings: A Case Study in Jazz.",
+    "pages": "633-639",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/251_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#AndradeF16"
+  },
+  "conf/ismir/Kirlin16": {
+    "@key": "conf/ismir/Kirlin16",
+    "@mdate": "2016-09-08",
+    "author": "Phillip B. Kirlin",
+    "title": "Global Properties of Expert and Algorithmic Hierarchical Music Analyses.",
+    "pages": "640-646",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/259_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Kirlin16"
+  },
+  "conf/ismir/ChenSR16": {
+    "@key": "conf/ismir/ChenSR16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Liang Chen",
+      "Erik Stolterman",
+      "Christopher Raphael"
+    ],
+    "title": "Human-Interactive Optical Music Recognition.",
+    "pages": "647-653",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/106_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#ChenSR16"
+  },
+  "conf/ismir/AthertonK16": {
+    "@key": "conf/ismir/AthertonK16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Jack Atherton",
+      "Blair Kaneshiro"
+    ],
+    "title": "I Said it First: Topological Analysis of Lyrical Influence Networks.",
+    "pages": "654-660",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/221_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#AthertonK16"
+  },
+  "conf/ismir/LiebmanSW16": {
+    "@key": "conf/ismir/LiebmanSW16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Elad Liebman",
+      "Peter Stone",
+      "Corey N. White"
+    ],
+    "title": "Impact of Music on Decision Making in Quantitative Tasks.",
+    "pages": "661-667",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/272_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#LiebmanSW16"
+  },
+  "conf/ismir/WaloschekBBH16": {
+    "@key": "conf/ismir/WaloschekBBH16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Simon Waloschek",
+      "Axel Berndt",
+      "Benjamin W. Bohl",
+      "Aristotelis Hadjakos"
+    ],
+    "title": "Interactive Scores in Classical Music Production.",
+    "pages": "668-673",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/192_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#WaloschekBBH16"
+  },
+  "conf/ismir/BantulaGR16": {
+    "@key": "conf/ismir/BantulaGR16",
+    "@mdate": "2018-08-19",
+    "author": [
+      "Helena Bantul\u00e0",
+      "Sergio I. Giraldo",
+      "Rafael Ram\u00edrez 0001"
+    ],
+    "title": "Jazz Ensemble Expressive Performance Modeling.",
+    "pages": "674-680",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/162_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#BantulaGR16"
+  },
+  "conf/ismir/ShanahanNC16": {
+    "@key": "conf/ismir/ShanahanNC16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Daniel Shanahan",
+      "Kerstin Neubarth",
+      "Darrell Conklin"
+    ],
+    "title": "Mining Musical Traits of Social Functions in Native American Music.",
+    "pages": "681-687",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/167_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#ShanahanNC16"
+  },
+  "conf/ismir/FigueiredoRFAA16": {
+    "@key": "conf/ismir/FigueiredoRFAA16",
+    "@mdate": "2017-06-28",
+    "author": [
+      "Flavio Figueiredo",
+      "Bruno Ribeiro 0001",
+      "Christos Faloutsos",
+      "Nazareno Andrade",
+      "Jussara M. Almeida"
+    ],
+    "title": "Mining Online Music Listening Trajectories.",
+    "pages": "688-694",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/193_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#FigueiredoRFAA16"
+  },
+  "conf/ismir/NakanoMYG16": {
+    "@key": "conf/ismir/NakanoMYG16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Tomoyasu Nakano",
+      "Daichi Mochihashi",
+      "Kazuyoshi Yoshii",
+      "Masataka Goto"
+    ],
+    "title": "Musical Typicality: How Many Similar Songs Exist?.",
+    "pages": "695-701",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/191_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#NakanoMYG16"
+  },
+  "conf/ismir/HyrkasH16": {
+    "@key": "conf/ismir/HyrkasH16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Jeremy Hyrkas",
+      "Bill Howe"
+    ],
+    "title": "MusicDB: A Platform for Longitudinal Music Analytics.",
+    "pages": "702-708",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/284_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#HyrkasH16"
+  },
+  "conf/ismir/Eghbal-zadehW16": {
+    "@key": "conf/ismir/Eghbal-zadehW16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Hamid Eghbal-zadeh",
+      "Gerhard Widmer"
+    ],
+    "title": "Noise Robust Music Artist Recognition Using I-Vector Features.",
+    "pages": "709-715",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/037_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Eghbal-zadehW16"
+  },
+  "conf/ismir/DzhambazovSSS16": {
+    "@key": "conf/ismir/DzhambazovSSS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Georgi Dzhambazov",
+      "Ajay Srinivasamurthy",
+      "Sertan Sent\u00fcrk",
+      "Xavier Serra"
+    ],
+    "title": "On the Use of Note Onsets for Improved Lyrics-To-Audio Alignment in Turkish Makam Music.",
+    "pages": "716-722",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/243_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#DzhambazovSSS16"
+  },
+  "conf/ismir/Fournier-Sniehotta16": {
+    "@key": "conf/ismir/Fournier-Sniehotta16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Rapha\u00ebl Fournier-S'niehotta",
+      "Philippe Rigaux",
+      "Nicolas Travers"
+    ],
+    "title": "Querying XML Score Databases: XQuery is not Enough!.",
+    "pages": "723-729",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/136_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Fournier-Sniehotta16"
+  },
+  "conf/ismir/VoglDK16": {
+    "@key": "conf/ismir/VoglDK16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Richard Vogl",
+      "Matthias Dorfer",
+      "Peter Knees"
+    ],
+    "title": "Recurrent Neural Networks for Drum Transcription.",
+    "pages": "730-736",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/269_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#VoglDK16"
+  },
+  "conf/ismir/RigaudR16": {
+    "@key": "conf/ismir/RigaudR16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Fran\u00e7ois Rigaud",
+      "Mathieu Radenen"
+    ],
+    "title": "Singing Voice Melody Transcription Using Deep Neural Networks.",
+    "pages": "737-743",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/163_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#RigaudR16"
+  },
+  "conf/ismir/HsuLC16": {
+    "@key": "conf/ismir/HsuLC16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Kai-Chun Hsu",
+      "Chih-Shan Lin",
+      "Tai-Shih Chi"
+    ],
+    "title": "Sparse Coding Based Music Genre Classification Using Spectro-Temporal Modulations.",
+    "pages": "744-750",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/046_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#HsuLC16"
+  },
+  "conf/ismir/GulatiSGSS16": {
+    "@key": "conf/ismir/GulatiSGSS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Sankalp Gulati",
+      "Joan Serr\u00e0",
+      "Kaustuv Kanti Ganguli",
+      "Sertan Sent\u00fcrk",
+      "Xavier Serra"
+    ],
+    "title": "Time-Delayed Melody Surfaces for R\u0101ga Recognition.",
+    "pages": "751-757",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/030_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#GulatiSGSS16"
+  },
+  "conf/ismir/CogliatiTD16": {
+    "@key": "conf/ismir/CogliatiTD16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Andrea Cogliati",
+      "David Temperley",
+      "Zhiyao Duan"
+    ],
+    "title": "Transcribing Human Piano Performances into Music Notation.",
+    "pages": "758-764",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/088_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#CogliatiTD16"
+  },
+  "conf/ismir/HuCLLHCD16": {
+    "@key": "conf/ismir/HuCLLHCD16",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "Kahyun Choi",
+      "Jin Ha Lee",
+      "Audrey Laplante",
+      "Yun Hao",
+      "Sally Jo Cunningham",
+      "J. Stephen Downie"
+    ],
+    "title": "WiMIR: An Informetric Study On Women Authors In ISMIR.",
+    "pages": "765-771",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/283_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#HuCLLHCD16"
+  },
+  "conf/ismir/Groves16": {
+    "@key": "conf/ismir/Groves16",
+    "@mdate": "2016-09-08",
+    "author": "Ryan Groves",
+    "title": "Automatic Melodic Reduction Using a Supervised Probabilistic Context-Free Grammar.",
+    "pages": "775-781",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/274_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#Groves16"
+  },
+  "conf/ismir/GrayB16": {
+    "@key": "conf/ismir/GrayB16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Patrick Gray",
+      "Razvan C. Bunescu"
+    ],
+    "title": "A Neural Greedy Model for Voice Separation in Symbolic Music.",
+    "pages": "782-788",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/296_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#GrayB16"
+  },
+  "conf/ismir/DorferAW16": {
+    "@key": "conf/ismir/DorferAW16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Matthias Dorfer",
+      "Andreas Arzt",
+      "Gerhard Widmer"
+    ],
+    "title": "Towards Score Following In Sheet Music Images.",
+    "pages": "789-795",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/027_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#DorferAW16"
+  },
+  "conf/ismir/RaffelE16": {
+    "@key": "conf/ismir/RaffelE16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Colin Raffel",
+      "Daniel P. W. Ellis"
+    ],
+    "title": "Extracting Ground-Truth Information from MIDI Files: A MIDIfesto.",
+    "pages": "796-802",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/105_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#RaffelE16"
+  },
+  "conf/ismir/ChoiFS16": {
+    "@key": "conf/ismir/ChoiFS16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Keunwoo Choi",
+      "Gy\u00f6rgy Fazekas",
+      "Mark B. Sandler"
+    ],
+    "title": "Automatic Tagging Using Deep Convolutional Neural Networks.",
+    "pages": "805-811",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/009_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#ChoiFS16"
+  },
+  "conf/ismir/DengK16": {
+    "@key": "conf/ismir/DengK16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Jun-qi Deng",
+      "Yu-Kwong Kwok"
+    ],
+    "title": "A Hybrid Gaussian-HMM-Deep Learning Approach for Automatic Chord Estimation with Very Large Vocabulary.",
+    "pages": "812-818",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/058_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#DengK16"
+  },
+  "conf/ismir/KumON16": {
+    "@key": "conf/ismir/KumON16",
+    "@mdate": "2016-09-08",
+    "author": [
+      "Sangeun Kum",
+      "Changheun Oh",
+      "Juhan Nam"
+    ],
+    "title": "Melody Extraction on Vocal Segments Using Multi-Column Deep Neural Networks.",
+    "pages": "819-825",
+    "year": "2016",
+    "booktitle": "ISMIR",
+    "ee": "https://wp.nyu.edu/ismir2016/wp-content/uploads/sites/2294/2016/07/119_Paper.pdf",
+    "crossref": "conf/ismir/2016",
+    "url": "db/conf/ismir/ismir2016.html#KumON16"
+  },
+  "conf/ismir/OramasNBS17": {
+    "@key": "conf/ismir/OramasNBS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Sergio Oramas",
+      "Oriol Nieto",
+      "Francesco Barbieri",
+      "Xavier Serra"
+    ],
+    "title": "Multi-Label Music Genre Classification from Audio, Text and Images Using Deep Features.",
+    "pages": "23-30",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#OramasNBS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/126_Paper.pdf"
+  },
+  "conf/ismir/EnsRP17": {
+    "@key": "conf/ismir/EnsRP17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jeff Ens",
+      "Bernhard E. Riecke",
+      "Philippe Pasquier"
+    ],
+    "title": "The Significance of the Low Complexity Dimension in Music Similarity Judgements.",
+    "pages": "31-38",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#EnsRP17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/79_Paper.pdf"
+  },
+  "conf/ismir/GanguliR17": {
+    "@key": "conf/ismir/GanguliR17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Kaustuv Kanti Ganguli",
+      "Preeti Rao"
+    ],
+    "title": "Towards Computational Modeling of the Ungrammatical in a Raga Performance.",
+    "pages": "39-45",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#GanguliR17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/89_Paper.pdf"
+  },
+  "conf/ismir/RepettoS17": {
+    "@key": "conf/ismir/RepettoS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Rafael Caro Repetto",
+      "Xavier Serra"
+    ],
+    "title": "A Collection of Music Scores for Corpus Based Jingju Singing Research.",
+    "pages": "46-52",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#RepettoS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/119_Paper.pdf"
+  },
+  "conf/ismir/MironJG17": {
+    "@key": "conf/ismir/MironJG17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Marius Miron",
+      "Jordi Janer",
+      "Emilia G\u00f3mez"
+    ],
+    "title": "Monaural Score-Informed Source Separation for Classical Music Using Convolutional Neural Networks.",
+    "pages": "55-62",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#MironJG17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/51_Paper.pdf"
+  },
+  "conf/ismir/BittnerMSLB17": {
+    "@key": "conf/ismir/BittnerMSLB17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Rachel M. Bittner",
+      "Brian McFee",
+      "Justin Salamon",
+      "Peter Li",
+      "Juan Pablo Bello"
+    ],
+    "title": "Deep Salience Representations for F0 Estimation in Polyphonic Music.",
+    "pages": "63-70",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#BittnerMSLB17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/85_Paper.pdf"
+  },
+  "conf/ismir/SalamonBBBGB17": {
+    "@key": "conf/ismir/SalamonBBBGB17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Justin Salamon",
+      "Rachel M. Bittner",
+      "Jordi Bonada",
+      "Juan J. Bosch",
+      "Emilia G\u00f3mez",
+      "Juan Pablo Bello"
+    ],
+    "title": "An Analysis/Synthesis Framework for Automatic F0 Annotation of Multitrack Datasets.",
+    "pages": "71-78",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SalamonBBBGB17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/164_Paper.pdf"
+  },
+  "conf/ismir/TsaiTM17": {
+    "@key": "conf/ismir/TsaiTM17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "T. J. Tsai",
+      "Steven K. Tjoa",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Make Your Own Accompaniment: Adapting Full-Mix Recordings to Match Solo-Only User Recordings.",
+    "pages": "79-86",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#TsaiTM17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/220_Paper.pdf"
+  },
+  "conf/ismir/BogdanovS17": {
+    "@key": "conf/ismir/BogdanovS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Dmitry Bogdanov",
+      "Xavier Serra"
+    ],
+    "title": "Quantifying Music Trends and Facts Using Editorial Metadata from the Discogs Database.",
+    "pages": "89-95",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#BogdanovS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/172_Paper.pdf"
+  },
+  "conf/ismir/VigliensoniF17": {
+    "@key": "conf/ismir/VigliensoniF17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Gabriel Vigliensoni",
+      "Ichiro Fujinaga"
+    ],
+    "title": "The Music Listening Histories Dataset.",
+    "pages": "96-102",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#VigliensoniF17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/180_Paper.pdf"
+  },
+  "conf/ismir/LiuHS17": {
+    "@key": "conf/ismir/LiuHS17",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Meijun Liu",
+      "Xiao Hu 0001",
+      "Markus Schedl"
+    ],
+    "title": "Artist Preferences and Cultural, Socio-Economic Distances Across Countries: A Big Data Perspective.",
+    "pages": "103-111",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#LiuHS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/234_Paper.pdf"
+  },
+  "conf/ismir/DorferAW17": {
+    "@key": "conf/ismir/DorferAW17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Matthias Dorfer",
+      "Andreas Arzt",
+      "Gerhard Widmer"
+    ],
+    "title": "Learning Audio-Sheet Music Correspondences for Score Identification and Offline Alignment.",
+    "pages": "115-122",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#DorferAW17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/32_Paper.pdf"
+  },
+  "conf/ismir/LiDSD17": {
+    "@key": "conf/ismir/LiDSD17",
+    "@mdate": "2018-08-23",
+    "author": [
+      "Bochen Li",
+      "Karthik Dinesh",
+      "Gaurav Sharma 0001",
+      "Zhiyao Duan"
+    ],
+    "title": "Video-Based Vibrato Detection and Analysis for Polyphonic String Music.",
+    "pages": "123-130",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#LiDSD17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/105_Paper.pdf"
+  },
+  "conf/ismir/GangKBD17": {
+    "@key": "conf/ismir/GangKBD17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Nick Gang",
+      "Blair Kaneshiro",
+      "Jonathan Berger",
+      "Jacek P. Dmochowski"
+    ],
+    "title": "Decoding Neurally Relevant Musical Features Using Canonical Correlation Analysis.",
+    "pages": "131-138",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#GangKBD17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/184_Paper.pdf"
+  },
+  "conf/ismir/ChoiFSC17": {
+    "@key": "conf/ismir/ChoiFSC17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Keunwoo Choi",
+      "Gy\u00f6rgy Fazekas",
+      "Mark B. Sandler",
+      "Kyunghyun Cho"
+    ],
+    "title": "Transfer Learning for Music Classification and Regression Tasks.",
+    "pages": "141-149",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#ChoiFSC17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/12_Paper.pdf"
+  },
+  "conf/ismir/VoglDWK17": {
+    "@key": "conf/ismir/VoglDWK17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Richard Vogl",
+      "Matthias Dorfer",
+      "Gerhard Widmer",
+      "Peter Knees"
+    ],
+    "title": "Drum Transcription via Joint Beat and Drum Modeling Using Convolutional Recurrent Neural Networks.",
+    "pages": "150-157",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#VoglDWK17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/123_Paper.pdf"
+  },
+  "conf/ismir/PeperkampHL17": {
+    "@key": "conf/ismir/PeperkampHL17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jeroen Peperkamp",
+      "Klaus Hildebrandt",
+      "Cynthia C. S. Liem"
+    ],
+    "title": "A Formalization of Relative Local Tempo Variations in Collections of Performances.",
+    "pages": "158-164",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#PeperkampHL17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/176_Paper.pdf"
+  },
+  "conf/ismir/PachetPR17": {
+    "@key": "conf/ismir/PachetPR17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Fran\u00e7ois Pachet",
+      "Alexandre Papadopoulos",
+      "Pierre Roy"
+    ],
+    "title": "Sampling Variations of Sequences for Structured Music Generation.",
+    "pages": "167-173",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#PachetPR17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/50_Paper.pdf"
+  },
+  "conf/ismir/RanjaniPS17": {
+    "@key": "conf/ismir/RanjaniPS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "H. G. Ranjani",
+      "Deepak Paramashivan",
+      "Thippur V. Sreenivas"
+    ],
+    "title": "Quantized Melodic Contours in Indian Art Music Perception: Application to Transcription.",
+    "pages": "174-180",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#RanjaniPS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/61_Paper.pdf"
+  },
+  "conf/ismir/LouboutinB17": {
+    "@key": "conf/ismir/LouboutinB17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Corentin Louboutin",
+      "Fr\u00e9d\u00e9ric Bimbot"
+    ],
+    "title": "Modeling the Multiscale Structure of Chord Sequences Using Polytopic Graphs.",
+    "pages": "181-187",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#LouboutinB17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/70_Paper.pdf"
+  },
+  "conf/ismir/McFeeB17": {
+    "@key": "conf/ismir/McFeeB17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Brian McFee",
+      "Juan Pablo Bello"
+    ],
+    "title": "Structured Training for Large-Vocabulary Chord Recognition.",
+    "pages": "188-194",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#McFeeB17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/77_Paper.pdf"
+  },
+  "conf/ismir/ShiAS17": {
+    "@key": "conf/ismir/ShiAS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Zhengshan Shi",
+      "Kumaran Arul",
+      "Julius O. Smith"
+    ],
+    "title": "Modeling and Digitizing Reproducing Piano Rolls.",
+    "pages": "197-203",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#ShiAS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/25_Paper.pdf"
+  },
+  "conf/ismir/KranenburgM17": {
+    "@key": "conf/ismir/KranenburgM17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Peter van Kranenburg",
+      "Geert Maessen"
+    ],
+    "title": "Comparing Offertory Melodies of Five Medieval Christian Chant Traditions.",
+    "pages": "204-210",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#KranenburgM17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/174_Paper.pdf"
+  },
+  "conf/ismir/HuangCRCE17": {
+    "@key": "conf/ismir/HuangCRCE17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Cheng-Zhi Anna Huang",
+      "Tim Cooijmans",
+      "Adam Roberts",
+      "Aaron C. Courville",
+      "Douglas Eck"
+    ],
+    "title": "Counterpoint by Convolution.",
+    "pages": "211-218",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#HuangCRCE17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/187_Paper.pdf"
+  },
+  "conf/ismir/WeiglP17": {
+    "@key": "conf/ismir/WeiglP17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "David M. Weigl",
+      "Kevin R. Page"
+    ],
+    "title": "A Framework for Distributed Semantic Annotation of Musical Score: \"Take It to the Bridge!\".",
+    "pages": "221-228",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#WeiglP17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/190_Paper.pdf"
+  },
+  "conf/ismir/SuzukiK17": {
+    "@key": "conf/ismir/SuzukiK17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Junichi Suzuki",
+      "Tetsuro Kitahara"
+    ],
+    "title": "A Music Player with Song Selection Function for a Group of People.",
+    "pages": "229-234",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SuzukiK17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/112_Paper.pdf"
+  },
+  "conf/ismir/SchreiberM17": {
+    "@key": "conf/ismir/SchreiberM17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Hendrik Schreiber",
+      "Meinard M\u00fcller"
+    ],
+    "title": "A Post-Processing Procedure for Improving Music Tempo Estimates Using Supervised Learning.",
+    "pages": "235-242",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SchreiberM17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/137_Paper.pdf"
+  },
+  "conf/ismir/ViraraghavanAM17": {
+    "@key": "conf/ismir/ViraraghavanAM17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Venkata Subramanian Viraraghavan",
+      "Rangarajan Aravind",
+      "Hema A. Murthy"
+    ],
+    "title": "A Statistical Analysis of Gamakas in Carnatic Music.",
+    "pages": "243-249",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#ViraraghavanAM17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/82_Paper.pdf"
+  },
+  "conf/ismir/SyueSLLLWS17": {
+    "@key": "conf/ismir/SyueSLLLWS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jia-Ling Syue",
+      "Li Su",
+      "Yi-Ju Lin",
+      "Pei-Ching Li",
+      "Yen-Kuang Lu",
+      "Yu-Lin Wang",
+      "Alvin W. Y. Su"
+    ],
+    "title": "Accurate Audio-to-Score Alignment for Expressive Violin Recordings.",
+    "pages": "250-256",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SyueSLLLWS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/107_Paper.pdf"
+  },
+  "conf/ismir/NarangR17": {
+    "@key": "conf/ismir/NarangR17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Krish Narang",
+      "Preeti Rao"
+    ],
+    "title": "Acoustic Features for Determining Goodness of Tabla Strokes.",
+    "pages": "257-263",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#NarangR17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/30_Paper.pdf"
+  },
+  "conf/ismir/GururaniL17": {
+    "@key": "conf/ismir/GururaniL17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Siddharth Gururani",
+      "Alexander Lerch"
+    ],
+    "title": "Automatic Sample Detection in Polyphonic Music.",
+    "pages": "264-271",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#GururaniL17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/118_Paper.pdf"
+  },
+  "conf/ismir/MasadaB17": {
+    "@key": "conf/ismir/MasadaB17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Kristen Masada",
+      "Razvan C. Bunescu"
+    ],
+    "title": "Chord Recognition in Symbolic Music Using Semi-Markov Conditional Random Fields.",
+    "pages": "272-278",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#MasadaB17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/224_Paper.pdf"
+  },
+  "conf/ismir/PauwelsOFS17": {
+    "@key": "conf/ismir/PauwelsOFS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Johan Pauwels",
+      "Ken O'Hanlon",
+      "Gy\u00f6rgy Fazekas",
+      "Mark B. Sandler"
+    ],
+    "title": "Confidence Measures and Their Applications in Music Labelling Systems Based on Hidden Markov Models.",
+    "pages": "279-285",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#PauwelsOFS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/195_Paper.pdf"
+  },
+  "conf/ismir/GkiokasK17": {
+    "@key": "conf/ismir/GkiokasK17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Aggelos Gkiokas",
+      "Vassilios Katsouros"
+    ],
+    "title": "Convolutional Neural Networks for Real-Time Beat Tracking: A Dancing Robot Application.",
+    "pages": "286-293",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#GkiokasK17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/135_Paper.pdf"
+  },
+  "conf/ismir/Tralie17": {
+    "@key": "conf/ismir/Tralie17",
+    "@mdate": "2017-11-13",
+    "author": "Christopher J. Tralie",
+    "title": "Early MFCC and HPCP Fusion for Robust Cover Song Identification.",
+    "pages": "294-301",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#Tralie17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/219_Paper.pdf"
+  },
+  "conf/ismir/HuCHCLLBD17": {
+    "@key": "conf/ismir/HuCHCLLBD17",
+    "@mdate": "2018-05-28",
+    "author": [
+      "Xiao Hu 0001",
+      "Kahyun Choi",
+      "Yun Hao",
+      "Sally Jo Cunningham",
+      "Jin Ha Lee",
+      "Audrey Laplante",
+      "David Bainbridge 0001",
+      "J. Stephen Downie"
+    ],
+    "title": "Exploring the Music Library Association Mailing List: A Text Mining Approach.",
+    "pages": "302-308",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#HuCHCLLBD17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/192_Paper.pdf"
+  },
+  "conf/ismir/Maezawa17": {
+    "@key": "conf/ismir/Maezawa17",
+    "@mdate": "2017-11-13",
+    "author": "Akira Maezawa",
+    "title": "Fast and Accurate: Improving a Simple Beat Tracker with a Selectively-Applied Deep Beat Identification.",
+    "pages": "309-315",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#Maezawa17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/9_Paper.pdf"
+  },
+  "conf/ismir/DefferrardBVB17": {
+    "@key": "conf/ismir/DefferrardBVB17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Micha\u00ebl Defferrard",
+      "Kirell Benzi",
+      "Pierre Vandergheynst",
+      "Xavier Bresson"
+    ],
+    "title": "FMA: A Dataset for Music Analysis.",
+    "pages": "316-323",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#DefferrardBVB17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/75_Paper.pdf"
+  },
+  "conf/ismir/YangCY17": {
+    "@key": "conf/ismir/YangCY17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Li-Chia Yang",
+      "Szu-Yu Chou",
+      "Yi-Hsuan Yang"
+    ],
+    "title": "MidiNet: A Convolutional Generative Adversarial Network for Symbolic-Domain Music Generation.",
+    "pages": "324-331",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#YangCY17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/226_Paper.pdf"
+  },
+  "conf/ismir/SearsAFSW17": {
+    "@key": "conf/ismir/SearsAFSW17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "David R. W. Sears",
+      "Andreas Arzt",
+      "Harald Frostel",
+      "Reinhard Sonnleitner",
+      "Gerhard Widmer"
+    ],
+    "title": "Modeling Harmony with Skip-Grams.",
+    "pages": "332-338",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SearsAFSW17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/18_Paper.pdf"
+  },
+  "conf/ismir/LosorelliNDK17": {
+    "@key": "conf/ismir/LosorelliNDK17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Steven Losorelli",
+      "Duc T. Nguyen",
+      "Jacek P. Dmochowski",
+      "Blair Kaneshiro"
+    ],
+    "title": "NMED-T: A Tempo-Focused Dataset of Cortical and Behavioral Responses to Naturalistic Music.",
+    "pages": "339-346",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#LosorelliNDK17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/198_Paper.pdf"
+  },
+  "conf/ismir/NakamuraYK17": {
+    "@key": "conf/ismir/NakamuraYK17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Eita Nakamura",
+      "Kazuyoshi Yoshii",
+      "Haruhiro Katayose"
+    ],
+    "title": "Performance Error Detection and Post-Processing for Fast and Accurate Symbolic Music Alignment.",
+    "pages": "347-353",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#NakamuraYK17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/35_Paper.pdf"
+  },
+  "conf/ismir/ArztW17": {
+    "@key": "conf/ismir/ArztW17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Andreas Arzt",
+      "Gerhard Widmer"
+    ],
+    "title": "Piece Identification in Classical Piano Music Without Reference Scores.",
+    "pages": "354-360",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#ArztW17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/127_Paper.pdf"
+  },
+  "conf/ismir/SchnellSLB17": {
+    "@key": "conf/ismir/SchnellSLB17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Norbert Schnell",
+      "Diemo Schwarz",
+      "Joseph Larralde",
+      "Riccardo Borghesi"
+    ],
+    "title": "PiPo, a Plugin Interface for Afferent Data Stream Processing Operators.",
+    "pages": "361-367",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SchnellSLB17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/125_Paper.pdf"
+  },
+  "conf/ismir/FanTTP17": {
+    "@key": "conf/ismir/FanTTP17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jianyu Fan",
+      "Kivan\u00e7 Tatar",
+      "Miles Thorogood",
+      "Philippe Pasquier"
+    ],
+    "title": "Ranking-Based Emotion Recognition for Experimental Music.",
+    "pages": "368-375",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#FanTTP17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/217_Paper.pdf"
+  },
+  "conf/ismir/NishikimiNGIY17": {
+    "@key": "conf/ismir/NishikimiNGIY17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Ryo Nishikimi",
+      "Eita Nakamura",
+      "Masataka Goto",
+      "Katsutoshi Itoyama",
+      "Kazuyoshi Yoshii"
+    ],
+    "title": "Scale- and Rhythm-Aware Musical Note Estimation for Vocal F0 Trajectories Based on a Semi-Tatum-Synchronous Hierarchical Hidden Semi-Markov Model.",
+    "pages": "376-382",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#NishikimiNGIY17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/4_Paper.pdf"
+  },
+  "conf/ismir/PonsGS17": {
+    "@key": "conf/ismir/PonsGS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jordi Pons",
+      "Rong Gong",
+      "Xavier Serra"
+    ],
+    "title": "Score-Informed Syllable Segmentation for A Cappella Singing Voice with Convolutional Neural Networks.",
+    "pages": "383-389",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#PonsGS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/46_Paper.pdf"
+  },
+  "conf/ismir/GuptaGRW17": {
+    "@key": "conf/ismir/GuptaGRW17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Chitralekha Gupta",
+      "David Grunberg",
+      "Preeti Rao",
+      "Ye Wang"
+    ],
+    "title": "Towards Automatic Mispronunciation Detection in Singing.",
+    "pages": "390-396",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#GuptaGRW17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/56_Paper.pdf"
+  },
+  "conf/ismir/ZhangRS17": {
+    "@key": "conf/ismir/ZhangRS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Shuo Zhang",
+      "Rafael Caro Repetto",
+      "Xavier Serra"
+    ],
+    "title": "Understanding the Expressive Functions of Jingju Metrical Patterns Through Lyrics Text Mining.",
+    "pages": "397-403",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#ZhangRS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/215_Paper.pdf"
+  },
+  "conf/ismir/CogliatiD17": {
+    "@key": "conf/ismir/CogliatiD17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Andrea Cogliati",
+      "Zhiyao Duan"
+    ],
+    "title": "A Metric for Music Notation Transcription Accuracy.",
+    "pages": "407-413",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#CogliatiD17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/131_Paper.pdf"
+  },
+  "conf/ismir/OliveiraNMA17": {
+    "@key": "conf/ismir/OliveiraNMA17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Ricardo S. Oliveira",
+      "Caio N\u00f3brega",
+      "Leandro Balby Marinho",
+      "Nazareno Andrade"
+    ],
+    "title": "A Multiobjective Music Recommendation Approach for Aspect-Based Diversification.",
+    "pages": "414-420",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#OliveiraNMA17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/153_Paper.pdf"
+  },
+  "conf/ismir/YcartB17": {
+    "@key": "conf/ismir/YcartB17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Adrien Ycart",
+      "Emmanouil Benetos"
+    ],
+    "title": "A Study on LSTM Networks for Polyphonic Music Sequence Modelling.",
+    "pages": "421-427",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#YcartB17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/60_Paper.pdf"
+  },
+  "conf/ismir/GongPS17": {
+    "@key": "conf/ismir/GongPS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Rong Gong",
+      "Jordi Pons",
+      "Xavier Serra"
+    ],
+    "title": "Audio to Score Matching by Combining Phonetic and Duration Information.",
+    "pages": "428-434",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#GongPS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/45_Paper.pdf"
+  },
+  "conf/ismir/SmithC17": {
+    "@key": "conf/ismir/SmithC17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jordan B. L. Smith",
+      "Elaine Chew"
+    ],
+    "title": "Automatic Interpretation of Music Structure Analyses: A Validated Technique for Post-Hoc Estimation of the Rationale for an Annotation.",
+    "pages": "435-441",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SmithC17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/130_Paper.pdf"
+  },
+  "conf/ismir/BittnerGHHJMM17": {
+    "@key": "conf/ismir/BittnerGHHJMM17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Rachel M. Bittner",
+      "Minwei Gu",
+      "Gandalf Hernandez",
+      "Eric J. Humphrey",
+      "Tristan Jehan",
+      "Hunter McCurry",
+      "Nicola Montecchio"
+    ],
+    "title": "Automatic Playlist Sequencing and Transitions.",
+    "pages": "442-448",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#BittnerGHHJMM17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/86_Paper.pdf"
+  },
+  "conf/ismir/LiangG0S17": {
+    "@key": "conf/ismir/LiangG0S17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Feynman T. Liang",
+      "Mark Gotham",
+      "Matthew Johnson 0003",
+      "Jamie Shotton"
+    ],
+    "title": "Automatic Stylistic Composition of Bach Chorales with Deep LSTM.",
+    "pages": "449-456",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#LiangG0S17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/156_Paper.pdf"
+  },
+  "conf/ismir/LiDP17": {
+    "@key": "conf/ismir/LiDP17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Shengchen Li",
+      "Simon Dixon",
+      "Mark D. Plumbley"
+    ],
+    "title": "Clustering Expressive Timing with Regressed Polynomial Coefficients Demonstrated by a Model Selection Test.",
+    "pages": "457-463",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#LiDP17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/36_Paper.pdf"
+  },
+  "conf/ismir/FangGLW17": {
+    "@key": "conf/ismir/FangGLW17",
+    "@mdate": "2017-12-13",
+    "author": [
+      "Jiakun Fang",
+      "David Grunberg",
+      "Diane T. Litman",
+      "Ye Wang"
+    ],
+    "title": "Discourse Analysis of Lyric and Lyric-Based Classification of Music.",
+    "pages": "464-471",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#FangGLW17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/37_Paper.pdf"
+  },
+  "conf/ismir/Calvo-ZaragozaV17": {
+    "@key": "conf/ismir/Calvo-ZaragozaV17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jorge Calvo-Zaragoza",
+      "Jose J. Valero-Mas",
+      "Antonio Pertusa"
+    ],
+    "title": "End-to-End Optical Music Recognition Using Neural Networks.",
+    "pages": "472-477",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#Calvo-ZaragozaV17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/34_Paper.pdf"
+  },
+  "conf/ismir/ChungCC17": {
+    "@key": "conf/ismir/ChungCC17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Chia-Hao Chung",
+      "Yian Chen",
+      "Homer H. Chen"
+    ],
+    "title": "Exploiting Playlists for Representation of Songs and Words for Text-Based Music Retrieval.",
+    "pages": "478-485",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#ChungCC17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/47_Paper.pdf"
+  },
+  "conf/ismir/FonsecaPFFBFOPS17": {
+    "@key": "conf/ismir/FonsecaPFFBFOPS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Eduardo Fonseca",
+      "Jordi Pons",
+      "Xavier Favory",
+      "Frederic Font",
+      "Dmitry Bogdanov",
+      "Andres Ferraro",
+      "Sergio Oramas",
+      "Alastair Porter",
+      "Xavier Serra"
+    ],
+    "title": "Freesound Datasets: A Platform for the Creation of Open Audio Datasets.",
+    "pages": "486-493",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#FonsecaPFFBFOPS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/161_Paper.pdf"
+  },
+  "conf/ismir/ChaconGA17": {
+    "@key": "conf/ismir/ChaconGA17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Carlos Eduardo Cancino Chac\u00f3n",
+      "Maarten Grachten",
+      "Kat Agres"
+    ],
+    "title": "From Bach to the Beatles: The Simulation of Human Tonal Expectation Using Ecologically-Trained Predictive Models.",
+    "pages": "494-501",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#ChaconGA17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/129_Paper.pdf"
+  },
+  "conf/ismir/TsushimaNIY17": {
+    "@key": "conf/ismir/TsushimaNIY17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Hiroaki Tsushima",
+      "Eita Nakamura",
+      "Katsutoshi Itoyama",
+      "Kazuyoshi Yoshii"
+    ],
+    "title": "Function- and Rhythm-Aware Melody Harmonization Based on Tree-Structured Parsing and Split-Merge Sampling of Chord Sequences.",
+    "pages": "502-508",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#TsushimaNIY17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/2_Paper.pdf"
+  },
+  "conf/ismir/ChenW17": {
+    "@key": "conf/ismir/ChenW17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Ning Chen",
+      "Shijun Wang"
+    ],
+    "title": "High-Level Music Descriptor Extraction Algorithm Based on Combination of Multi-Channel CNNs and LSTM.",
+    "pages": "509-514",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#ChenW17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/17_Paper.pdf"
+  },
+  "conf/ismir/RossMGBR17": {
+    "@key": "conf/ismir/RossMGBR17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Joe Cheri Ross",
+      "Abhijit Mishra",
+      "Kaustuv Kanti Ganguli",
+      "Pushpak Bhattacharyya",
+      "Preeti Rao"
+    ],
+    "title": "Identifying Raga Similarity Through Embeddings Learned from Compositions' Notation.",
+    "pages": "515-522",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#RossMGBR17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/122_Paper.pdf"
+  },
+  "conf/ismir/CazauWAWN17": {
+    "@key": "conf/ismir/CazauWAWN17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Dorian Cazau",
+      "Yuancheng Wang",
+      "Olivier Adam",
+      "Qiao Wang",
+      "Gr\u00e9gory Nuel"
+    ],
+    "title": "Improving Note Segmentation in Automatic Piano Music Transcription Systems with a Two-State Pitch-Wise HMM Method.",
+    "pages": "523-530",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#CazauWAWN17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/100_Paper.pdf"
+  },
+  "conf/ismir/DengK17": {
+    "@key": "conf/ismir/DengK17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jun-qi Deng",
+      "Yu-Kwong Kwok"
+    ],
+    "title": "Large Vocabulary Automatic Chord Estimation with an Even Chance Training Scheme.",
+    "pages": "531-536",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#DengK17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/28_Paper.pdf"
+  },
+  "conf/ismir/MishraSD17": {
+    "@key": "conf/ismir/MishraSD17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Saumitra Mishra",
+      "Bob L. Sturm",
+      "Simon Dixon"
+    ],
+    "title": "Local Interpretable Model-Agnostic Explanations for Music Content Analysis.",
+    "pages": "537-543",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#MishraSD17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/216_Paper.pdf"
+  },
+  "conf/ismir/TsukudaIG17": {
+    "@key": "conf/ismir/TsukudaIG17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Kosetsu Tsukuda",
+      "Keisuke Ishida",
+      "Masataka Goto"
+    ],
+    "title": "Lyric Jumper: A Lyrics-Based Music Exploratory Web Service by Modeling Lyrics Generative Process.",
+    "pages": "544-551",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#TsukudaIG17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/96_Paper.pdf"
+  },
+  "conf/ismir/SchrammMSB17": {
+    "@key": "conf/ismir/SchrammMSB17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Rodrigo Schramm",
+      "Andrew Mcleod",
+      "Mark Steedman",
+      "Emmanouil Benetos"
+    ],
+    "title": "Multi-Pitch Detection and Voice Assignment for A Cappella Recordings of Multiple Singers.",
+    "pages": "552-559",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SchrammMSB17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/26_Paper.pdf"
+  },
+  "conf/ismir/SebastianM17": {
+    "@key": "conf/ismir/SebastianM17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jilt Sebastian",
+      "Hema A. Murthy"
+    ],
+    "title": "Onset Detection in Composition Items of Carnatic Music.",
+    "pages": "560-567",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SebastianM17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/91_Paper.pdf"
+  },
+  "conf/ismir/ArigaFG17": {
+    "@key": "conf/ismir/ArigaFG17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Shunya Ariga",
+      "Satoru Fukayama",
+      "Masataka Goto"
+    ],
+    "title": "Song2Guitar: A Difficulty-Aware Arrangement System for Generating Guitar Solo Covers from Polyphonic Audio of Popular Music.",
+    "pages": "568-574",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#ArigaFG17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/41_Paper.pdf"
+  },
+  "conf/ismir/Parada-Cabaleiro17": {
+    "@key": "conf/ismir/Parada-Cabaleiro17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Emilia Parada-Cabaleiro",
+      "Anton Batliner",
+      "Alice Baird",
+      "Bj\u00f6rn W. Schuller"
+    ],
+    "title": "The SEILS Dataset: Symbolically Encoded Scores in Modern-Early Notation for Computational Musicology.",
+    "pages": "575-581",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#Parada-Cabaleiro17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/14_Paper.pdf"
+  },
+  "conf/ismir/LaplanteBA17": {
+    "@key": "conf/ismir/LaplanteBA17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Audrey Laplante",
+      "Timothy D. Bowman",
+      "Nawel Aamar"
+    ],
+    "title": "\"I'm at #Osheaga!\": Listening to the Backchannel of a Music Festival on Twitter.",
+    "pages": "585-591",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#LaplanteBA17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/207_Paper.pdf"
+  },
+  "conf/ismir/CrestelEHM17": {
+    "@key": "conf/ismir/CrestelEHM17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "L\u00e9opold Crestel",
+      "Philippe Esling",
+      "Lena Heng",
+      "Stephen McAdams"
+    ],
+    "title": "A Database Linking Piano and Orchestral MIDI Scores with Application to Automatic Projective Orchestration.",
+    "pages": "592-598",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#CrestelEHM17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/235_Paper.pdf"
+  },
+  "conf/ismir/DaiD17": {
+    "@key": "conf/ismir/DaiD17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jiajie Dai",
+      "Simon Dixon"
+    ],
+    "title": "Analysis of Interactive Intonation in Unaccompanied SATB Ensembles.",
+    "pages": "599-605",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#DaiD17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/24_Paper.pdf"
+  },
+  "conf/ismir/SouthallSH17": {
+    "@key": "conf/ismir/SouthallSH17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Carl Southall",
+      "Ryan Stables",
+      "Jason Hockman"
+    ],
+    "title": "Automatic Drum Transcription for Polyphonic Recordings Using Soft Attention Mechanisms and Convolutional Neural Networks.",
+    "pages": "606-612",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SouthallSH17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/146_Paper.pdf"
+  },
+  "conf/ismir/WuL17": {
+    "@key": "conf/ismir/WuL17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Chih-Wei Wu",
+      "Alexander Lerch"
+    ],
+    "title": "Automatic Drum Transcription Using the Student-Teacher Learning Paradigm with Unlabeled Music Data.",
+    "pages": "613-620",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#WuL17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/148_Paper.pdf"
+  },
+  "conf/ismir/LimRL17": {
+    "@key": "conf/ismir/LimRL17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Hyungui Lim",
+      "Seungyeon Rhyu",
+      "Kyogu Lee"
+    ],
+    "title": "Chord Generation from Symbolic Melody Using BLSTM Networks.",
+    "pages": "621-627",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#LimRL17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/134_Paper.pdf"
+  },
+  "conf/ismir/HeoKKL17": {
+    "@key": "conf/ismir/HeoKKL17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Hoon Heo",
+      "Hyunwoo J. Kim",
+      "Wan Soo Kim",
+      "Kyogu Lee"
+    ],
+    "title": "Cover Song Identification with Metric Learning Using Distance as a Feature.",
+    "pages": "628-634",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#HeoKKL17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/33_Paper.pdf"
+  },
+  "conf/ismir/Kinnaird17": {
+    "@key": "conf/ismir/Kinnaird17",
+    "@mdate": "2017-11-13",
+    "author": "Katherine M. Kinnaird",
+    "title": "Examining Musical Meaning in Similarity Thresholds.",
+    "pages": "635-641",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#Kinnaird17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/39_Paper.pdf"
+  },
+  "conf/ismir/ZalkowWM17": {
+    "@key": "conf/ismir/ZalkowWM17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Frank Zalkow",
+      "Christof Wei\u00df",
+      "Meinard M\u00fcller"
+    ],
+    "title": "Exploring Tonal-Dramatic Relationships in Richard Wagner's Ring Cycle.",
+    "pages": "642-648",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#ZalkowWM17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/132_Paper.pdf"
+  },
+  "conf/ismir/LanghabelLTR17": {
+    "@key": "conf/ismir/LanghabelLTR17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jonas Langhabel",
+      "Robert Lieck",
+      "Marc Toussaint",
+      "Martin Rohrmeier"
+    ],
+    "title": "Feature Discovery for Sequential Prediction of Monophonic Music.",
+    "pages": "649-656",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#LanghabelLTR17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/163_Paper.pdf"
+  },
+  "conf/ismir/TengZG17": {
+    "@key": "conf/ismir/TengZG17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Yifei Teng",
+      "Anny Zhao",
+      "Camille Goudeseune"
+    ],
+    "title": "Generating Nontrivial Melodies for Music as a Service.",
+    "pages": "657-663",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#TengZG17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/178_Paper.pdf"
+  },
+  "conf/ismir/KedytePWD17": {
+    "@key": "conf/ismir/KedytePWD17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Vytaute Kedyte",
+      "Maria Panteli",
+      "Tillman Weyde",
+      "Simon Dixon"
+    ],
+    "title": "Geographical Origin Prediction of Folk Music Recordings from the United Kingdom.",
+    "pages": "664-670",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#KedytePWD17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/59_Paper.pdf"
+  },
+  "conf/ismir/RenKVS17": {
+    "@key": "conf/ismir/RenKVS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Iris Yuping Ren",
+      "Hendrik Vincent Koops",
+      "Anja Volk",
+      "Wouter Swierstra"
+    ],
+    "title": "In Search of the Consensus Among Musical Pattern Discovery Algorithms.",
+    "pages": "671-678",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#RenKVS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/120_Paper.pdf"
+  },
+  "conf/ismir/Srinivasamurthy17": {
+    "@key": "conf/ismir/Srinivasamurthy17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Ajay Srinivasamurthy",
+      "Andre Holzapfel",
+      "Xavier Serra"
+    ],
+    "title": "Informed Automatic Meter Analysis of Music Recordings.",
+    "pages": "679-685",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#Srinivasamurthy17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/93_Paper.pdf"
+  },
+  "conf/ismir/IbrahimGAGW17": {
+    "@key": "conf/ismir/IbrahimGAGW17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Karim M. Ibrahim",
+      "David Grunberg",
+      "Kat Agres",
+      "Chitralekha Gupta",
+      "Ye Wang"
+    ],
+    "title": "Intelligibility of Sung Lyrics: A Pilot Study.",
+    "pages": "686-693",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#IbrahimGAGW17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/103_Paper.pdf"
+  },
+  "conf/ismir/Tsaptsinos17": {
+    "@key": "conf/ismir/Tsaptsinos17",
+    "@mdate": "2017-11-13",
+    "author": "Alexandros Tsaptsinos",
+    "title": "Lyrics-Based Music Genre Classification Using a Hierarchical Attention Network.",
+    "pages": "694-701",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#Tsaptsinos17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/43_Paper.pdf"
+  },
+  "conf/ismir/DzhambazovHSS17": {
+    "@key": "conf/ismir/DzhambazovHSS17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Georgi Dzhambazov",
+      "Andre Holzapfel",
+      "Ajay Srinivasamurthy",
+      "Xavier Serra"
+    ],
+    "title": "Metrical-Accent Aware Vocal Onset Detection in Polyphonic Audio.",
+    "pages": "702-708",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#DzhambazovHSS17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/159_Paper.pdf"
+  },
+  "conf/ismir/HumphreyMBJJ17": {
+    "@key": "conf/ismir/HumphreyMBJJ17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Eric J. Humphrey",
+      "Nicola Montecchio",
+      "Rachel M. Bittner",
+      "Andreas Jansson",
+      "Tristan Jehan"
+    ],
+    "title": "Mining Labeled Data from Web-Scale Collections for Vocal Activity Detection in Music.",
+    "pages": "709-715",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#HumphreyMBJJ17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/181_Paper.pdf"
+  },
+  "conf/ismir/SmithG17": {
+    "@key": "conf/ismir/SmithG17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jordan B. L. Smith",
+      "Masataka Goto"
+    ],
+    "title": "Multi-Part Pattern Analysis: Combining Structure Analysis and Source Separation to Discover Intra-Part Repeated Sequences.",
+    "pages": "716-723",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#SmithG17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/94_Paper.pdf"
+  },
+  "conf/ismir/Calvo-ZaragozaV17a": {
+    "@key": "conf/ismir/Calvo-ZaragozaV17a",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Jorge Calvo-Zaragoza",
+      "Gabriel Vigliensoni",
+      "Ichiro Fujinaga"
+    ],
+    "title": "One-Step Detection of Background, Staff Lines, and Symbols in Medieval Music Manuscripts with Convolutional Neural Networks.",
+    "pages": "724-730",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#Calvo-ZaragozaV17a",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/162_Paper.pdf"
+  },
+  "conf/ismir/WelU17": {
+    "@key": "conf/ismir/WelU17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Eelco van der Wel",
+      "Karen Ullrich"
+    ],
+    "title": "Optical Music Recognition with Convolutional Sequence-to-Sequence Models.",
+    "pages": "731-737",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#WelU17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/69_Paper.pdf"
+  },
+  "conf/ismir/WangMD17": {
+    "@key": "conf/ismir/WangMD17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Cheng-i Wang",
+      "Gautham J. Mysore",
+      "Shlomo Dubnov"
+    ],
+    "title": "Re-Visiting the Music Segmentation Problem with Crowdsourcing.",
+    "pages": "738-744",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#WangMD17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/102_Paper.pdf"
+  },
+  "conf/ismir/JanssonHMBKW17": {
+    "@key": "conf/ismir/JanssonHMBKW17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Andreas Jansson",
+      "Eric J. Humphrey",
+      "Nicola Montecchio",
+      "Rachel M. Bittner",
+      "Aparna Kumar",
+      "Tillman Weyde"
+    ],
+    "title": "Singing Voice Separation with Deep U-Net Convolutional Networks.",
+    "pages": "745-751",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#JanssonHMBKW17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/171_Paper.pdf"
+  },
+  "conf/ismir/BigoGGGL17": {
+    "@key": "conf/ismir/BigoGGGL17",
+    "@mdate": "2017-11-13",
+    "author": [
+      "Louis Bigo",
+      "Mathieu Giraud",
+      "Richard Groult",
+      "Nicolas Guiomard-Kagan",
+      "Florence Lev\u00e9"
+    ],
+    "title": "Sketching Sonata Form Structure in Selected Classical String Quartets.",
+    "pages": "752-759",
+    "year": "2017",
+    "booktitle": "ISMIR",
+    "crossref": "conf/ismir/2017",
+    "url": "db/conf/ismir/ismir2017.html#BigoGGGL17",
+    "ee": "https://ismir2017.smcnus.org/wp-content/uploads/2017/10/228_Paper.pdf"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests
 beautifulsoup4
+xmltodict
+tqdm

--- a/scripts/parse_dblp.py
+++ b/scripts/parse_dblp.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# coding: utf8
 """Download metadata from the DBLP archive.
 
 Usage
@@ -9,18 +11,25 @@ $ python scripts/parse_dblp.py proceedings.json
 import argparse
 import bs4
 import logging
-from joblib import Parallel, delayed
 import json
 import os
 import requests
 import sys
+import time
+import tqdm
+import xmltodict
 
-logger = logging.getLogger("demo_upload")
+logger = logging.getLogger("mirror-dblp")
 
 DBLP = "http://dblp.uni-trier.de/db/conf/ismir/ismir{year}.html"
+XML = "https://dblp.uni-trier.de/rec/xml/{cite_key}.xml"
 
 
-def extract_proceedings(year):
+def get_cite_key(s):
+    return s.split('/')[-1]
+
+
+def collect_citekeys(year):
     """Recover paper metadata from DBLP given a conference year.
 
     Parameters
@@ -30,33 +39,60 @@ def extract_proceedings(year):
 
     Returns
     -------
-    records : list
-        Collection of dictionaries containing paper details.
+    cite_keys : list
+        Collection of paper citation keys.
     """
     resp = requests.get(DBLP.format(year=str(year)))
-    soup = bs4.BeautifulSoup(resp.text, 'lxml')
+    soup = bs4.BeautifulSoup(resp.text)
     records = soup.findAll(attrs={'class': 'entry inproceedings'})
-    data = []
-    for rec in records:
-        creators = [auth.text for auth in rec(itemprop='author')]
-        title = rec(**{'class': 'title'})[0].text
-        pdf_url = rec(**{'class': 'head'})[0].find_next("a")['href']
-        data += [dict(creators=creators, title=title, pdf_url=pdf_url,
-                      conference_acronym="ISMIR{}".format(year))]
-    return data
+    cite_keys = [rec.attrs.get('id') for rec in records]
+
+    print("ISMIR{}: {} rows".format(year, len(cite_keys)))
+    return cite_keys
 
 
-def main(output_file, num_cpus, verbose):
-    pool = Parallel(n_jobs=num_cpus, verbose=verbose)
-    fx = delayed(extract_proceedings)
-    results = pool(fx(year) for year in range(2000, 2017))
-    with open(output_file, 'w') as fp:
-        json.dump(results, fp)
+def fetch_record(cite_key):
+    resp = requests.get(XML.format(cite_key=cite_key))
+    if resp.status_code >= 400:
+        raise ValueError(XML.format(cite_key=cite_key))
+
+    xml = resp.text.replace('\n', '')
+    return dict(xmltodict.parse(xml)['dblp']['inproceedings'])
+
+
+def main(output_file, num_cpus, verbose, resume=False, delay=0.5):
+    cite_keys = []
+    for year in range(2000, 2018):
+        cite_keys += collect_citekeys(year)
+
+    if resume and os.path.exists(output_file):
+        with open(output_file, 'r') as fp:
+            records = json.load(fp)
+    else:
+        records = dict()
+
+    try:
+        for ckey in tqdm.tqdm(cite_keys):
+            now = time.time()
+            if ckey not in records:
+                records[ckey] = fetch_record(ckey)
+                time.sleep(max([delay - (time.time() - now), 0]))
+
+    except KeyboardInterrupt:
+        print('Halting early')
+
+    except ValueError as derp:
+        print("Fetch failed: {}".format(derp))
+
+    finally:
+        print("Total {} rows".format(len(records)))
+        with open(output_file, 'w') as fp:
+            json.dump(records, fp, indent=2)
+
     return os.path.exists(output_file)
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
     parser = argparse.ArgumentParser(description=__doc__)
 
     # Inputs
@@ -69,7 +105,14 @@ if __name__ == '__main__':
     parser.add_argument("--verbose",
                         metavar="verbose", type=int, default=0,
                         help="Verbosity level for joblib.")
+    parser.add_argument("--resume",
+                        action='store_true',
+                        help="If given, will resume")
+    parser.add_argument("--delay",
+                        type=float, default=0.5,
+                        help="Delay time in seconds between XML requests.")
     args = parser.parse_args()
-    success = main(args.output_file, args.num_cpus, args.verbose)
+    success = main(args.output_file, args.num_cpus, args.verbose,
+                   args.resume, args.delay)
     logging.info("Complete scrape: success={}".format(success))
     sys.exit(0 if success else 1)


### PR DESCRIPTION
Pulls down DBLP cite keys and corresponding XML records as JSON objects, cached copy included in this PR. This proceedings object can be used for subsequent Zenodo ingestion.