### PR TITLE
Update Zenodo record ids for 2023 conference

### DIFF
--- a/database/proceedings/2023.json
+++ b/database/proceedings/2023.json
@@ -1304,12 +1304,12 @@
       "Gy\u00f6rgy Fazekas"
     ],
     "year": "2023",
-    "doi": "10.5281/zenodo.10265377",
-    "url": "https://doi.org/10.5281/zenodo.10265377",
-    "ee": "https://zenodo.org/record/10265377/files/000079.pdf",
+    "doi": "10.5281/zenodo.13916489",
+    "url": "https://doi.org/10.5281/zenodo.13916489",
+    "ee": "https://zenodo.org/record/13916489/files/000079.pdf",
     "pages": "667-675",
     "abstract": "This paper introduces GlOttal-flow LPC Filter (GOLF), a novel method for singing voice synthesis (SVS) that exploits the physical characteristics of the human voice using differentiable digital signal processing. GOLF employs a glottal model as the harmonic source and IIR filters to simulate the vocal tract, resulting in an interpretable and efficient approach. We show it is competitive with state-of-the-art singing voice vocoders, requiring fewer synthesis parameters and less memory to train, and runs an order of magnitude faster for inference. Additionally, we demonstrate that GOLF can model the phase components of the human voice, which has immense potential for rendering and analysing singing voices in a differentiable manner. Our results highlight the effectiveness of incorporating the physical properties of the human voice mechanism into SVS and underscore the advantages of signal-processing-based approaches, which offer greater interpretability and efficiency in synthesis.",
-    "zenodo_id": 10265377,
+    "zenodo_id": 13916489,
     "dblp_key": null
   },
   {

--- a/database/proceedings/2023_dblp.html
+++ b/database/proceedings/2023_dblp.html
@@ -332,7 +332,7 @@ Towards Improving Harmonic Sensitivity and Prediction Stability for Singing Melo
 <li>Chin-Yun Yu, György Fazekas:
 Singing Voice Synthesis Using Differentiable LPC and Glottal-Flow-Inspired Wavetables.
 667-675
-<ee>https://zenodo.org/record/10265377/files/000079.pdf</ee>
+<ee>https://zenodo.org/record/13916489/files/000079.pdf</ee>
 <li>Qiaoyu Yang, Frank Cwitkowitz, Zhiyao Duan:
 Harmonic Analysis With Neural Semi-CRF.
 676-683

--- a/database/proceedings/2023_dblp.xml
+++ b/database/proceedings/2023_dblp.xml
@@ -708,7 +708,7 @@
                 <author>György Fazekas</author>
                 <title>Singing Voice Synthesis Using Differentiable LPC and Glottal-Flow-Inspired Wavetables</title>
                 <pages>667-675</pages>
-                <doi>10.5281/zenodo.10265377</doi>
+                <doi>10.5281/zenodo.13916489</doi>
             </publ>
             <publ>
                 <author>Qiaoyu Yang</author>


### PR DESCRIPTION
Following the discussion on the ISMIR mailing list, a small update to the full proceedings and one paper have been uploaded to Zenodo. This PR updates the links on the homepage to those most recent versions.